### PR TITLE
fix: Fix a bug while processing markdown file: 'str' object has no attribute 'get_ref'

### DIFF
--- a/docling_core/types/doc/document.py
+++ b/docling_core/types/doc/document.py
@@ -1572,7 +1572,8 @@ class DoclingDocument(BaseModel):
         if prov:
             tbl_item.prov.append(prov)
         if caption:
-            tbl_item.captions.append(caption.get_ref())
+            if hasattr(caption, "get_ref"):
+                tbl_item.captions.append(caption.get_ref())
 
         self.tables.append(tbl_item)
         parent.children.append(RefItem(cref=cref))
@@ -1611,9 +1612,7 @@ class DoclingDocument(BaseModel):
         if prov:
             fig_item.prov.append(prov)
         if caption:
-            if isinstance(caption, str):
-                fig_item.captions.append(RefItem(cref=caption))
-            elif hasattr(caption, "get_ref"):
+            if hasattr(caption, "get_ref"):
                 fig_item.captions.append(caption.get_ref())
 
         self.pictures.append(fig_item)


### PR DESCRIPTION
I've reached an unexpected crash while processing markdown (.md) files.  

Stacktrace:
```bash
  File "/root/envs/eth/lib/python3.10/site-packages/docling/backend/md_backend.py", line 306, in iterate_elements
    self.iterate_elements(child, depth + 1, doc, parent_element)
  File "/root/envs/eth/lib/python3.10/site-packages/docling/backend/md_backend.py", line 306, in iterate_elements
    self.iterate_elements(child, depth + 1, doc, parent_element)
  File "/root/envs/eth/lib/python3.10/site-packages/docling/backend/md_backend.py", line 224, in iterate_elements
    doc.add_picture(parent=parent_element, caption=element.title)
  File "/root/envs/eth/lib/python3.10/site-packages/docling_core/types/doc/document.py", line 1602, in add_picture
    fig_item.captions.append(caption.get_ref())
AttributeError: 'str' object has no attribute 'get_ref'
```

Example data:
```md
[![text](https://example.com "text")](https://example.com "text")
```

The `caption` is neither a text nor a ref item, it's a `str`. So `get_ref` should not be executed there.