### PR TITLE
fix: DivisionByZero in intersection_over_self

### DIFF
--- a/docling_core/types/doc/base.py
+++ b/docling_core/types/doc/base.py
@@ -182,7 +182,10 @@ class BoundingBox(BaseModel):
     ) -> float:
         """intersection_over_self."""
         intersection_area = self.intersection_area_with(other=other)
-        return intersection_area / self.area()
+        if self.area() > 0:
+            return intersection_area / self.area()
+        else:
+            return 0.0
 
     def to_bottom_left_origin(self, page_height: float) -> "BoundingBox":
         """to_bottom_left_origin.


### PR DESCRIPTION
Preventing intersection_over_self to throw DivisionByZero when area of the element is zero.

Should resolve this issue: https://github.com/docling-project/docling/issues/1266