### PR TITLE
Adding handling for str as filename argument to load/save methods

### DIFF
--- a/docling_core/types/doc/document.py
+++ b/docling_core/types/doc/document.py
@@ -2475,12 +2475,14 @@ class DoclingDocument(BaseModel):
 
     def save_as_json(
         self,
-        filename: Path,
+        filename: str | Path,
         artifacts_dir: Optional[Path] = None,
         image_mode: ImageRefMode = ImageRefMode.EMBEDDED,
         indent: int = 2,
     ):
         """Save as json."""
+        if isinstance(filename, str):
+            filename = Path(filename)
         artifacts_dir, reference_path = self._get_output_paths(filename, artifacts_dir)
 
         if image_mode == ImageRefMode.REFERENCED:
@@ -2495,7 +2497,7 @@ class DoclingDocument(BaseModel):
             json.dump(out, fw, indent=indent)
 
     @classmethod
-    def load_from_json(cls, filename: Path) -> "DoclingDocument":
+    def load_from_json(cls, filename: str | Path) -> "DoclingDocument":
         """load_from_json.
 
         :param filename: The filename to load a saved DoclingDocument from a .json.
@@ -2505,17 +2507,21 @@ class DoclingDocument(BaseModel):
         :rtype: DoclingDocument
 
         """
+        if isinstance(filename, str):
+            filename = Path(filename)
         with open(filename, "r", encoding="utf-8") as f:
             return cls.model_validate_json(f.read())
 
     def save_as_yaml(
         self,
-        filename: Path,
+        filename: str | Path,
         artifacts_dir: Optional[Path] = None,
         image_mode: ImageRefMode = ImageRefMode.EMBEDDED,
         default_flow_style: bool = False,
     ):
         """Save as yaml."""
+        if isinstance(filename, str):
+            filename = Path(filename)
         artifacts_dir, reference_path = self._get_output_paths(filename, artifacts_dir)
 
         if image_mode == ImageRefMode.REFERENCED:
@@ -2530,7 +2536,7 @@ class DoclingDocument(BaseModel):
             yaml.dump(out, fw, default_flow_style=default_flow_style)
 
     @classmethod
-    def load_from_yaml(cls, filename: Path) -> "DoclingDocument":
+    def load_from_yaml(cls, filename: str | Path) -> "DoclingDocument":
         """load_from_yaml.
 
         Args:
@@ -2539,6 +2545,8 @@ class DoclingDocument(BaseModel):
         Returns:
             DoclingDocument: the loaded DoclingDocument
         """
+        if isinstance(filename, str):
+            filename = Path(filename)
         with open(filename, encoding="utf-8") as f:
             data = yaml.load(f, Loader=yaml.FullLoader)
         return DoclingDocument.model_validate(data)
@@ -2556,7 +2564,7 @@ class DoclingDocument(BaseModel):
 
     def save_as_markdown(
         self,
-        filename: Path,
+        filename: str | Path,
         artifacts_dir: Optional[Path] = None,
         delim: str = "\n\n",
         from_element: int = 0,
@@ -2572,6 +2580,8 @@ class DoclingDocument(BaseModel):
         included_content_layers: set[ContentLayer] = DEFAULT_CONTENT_LAYERS,
     ):
         """Save to markdown."""
+        if isinstance(filename, str):
+            filename = Path(filename)
         artifacts_dir, reference_path = self._get_output_paths(filename, artifacts_dir)
 
         if image_mode == ImageRefMode.REFERENCED:
@@ -2702,7 +2712,7 @@ class DoclingDocument(BaseModel):
 
     def save_as_html(
         self,
-        filename: Path,
+        filename: str | Path,
         artifacts_dir: Optional[Path] = None,
         from_element: int = 0,
         to_element: int = sys.maxsize,
@@ -2715,6 +2725,8 @@ class DoclingDocument(BaseModel):
         included_content_layers: set[ContentLayer] = DEFAULT_CONTENT_LAYERS,
     ):
         """Save to HTML."""
+        if isinstance(filename, str):
+            filename = Path(filename)
         artifacts_dir, reference_path = self._get_output_paths(filename, artifacts_dir)
 
         if image_mode == ImageRefMode.REFERENCED:
@@ -2740,8 +2752,10 @@ class DoclingDocument(BaseModel):
             fw.write(html_out)
 
     def _get_output_paths(
-        self, filename: Path, artifacts_dir: Optional[Path] = None
+        self, filename: str | Path, artifacts_dir: Optional[Path] = None
     ) -> Tuple[Path, Optional[Path]]:
+        if isinstance(filename, str):
+            filename = Path(filename)
         if artifacts_dir is None:
             # Remove the extension and add '_pictures'
             artifacts_dir = filename.with_suffix("")
