### PR TITLE
fix: UnboundLocal variable

### DIFF
--- a/docling_core/types/doc/document.py
+++ b/docling_core/types/doc/document.py
@@ -1383,7 +1383,7 @@ class TableItem(FloatingItem):
                     if add_cross_cell:
                         body.append(str(TableToken.OTSL_XCEL.value))
             body.append(str(TableToken.OTSL_NL.value))
-            body_str = "".join(body)
+        body_str = "".join(body)
         return body_str
 
     @deprecated("Use export_to_doctags() instead.")


### PR DESCRIPTION
To fix `UnboundLocalError: cannot access local variable 'body_str' where it is not associated with a value` error in the edge case of an empty table.