### PR TITLE
fix: update deserialization for better recovery

### DIFF
--- a/docling_core/types/doc/document.py
+++ b/docling_core/types/doc/document.py
@@ -3606,7 +3606,9 @@ class DoclingDocument(BaseModel):
                 rf"{DocumentToken.UNORDERED_LIST.value}|"
                 rf"{DocItemLabel.KEY_VALUE_REGION}|"
                 rf"{DocumentToken.CHART.value}|"
-                rf"{DocumentToken.OTSL.value})>.*?</(?P=tag)>"
+                rf"{DocumentToken.OTSL.value})>"
+                rf"(?P<content>.*?)"
+                rf"(?:(?P<closed></(?P=tag)>)|(?P<eof>$))"
             )
             pattern = re.compile(tag_pattern, re.DOTALL)
 
@@ -3616,6 +3618,10 @@ class DoclingDocument(BaseModel):
                 tag_name = match.group("tag")
 
                 bbox = extract_bounding_box(full_chunk)  # Extracts first bbox
+                if not match.group("closed"):
+                    # no closing tag; only the existence of the item is recovered
+                    full_chunk = f"<{tag_name}></{tag_name}>"
+
                 doc_label = tag_to_doclabel.get(tag_name, DocItemLabel.PARAGRAPH)
 
                 if tag_name == DocumentToken.OTSL.value:


### PR DESCRIPTION
Update for recovery in deserialization. Recover either:
- the existence of the item, or
- the existence + the location of the item,

in cases where the model enters infinite repetition during prediction.

If the end of the string is encountered instead of a closing tag, do not discard the item entirely. Instead, populate the `DoclingDocument` with available information.