@@ -3516,7 +3530,7 @@ class DoclingDocument(BaseModel):
 
     def save_as_doctags(
         self,
-        filename: Path,
+        filename: str | Path,
         delim: str = "",
         from_element: int = 0,
         to_element: int = sys.maxsize,
@@ -3531,6 +3545,8 @@ class DoclingDocument(BaseModel):
         add_table_cell_text: bool = True,
     ):
         r"""Save the document content to DocTags format."""
+        if isinstance(filename, str):
+            filename = Path(filename)
         out = self.export_to_document_tokens(
             delim=delim,
             from_element=from_element,

--- a/docling_core/types/doc/page.py
+++ b/docling_core/types/doc/page.py
@@ -546,7 +546,7 @@ class SegmentedPdfPage(SegmentedPage):
 
     def save_as_json(
         self,
-        filename: Path,
+        filename: str | Path,
         indent: int = 2,
     ):
         """Save the page data as a JSON file.
@@ -555,12 +555,14 @@ class SegmentedPdfPage(SegmentedPage):
             filename: Path to save the JSON file
             indent: Indentation level for JSON formatting
         """
+        if isinstance(filename, str):
+            filename = Path(filename)
         out = self.export_to_dict()
         with open(filename, "w", encoding="utf-8") as fw:
             json.dump(out, fw, indent=indent)
 
     @classmethod
-    def load_from_json(cls, filename: Path) -> "SegmentedPdfPage":
+    def load_from_json(cls, filename: str | Path) -> "SegmentedPdfPage":
         """Load page data from a JSON file.
 
         Args:
@@ -569,6 +571,8 @@ class SegmentedPdfPage(SegmentedPage):
         Returns:
             Instantiated SegmentedPdfPage object
         """
+        if isinstance(filename, str):
+            filename = Path(filename)
         with open(filename, "r", encoding="utf-8") as f:
             return cls.model_validate_json(f.read())
 
@@ -1155,19 +1159,21 @@ class PdfTableOfContents(BaseModel):
         """
         return self.model_dump(mode=mode, by_alias=True, exclude_none=True)
 
-    def save_as_json(self, filename: Path, indent: int = 2):
+    def save_as_json(self, filename: str | Path, indent: int = 2):
         """Save the table of contents as a JSON file.
 
         Args:
             filename: Path to save the JSON file
             indent: Indentation level for JSON formatting
         """
+        if isinstance(filename, str):
+            filename = Path(str)
         out = self.export_to_dict()
         with open(filename, "w", encoding="utf-8") as fw:
             json.dump(out, fw, indent=indent)
 
     @classmethod
-    def load_from_json(cls, filename: Path) -> "PdfTableOfContents":
+    def load_from_json(cls, filename: str | Path) -> "PdfTableOfContents":
         """Load table of contents from a JSON file.
 
         Args:
@@ -1176,6 +1182,8 @@ class PdfTableOfContents(BaseModel):
         Returns:
             Instantiated PdfTableOfContents object
         """
+        if isinstance(filename, str):
+            filename = Path(str)
         with open(filename, "r", encoding="utf-8") as f:
             return cls.model_validate_json(f.read())
 
@@ -1213,19 +1221,21 @@ class ParsedPdfDocument(BaseModel):
         """
         return self.model_dump(mode=mode, by_alias=True, exclude_none=True)
 
-    def save_as_json(self, filename: Path, indent: int = 2):
+    def save_as_json(self, filename: str | Path, indent: int = 2):
         """Save the document as a JSON file.
 
         Args:
             filename: Path to save the JSON file
             indent: Indentation level for JSON formatting
         """
+        if isinstance(filename, str):
+            filename = Path(str)
         out = self.export_to_dict()
         with open(filename, "w", encoding="utf-8") as fw:
             json.dump(out, fw, indent=indent)
 
     @classmethod
-    def load_from_json(cls, filename: Path) -> "ParsedPdfDocument":
+    def load_from_json(cls, filename: str | Path) -> "ParsedPdfDocument":
         """Load document from a JSON file.
 
         Args:
@@ -1234,5 +1244,7 @@ class ParsedPdfDocument(BaseModel):
         Returns:
             Instantiated ParsedPdfDocument object
         """
+        if isinstance(filename, str):
+            filename = Path(str)
         with open(filename, "r", encoding="utf-8") as f:
             return cls.model_validate_json(f.read())


### PR DESCRIPTION
## Summary

This PR makes a minor change to the handling of the `filename` argument in the `save_as_*` and `load_from_*` methods of the `document` and `page` classes.

See: https://github.com/docling-project/docling/issues/1189

## Details

Currently, if a `str` is passed to the `save_as_*` or `load_from_*` methods of the `document` or `pages` types, it will fail with an `AttributeError`.

The changes in this PR handle `str` inputs to these methods, and automatically casts them to `pathlib.Path`.

All tests have succesffuly passed :)

