### PR TITLE
fix: Automatic transformation of output cells bbox coord origin defined by input in get_cells_in_bbox

### DIFF
--- a/docling_core/types/doc/page.py
+++ b/docling_core/types/doc/page.py
@@ -531,6 +531,12 @@ class SegmentedPdfPage(SegmentedPage):
         cells = []
         for page_cell in self.iterate_cells(cell_unit):
             cell_bbox = page_cell.to_bounding_box()
+            # Bring cell_bbox coord origin to the same as input bbox.coord_origin:
+            if cell_bbox.coord_origin != bbox.coord_origin:
+                if bbox.coord_origin == CoordOrigin.TOPLEFT:
+                    cell_bbox = cell_bbox.to_top_left_origin(self.dimension.height)
+                elif bbox.coord_origin == CoordOrigin.BOTTOMLEFT:
+                    cell_bbox = cell_bbox.to_bottom_left_origin(self.dimension.height)
             if cell_bbox.intersection_over_self(bbox) > ios:
                 cells.append(page_cell)
 

--- a/docling_core/types/doc/page.py
+++ b/docling_core/types/doc/page.py
@@ -530,16 +530,19 @@ class SegmentedPdfPage(SegmentedPage):
         """
         cells = []
         for page_cell in self.iterate_cells(cell_unit):
-            cell_bbox = page_cell.to_bounding_box()
             # Bring cell_bbox coord origin to the same as input bbox.coord_origin:
-            if cell_bbox.coord_origin != bbox.coord_origin:
+            if page_cell.rect.coord_origin != bbox.coord_origin:
                 if bbox.coord_origin == CoordOrigin.TOPLEFT:
-                    cell_bbox = cell_bbox.to_top_left_origin(self.dimension.height)
+                    page_cell.rect = page_cell.rect.to_top_left_origin(
+                        self.dimension.height
+                    )
                 elif bbox.coord_origin == CoordOrigin.BOTTOMLEFT:
-                    cell_bbox = cell_bbox.to_bottom_left_origin(self.dimension.height)
+                    page_cell.rect = page_cell.rect.to_bottom_left_origin(
+                        self.dimension.height
+                    )
+            cell_bbox = page_cell.to_bounding_box()
             if cell_bbox.intersection_over_self(bbox) > ios:
                 cells.append(page_cell)
-
         return cells
 
     def export_to_dict(self) -> Dict:

--- a/docling_core/types/doc/page.py
+++ b/docling_core/types/doc/page.py
@@ -1,5 +1,6 @@
 """Datastructures for PaginatedDocument."""
 
+import copy
 import json
 import logging
 import math
@@ -530,19 +531,16 @@ class SegmentedPdfPage(SegmentedPage):
         """
         cells = []
         for page_cell in self.iterate_cells(cell_unit):
+            pc = copy.deepcopy(page_cell)
             # Bring cell_bbox coord origin to the same as input bbox.coord_origin:
             if page_cell.rect.coord_origin != bbox.coord_origin:
                 if bbox.coord_origin == CoordOrigin.TOPLEFT:
-                    page_cell.rect = page_cell.rect.to_top_left_origin(
-                        self.dimension.height
-                    )
+                    pc.rect = pc.rect.to_top_left_origin(self.dimension.height)
                 elif bbox.coord_origin == CoordOrigin.BOTTOMLEFT:
-                    page_cell.rect = page_cell.rect.to_bottom_left_origin(
-                        self.dimension.height
-                    )
-            cell_bbox = page_cell.to_bounding_box()
+                    pc.rect = pc.rect.to_bottom_left_origin(self.dimension.height)
+            cell_bbox = pc.to_bounding_box()
             if cell_bbox.intersection_over_self(bbox) > ios:
-                cells.append(page_cell)
+                cells.append(pc)
         return cells
 
     def export_to_dict(self) -> Dict:


### PR DESCRIPTION
Added automatic transformation of page cell_bbox coord origin to the same as input bbox.coord_origin when requesting get_cells_in_bbox.

Current behavior - is to throw error and stop if the input coord_origin differs from backend page coord_origin, which is almost always when get_cells_in_bbox is used in a client code of Docling. This PR fixes it, and presents resulting cells pre-transformed into the same origin as input crop bbox.

This small fix removes the overhead in the client code we put in Docling.