### PR TITLE
Update page.py

### DIFF
--- a/docling_core/types/doc/page.py
+++ b/docling_core/types/doc/page.py
@@ -317,6 +317,7 @@ class PdfTextCell(TextCell):
 
     font_key: str
     font_name: str
+    font_size: Optional[float] = None
 
     from_ocr: Literal[False] = False
 


### PR DESCRIPTION
feat: added optional font_size

My project needs a font size (if available) within the pdf spans. 

It appears the C++ within docling parse already contains this information, so we updated pdf_parser.py with a corresponding field. (See the pull request over at docling parse). 

*This* change updates page.py to include a field to store the font size.