### PR TITLE
fix: properly handle document_index in load_from_doctags()

### DIFF
--- a/docling_core/types/doc/document.py
+++ b/docling_core/types/doc/document.py
@@ -3458,7 +3458,30 @@ class DoclingDocument(BaseModel):
                         self.add_table(data=table_data, prov=prov, caption=caption)
                     else:
                         self.add_table(data=table_data, caption=caption)
-
+                elif tag_name == DocumentToken.DOCUMENT_INDEX:
+                    text_content = extract_inner_text(full_chunk)
+                    table_data = TableData(
+                        table_cells=[
+                            TableCell(
+                                text=text_content,
+                                start_col_offset_idx=0,
+                                end_col_offset_idx=0,
+                                start_row_offset_idx=0,
+                                end_row_offset_idx=0,
+                            )
+                        ],
+                        num_cols=1,
+                        num_rows=1,
+                    )
+                    if bbox:
+                        prov = ProvenanceItem(
+                            bbox=bbox.resize_by_scale(pg_width, pg_height),
+                            charspan=(0, 0),
+                            page_no=page_no,
+                        )
+                        self.add_table(data=table_data, prov=prov)
+                    else:
+                        self.add_table(data=table_data)
                 elif tag_name == DocItemLabel.PICTURE:
                     caption, caption_bbox = extract_caption(full_chunk)
                     if image:

--- a/test/test_doctags_load.py
+++ b/test/test_doctags_load.py
@@ -77,3 +77,14 @@ def test_doctags_picture_provenances_and_captions():
     for picture in doc.pictures:
         assert len(picture.prov) > 0
         assert len(picture.captions) > 0
+
+
+def test_doctags_document_index():
+    doc = DoclingDocument(name="Document")
+    doctags = """<doctag><document_index><loc_108><loc_46><loc_419><loc_437>Foo </document_index>
+<page_footer><loc_242><loc_460><loc_256><loc_466>viii</page_footer>
+</doctag>"""
+    doctags_doc = DocTagsDocument.from_doctags_and_image_pairs([doctags], None)
+    doc.load_from_doctags(doctags_doc)
+    assert doc.tables[0].data.table_cells[0].text == "Foo"
+    assert doc.tables[0].prov[0].bbox is not None

--- a/test/test_doctags_load.py
+++ b/test/test_doctags_load.py
@@ -81,9 +81,7 @@ def test_doctags_picture_provenances_and_captions():
 
 def test_doctags_document_index():
     doc = DoclingDocument(name="Document")
-    doctags = """<doctag><document_index><loc_108><loc_46><loc_419><loc_437>Foo </document_index>
-<page_footer><loc_242><loc_460><loc_256><loc_466>viii</page_footer>
-</doctag>"""
+    doctags = "<doctag><document_index><loc_108><loc_46><loc_419><loc_437>Foo </document_index></doctag>"
     doctags_doc = DocTagsDocument.from_doctags_and_image_pairs([doctags], None)
     doc.load_from_doctags(doctags_doc)
     assert doc.tables[0].data.table_cells[0].text == "Foo"


### PR DESCRIPTION
`DOCUMENT_INDEX` is currently handled by the `TextItem` part in `load_from_doctags`, which fails because it is not a supported label. Properly handle `DOCUMENT_INDEX` label by adding it as a trivial `TableItem`. I have never seen a document index with structure so far, thus the assumption that the content is one long string.