### PR TITLE
fix: prevent duplicated cell content in TableData.grid when table_cel…

### DIFF
--- a/docling_core/types/doc/document.py
+++ b/docling_core/types/doc/document.py
@@ -352,6 +352,7 @@ class TableData(BaseModel):  # TBD
         ]
 
         # Overwrite cells in table data for which there is actual cell content.
+        count = 1
         for cell in self.table_cells:
             for i in range(
                 min(cell.start_row_offset_idx, self.num_rows),
@@ -361,7 +362,11 @@ class TableData(BaseModel):  # TBD
                     min(cell.start_col_offset_idx, self.num_cols),
                     min(cell.end_col_offset_idx, self.num_cols),
                 ):
-                    table_data[i][j] = cell
+                    if count <= len(self.table_cells):
+                        table_data[i][j] = cell
+                        count += 1
+                    else:
+                        break
 
         return table_data
 


### PR DESCRIPTION
**Title:**  
fix: prevent duplicated cell content in TableData.grid when table_cells is shorter than grid

**Description:**

### Table
<img width="730" alt="image" src="https://github.com/user-attachments/assets/be577d36-8591-4128-9d37-524620b72d67" />

### Problem
When the number of `table_cells` is less than the size of the grid in `TableData.grid`, the previous implementation would fill the remaining grid cells by repeatedly using the last cell's content. This resulted in duplicated content in the output tables, especially in the last row, which could be misleading and did not match the original document layout.

### Solution
This PR introduces a counter to ensure that only the available `table_cells` are assigned to the grid. Any extra cells in the grid will remain empty, preserving the correct table structure and preventing unwanted duplication.

### Example

**Before (incorrect, duplicated content):**
```
| 规格型号 | 名称/规格 | 原产地 | 数量 | 单价（元） | 总价（元） | 备注 |
|---|---|---|---|---|---|---|
| GH6785 | 颈椎理疗仪 | 广东佛山 | 10 | 4000 | 40000 |   |
| GH7698 | 腰椎理疗仪 | 广东佛山 | 22 | 8000 | 160000 |   |
|   |   |   |   |   |   |   |
|   |   |   |   |   |   |   |
| 合计：人民币（大写）贰拾万  元整（￥210000元） | 合计：人民币（大写）贰拾万  元整（￥210000元） | ...（repeated）|
```

**After (correct, matches original layout):**
```
| 规格型号 | 名称/规格 | 原产地 | 数量 | 单价（元） | 总价（元） | 备注 |
|---|---|---|---|---|---|---|
| GH6785 | 颈椎理疗仪 | 广东佛山 | 10 | 4000 | 40000 |   |
| GH7698 | 腰椎理疗仪 | 广东佛山 | 22 | 8000 | 160000 |   |
|   |   |   |   |   |   |   |
|   |   |   |   |   |   |   |
| 合计：人民币（大写）贰拾万  元整（￥210000元） |   |   |   |   |   |   |
```

### Impact
- Only affects the behavior of `TableData.grid`.
- Output tables will now accurately reflect the original document, with no misleading repeated content.

### Compatibility & Risk
- This is a bugfix and should not affect normal cases where the number of cells matches the grid size.
- No breaking changes are expected.

### Reviewer Notes
- Please check if the new logic for breaking out of the assignment loop is robust for all edge cases.
- Consider if there is a more elegant way to handle this mapping, but the current fix addresses the immediate duplication issue.
