### PR TITLE
fix: add 'text/csv' mimetype to _extra_mimetypes type list

### DIFF
--- a/docling_core/types/doc/document.py
+++ b/docling_core/types/doc/document.py
@@ -414,6 +414,7 @@ class DocumentOrigin(BaseModel):
         "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
         "text/asciidoc",
         "text/markdown",
+        "text/csv",
     ]
 
     @field_validator("binary_hash", mode="before")


### PR DESCRIPTION
### Bug
Value error, 'text/csv' is not a valid MIME type [type=value_error, input_value='text/csv', input_type=str]
For further information visit https://errors.pydantic.dev/2.10/v/value_error

### Steps to reproduce
converter = DocumentConverter()
result = converter.convert(Path("tests/data/csv/csv-comma.csv"))
output = result.document.export_to_markdown()

### docling-core version
2.23.3

### Python version
3.10.11

### os version
Windows 11


I have filed this PR in following to this issue [here](https://github.com/docling-project/docling/issues/1206).