### PR TITLE
chore: bring HybridChunker to init file for easy access

### DIFF
--- a/docling_core/transforms/chunker/__init__.py
+++ b/docling_core/transforms/chunker/__init__.py
@@ -11,3 +11,4 @@ from docling_core.transforms.chunker.hierarchical_chunker import (
     DocMeta,
     HierarchicalChunker,
 )
+from docling_core.transforms.chunker.hybrid_chunker import HybridChunker


### PR DESCRIPTION
To be aligned with the `HierarchicalChunker` and for an easy import from applications, the `HybridChunker` has been added to the `__init__.py` file of the `docling_core/transforms/chunker` directory