### PR TITLE
fix: hashlib usage for FIPS

### DIFF
--- a/docling_core/types/doc/document.py
+++ b/docling_core/types/doc/document.py
@@ -1073,7 +1073,7 @@ class PictureItem(FloatingItem):
             image_bytes = self.image._pil.tobytes()
 
             # Create a hash object (e.g., SHA-256)
-            hasher = hashlib.sha256()
+            hasher = hashlib.sha256(usedforsecurity=False)
 
             # Feed the image bytes into the hash object
             hasher.update(image_bytes)

--- a/docling_core/utils/legacy.py
+++ b/docling_core/utils/legacy.py
@@ -47,7 +47,7 @@ from docling_core.types.legacy_doc.document import ExportedCCSDocument as DsDocu
 
 
 def _create_hash(string: str):
-    hasher = hashlib.sha256()
+    hasher = hashlib.sha256(usedforsecurity=False)
     hasher.update(string.encode("utf-8"))
 
     return hasher.hexdigest()


### PR DESCRIPTION
Since we don't rely on hashes for credentials and security, we should use the option `usedforsecurity=False` to facilitate FIPS use cases.