### PR TITLE
fix: HTMLTableSerializer efficiency and dir attribute

### DIFF
--- a/docling_core/transforms/serializer/html.py
+++ b/docling_core/transforms/serializer/html.py
@@ -395,7 +395,7 @@ class HTMLTableSerializer(BaseTableSerializer):
 
                     text_dir = get_text_direction(content)
                     if text_dir == "rtl":
-                        opening_tag += f' dir="{dir}"'
+                        opening_tag += f' dir="{text_dir}"'
 
                     body += f"<{opening_tag}>{content}</{celltag}>"
                 body += "</tr>"


### PR DESCRIPTION
HTMLTableSerializer Improvements
- Changed indexing to iteration for the 2D linked list grid due to performance issues with large XLSX exports to Markdown. The original implementation was extremely slow and wouldn't finish. It is good now.
- Also a tiny issue with text direction, and this PR fixes it.

fixes https://github.com/docling-project/docling-core/issues/279#issue-3033288664