### PR TITLE
feat: add subscript & superscript formatting

### DIFF
--- a/docling_core/transforms/serializer/base.py
+++ b/docling_core/transforms/serializer/base.py
@@ -203,6 +203,16 @@ class BaseDocSerializer(ABC):
         ...
 
     @abstractmethod
+    def serialize_subscript(self, text: str, **kwargs: Any) -> str:
+        """Hook for subscript formatting serialization."""
+        ...
+
+    @abstractmethod
+    def serialize_superscript(self, text: str, **kwargs: Any) -> str:
+        """Hook for superscript formatting serialization."""
+        ...
+
+    @abstractmethod
     def serialize_hyperlink(
         self,
         text: str,

--- a/docling_core/transforms/serializer/common.py
+++ b/docling_core/transforms/serializer/common.py
@@ -455,6 +455,10 @@ class DocSerializer(BaseModel, BaseDocSerializer):
                 res = self.serialize_underline(text=res)
             if formatting.strikethrough:
                 res = self.serialize_strikethrough(text=res)
+            if formatting.subscript:
+                res = self.serialize_subscript(text=res)
+            if formatting.superscript:
+                res = self.serialize_superscript(text=res)
         if params.include_hyperlinks and hyperlink:
             res = self.serialize_hyperlink(text=res, hyperlink=hyperlink)
         return res
@@ -477,6 +481,16 @@ class DocSerializer(BaseModel, BaseDocSerializer):
     @override
     def serialize_strikethrough(self, text: str, **kwargs: Any) -> str:
         """Hook for strikethrough formatting serialization."""
+        return text
+
+    @override
+    def serialize_subscript(self, text: str, **kwargs: Any) -> str:
+        """Hook for subscript formatting serialization."""
+        return text
+
+    @override
+    def serialize_superscript(self, text: str, **kwargs: Any) -> str:
+        """Hook for superscript formatting serialization."""
         return text
 
     @override

--- a/docling_core/transforms/serializer/html.py
+++ b/docling_core/transforms/serializer/html.py
@@ -848,6 +848,16 @@ class HTMLDocSerializer(DocSerializer):
         return f"<del>{text}</del>"
 
     @override
+    def serialize_subscript(self, text: str, **kwargs: Any) -> str:
+        """Apply HTML-specific subscript serialization."""
+        return f"<sub>{text}</sub>"
+
+    @override
+    def serialize_superscript(self, text: str, **kwargs: Any) -> str:
+        """Apply HTML-specific superscript serialization."""
+        return f"<sup>{text}</sup>"
+
+    @override
     def serialize_hyperlink(
         self,
         text: str,

--- a/docling_core/types/doc/document.py
+++ b/docling_core/types/doc/document.py
@@ -836,6 +836,8 @@ class Formatting(BaseModel):
     italic: bool = False
     underline: bool = False
     strikethrough: bool = False
+    subscript: bool = False
+    superscript: bool = False
 
 
 class TextItem(DocItem):

--- a/docs/DoclingDocument.json
+++ b/docs/DoclingDocument.json
@@ -554,6 +554,16 @@
           "default": false,
           "title": "Strikethrough",
           "type": "boolean"
+        },
+        "subscript": {
+          "default": false,
+          "title": "Subscript",
+          "type": "boolean"
+        },
+        "superscript": {
+          "default": false,
+          "title": "Superscript",
+          "type": "boolean"
         }
       },
       "title": "Formatting",

--- a/test/data/doc/constructed_doc.appended_child.json.gt
+++ b/test/data/doc/constructed_doc.appended_child.json.gt
@@ -70,10 +70,10 @@
         "$ref": "#/groups/9"
       },
       {
-        "$ref": "#/texts/40"
+        "$ref": "#/texts/42"
       },
       {
-        "$ref": "#/texts/41"
+        "$ref": "#/texts/43"
       }
     ],
     "content_layer": "body",
@@ -242,6 +242,12 @@
         },
         {
           "$ref": "#/texts/30"
+        },
+        {
+          "$ref": "#/texts/31"
+        },
+        {
+          "$ref": "#/texts/32"
         }
       ],
       "content_layer": "body",
@@ -255,16 +261,16 @@
       },
       "children": [
         {
-          "$ref": "#/texts/31"
-        },
-        {
-          "$ref": "#/texts/32"
-        },
-        {
           "$ref": "#/texts/33"
         },
         {
-          "$ref": "#/texts/39"
+          "$ref": "#/texts/34"
+        },
+        {
+          "$ref": "#/texts/35"
+        },
+        {
+          "$ref": "#/texts/41"
         }
       ],
       "content_layer": "body",
@@ -273,26 +279,6 @@
     },
     {
       "self_ref": "#/groups/10",
-      "parent": {
-        "$ref": "#/texts/33"
-      },
-      "children": [
-        {
-          "$ref": "#/texts/34"
-        },
-        {
-          "$ref": "#/texts/35"
-        },
-        {
-          "$ref": "#/texts/38"
-        }
-      ],
-      "content_layer": "body",
-      "name": "list B",
-      "label": "ordered_list"
-    },
-    {
-      "self_ref": "#/groups/11",
       "parent": {
         "$ref": "#/texts/35"
       },
@@ -304,7 +290,27 @@
           "$ref": "#/texts/37"
         },
         {
-          "$ref": "#/texts/42"
+          "$ref": "#/texts/40"
+        }
+      ],
+      "content_layer": "body",
+      "name": "list B",
+      "label": "ordered_list"
+    },
+    {
+      "self_ref": "#/groups/11",
+      "parent": {
+        "$ref": "#/texts/37"
+      },
+      "children": [
+        {
+          "$ref": "#/texts/38"
+        },
+        {
+          "$ref": "#/texts/39"
+        },
+        {
+          "$ref": "#/texts/44"
         }
       ],
       "content_layer": "body",
@@ -515,8 +521,8 @@
       "content_layer": "body",
       "label": "code",
       "prov": [],
-      "orig": "<p>Hello world</p>",
-      "text": "<p>Hello world</p>",
+      "orig": "print(\"Hello world\")",
+      "text": "print(\"Hello world\")",
       "captions": [],
       "references": [],
       "footnotes": [],
@@ -649,7 +655,9 @@
         "bold": true,
         "italic": false,
         "underline": false,
-        "strikethrough": false
+        "strikethrough": false,
+        "subscript": false,
+        "superscript": false
       }
     },
     {
@@ -667,7 +675,9 @@
         "bold": false,
         "italic": true,
         "underline": false,
-        "strikethrough": false
+        "strikethrough": false,
+        "subscript": false,
+        "superscript": false
       }
     },
     {
@@ -685,7 +695,9 @@
         "bold": false,
         "italic": false,
         "underline": true,
-        "strikethrough": false
+        "strikethrough": false,
+        "subscript": false,
+        "superscript": false
       }
     },
     {
@@ -703,11 +715,53 @@
         "bold": false,
         "italic": false,
         "underline": false,
-        "strikethrough": true
+        "strikethrough": true,
+        "subscript": false,
+        "superscript": false
       }
     },
     {
       "self_ref": "#/texts/28",
+      "parent": {
+        "$ref": "#/groups/8"
+      },
+      "children": [],
+      "content_layer": "body",
+      "label": "text",
+      "prov": [],
+      "orig": "subscript",
+      "text": "subscript",
+      "formatting": {
+        "bold": false,
+        "italic": false,
+        "underline": false,
+        "strikethrough": false,
+        "subscript": true,
+        "superscript": false
+      }
+    },
+    {
+      "self_ref": "#/texts/29",
+      "parent": {
+        "$ref": "#/groups/8"
+      },
+      "children": [],
+      "content_layer": "body",
+      "label": "text",
+      "prov": [],
+      "orig": "superscript",
+      "text": "superscript",
+      "formatting": {
+        "bold": false,
+        "italic": false,
+        "underline": false,
+        "strikethrough": false,
+        "subscript": false,
+        "superscript": true
+      }
+    },
+    {
+      "self_ref": "#/texts/30",
       "parent": {
         "$ref": "#/groups/8"
       },
@@ -720,7 +774,7 @@
       "hyperlink": "."
     },
     {
-      "self_ref": "#/texts/29",
+      "self_ref": "#/texts/31",
       "parent": {
         "$ref": "#/groups/8"
       },
@@ -732,7 +786,7 @@
       "text": "&"
     },
     {
-      "self_ref": "#/texts/30",
+      "self_ref": "#/texts/32",
       "parent": {
         "$ref": "#/groups/8"
       },
@@ -746,12 +800,14 @@
         "bold": true,
         "italic": true,
         "underline": true,
-        "strikethrough": true
+        "strikethrough": true,
+        "subscript": false,
+        "superscript": false
       },
       "hyperlink": "https://github.com/DS4SD/docling"
     },
     {
-      "self_ref": "#/texts/31",
+      "self_ref": "#/texts/33",
       "parent": {
         "$ref": "#/groups/9"
       },
@@ -765,7 +821,7 @@
       "marker": "-"
     },
     {
-      "self_ref": "#/texts/32",
+      "self_ref": "#/texts/34",
       "parent": {
         "$ref": "#/groups/9"
       },
@@ -779,7 +835,7 @@
       "marker": "-"
     },
     {
-      "self_ref": "#/texts/33",
+      "self_ref": "#/texts/35",
       "parent": {
         "$ref": "#/groups/9"
       },
@@ -797,7 +853,7 @@
       "marker": "-"
     },
     {
-      "self_ref": "#/texts/34",
+      "self_ref": "#/texts/36",
       "parent": {
         "$ref": "#/groups/10"
       },
@@ -811,7 +867,7 @@
       "marker": "-"
     },
     {
-      "self_ref": "#/texts/35",
+      "self_ref": "#/texts/37",
       "parent": {
         "$ref": "#/groups/10"
       },
@@ -829,7 +885,7 @@
       "marker": "-"
     },
     {
-      "self_ref": "#/texts/36",
+      "self_ref": "#/texts/38",
       "parent": {
         "$ref": "#/groups/11"
       },
@@ -843,7 +899,7 @@
       "marker": "-"
     },
     {
-      "self_ref": "#/texts/37",
+      "self_ref": "#/texts/39",
       "parent": {
         "$ref": "#/groups/11"
       },
@@ -857,7 +913,7 @@
       "marker": "-"
     },
     {
-      "self_ref": "#/texts/38",
+      "self_ref": "#/texts/40",
       "parent": {
         "$ref": "#/groups/10"
       },
@@ -871,7 +927,7 @@
       "marker": "-"
     },
     {
-      "self_ref": "#/texts/39",
+      "self_ref": "#/texts/41",
       "parent": {
         "$ref": "#/groups/9"
       },
@@ -885,7 +941,7 @@
       "marker": "-"
     },
     {
-      "self_ref": "#/texts/40",
+      "self_ref": "#/texts/42",
       "parent": {
         "$ref": "#/body"
       },
@@ -897,7 +953,7 @@
       "text": "The end."
     },
     {
-      "self_ref": "#/texts/41",
+      "self_ref": "#/texts/43",
       "parent": {
         "$ref": "#/body"
       },
@@ -909,7 +965,7 @@
       "text": "child text appended at body"
     },
     {
-      "self_ref": "#/texts/42",
+      "self_ref": "#/texts/44",
       "parent": {
         "$ref": "#/groups/11"
       },

--- a/test/data/doc/constructed_doc.deleted_group.json.gt
+++ b/test/data/doc/constructed_doc.deleted_group.json.gt
@@ -73,7 +73,7 @@
         "$ref": "#/groups/9"
       },
       {
-        "$ref": "#/texts/40"
+        "$ref": "#/texts/42"
       }
     ],
     "content_layer": "body",
@@ -242,6 +242,12 @@
         },
         {
           "$ref": "#/texts/30"
+        },
+        {
+          "$ref": "#/texts/31"
+        },
+        {
+          "$ref": "#/texts/32"
         }
       ],
       "content_layer": "body",
@@ -255,16 +261,16 @@
       },
       "children": [
         {
-          "$ref": "#/texts/31"
-        },
-        {
-          "$ref": "#/texts/32"
-        },
-        {
           "$ref": "#/texts/33"
         },
         {
-          "$ref": "#/texts/39"
+          "$ref": "#/texts/34"
+        },
+        {
+          "$ref": "#/texts/35"
+        },
+        {
+          "$ref": "#/texts/41"
         }
       ],
       "content_layer": "body",
@@ -274,17 +280,17 @@
     {
       "self_ref": "#/groups/10",
       "parent": {
-        "$ref": "#/texts/33"
+        "$ref": "#/texts/35"
       },
       "children": [
         {
-          "$ref": "#/texts/34"
+          "$ref": "#/texts/36"
         },
         {
-          "$ref": "#/texts/35"
+          "$ref": "#/texts/37"
         },
         {
-          "$ref": "#/texts/38"
+          "$ref": "#/texts/40"
         }
       ],
       "content_layer": "body",
@@ -294,14 +300,14 @@
     {
       "self_ref": "#/groups/11",
       "parent": {
-        "$ref": "#/texts/35"
+        "$ref": "#/texts/37"
       },
       "children": [
         {
-          "$ref": "#/texts/36"
+          "$ref": "#/texts/38"
         },
         {
-          "$ref": "#/texts/37"
+          "$ref": "#/texts/39"
         }
       ],
       "content_layer": "body",
@@ -512,8 +518,8 @@
       "content_layer": "body",
       "label": "code",
       "prov": [],
-      "orig": "<p>Hello world</p>",
-      "text": "<p>Hello world</p>",
+      "orig": "print(\"Hello world\")",
+      "text": "print(\"Hello world\")",
       "captions": [],
       "references": [],
       "footnotes": [],
@@ -646,7 +652,9 @@
         "bold": true,
         "italic": false,
         "underline": false,
-        "strikethrough": false
+        "strikethrough": false,
+        "subscript": false,
+        "superscript": false
       }
     },
     {
@@ -664,7 +672,9 @@
         "bold": false,
         "italic": true,
         "underline": false,
-        "strikethrough": false
+        "strikethrough": false,
+        "subscript": false,
+        "superscript": false
       }
     },
     {
@@ -682,7 +692,9 @@
         "bold": false,
         "italic": false,
         "underline": true,
-        "strikethrough": false
+        "strikethrough": false,
+        "subscript": false,
+        "superscript": false
       }
     },
     {
@@ -700,11 +712,53 @@
         "bold": false,
         "italic": false,
         "underline": false,
-        "strikethrough": true
+        "strikethrough": true,
+        "subscript": false,
+        "superscript": false
       }
     },
     {
       "self_ref": "#/texts/28",
+      "parent": {
+        "$ref": "#/groups/8"
+      },
+      "children": [],
+      "content_layer": "body",
+      "label": "text",
+      "prov": [],
+      "orig": "subscript",
+      "text": "subscript",
+      "formatting": {
+        "bold": false,
+        "italic": false,
+        "underline": false,
+        "strikethrough": false,
+        "subscript": true,
+        "superscript": false
+      }
+    },
+    {
+      "self_ref": "#/texts/29",
+      "parent": {
+        "$ref": "#/groups/8"
+      },
+      "children": [],
+      "content_layer": "body",
+      "label": "text",
+      "prov": [],
+      "orig": "superscript",
+      "text": "superscript",
+      "formatting": {
+        "bold": false,
+        "italic": false,
+        "underline": false,
+        "strikethrough": false,
+        "subscript": false,
+        "superscript": true
+      }
+    },
+    {
+      "self_ref": "#/texts/30",
       "parent": {
         "$ref": "#/groups/8"
       },
@@ -717,7 +771,7 @@
       "hyperlink": "."
     },
     {
-      "self_ref": "#/texts/29",
+      "self_ref": "#/texts/31",
       "parent": {
         "$ref": "#/groups/8"
       },
@@ -729,7 +783,7 @@
       "text": "&"
     },
     {
-      "self_ref": "#/texts/30",
+      "self_ref": "#/texts/32",
       "parent": {
         "$ref": "#/groups/8"
       },
@@ -743,12 +797,14 @@
         "bold": true,
         "italic": true,
         "underline": true,
-        "strikethrough": true
+        "strikethrough": true,
+        "subscript": false,
+        "superscript": false
       },
       "hyperlink": "https://github.com/DS4SD/docling"
     },
     {
-      "self_ref": "#/texts/31",
+      "self_ref": "#/texts/33",
       "parent": {
         "$ref": "#/groups/9"
       },
@@ -762,7 +818,7 @@
       "marker": "-"
     },
     {
-      "self_ref": "#/texts/32",
+      "self_ref": "#/texts/34",
       "parent": {
         "$ref": "#/groups/9"
       },
@@ -776,7 +832,7 @@
       "marker": "-"
     },
     {
-      "self_ref": "#/texts/33",
+      "self_ref": "#/texts/35",
       "parent": {
         "$ref": "#/groups/9"
       },
@@ -794,7 +850,7 @@
       "marker": "-"
     },
     {
-      "self_ref": "#/texts/34",
+      "self_ref": "#/texts/36",
       "parent": {
         "$ref": "#/groups/10"
       },
@@ -808,7 +864,7 @@
       "marker": "-"
     },
     {
-      "self_ref": "#/texts/35",
+      "self_ref": "#/texts/37",
       "parent": {
         "$ref": "#/groups/10"
       },
@@ -826,7 +882,7 @@
       "marker": "-"
     },
     {
-      "self_ref": "#/texts/36",
+      "self_ref": "#/texts/38",
       "parent": {
         "$ref": "#/groups/11"
       },
@@ -840,7 +896,7 @@
       "marker": "-"
     },
     {
-      "self_ref": "#/texts/37",
+      "self_ref": "#/texts/39",
       "parent": {
         "$ref": "#/groups/11"
       },
@@ -854,7 +910,7 @@
       "marker": "-"
     },
     {
-      "self_ref": "#/texts/38",
+      "self_ref": "#/texts/40",
       "parent": {
         "$ref": "#/groups/10"
       },
@@ -868,7 +924,7 @@
       "marker": "-"
     },
     {
-      "self_ref": "#/texts/39",
+      "self_ref": "#/texts/41",
       "parent": {
         "$ref": "#/groups/9"
       },
@@ -882,7 +938,7 @@
       "marker": "-"
     },
     {
-      "self_ref": "#/texts/40",
+      "self_ref": "#/texts/42",
       "parent": {
         "$ref": "#/body"
       },

--- a/test/data/doc/constructed_doc.deleted_picture.json.gt
+++ b/test/data/doc/constructed_doc.deleted_picture.json.gt
@@ -70,7 +70,7 @@
         "$ref": "#/groups/9"
       },
       {
-        "$ref": "#/texts/40"
+        "$ref": "#/texts/42"
       }
     ],
     "content_layer": "body",
@@ -239,6 +239,12 @@
         },
         {
           "$ref": "#/texts/30"
+        },
+        {
+          "$ref": "#/texts/31"
+        },
+        {
+          "$ref": "#/texts/32"
         }
       ],
       "content_layer": "body",
@@ -252,16 +258,16 @@
       },
       "children": [
         {
-          "$ref": "#/texts/31"
-        },
-        {
-          "$ref": "#/texts/32"
-        },
-        {
           "$ref": "#/texts/33"
         },
         {
-          "$ref": "#/texts/39"
+          "$ref": "#/texts/34"
+        },
+        {
+          "$ref": "#/texts/35"
+        },
+        {
+          "$ref": "#/texts/41"
         }
       ],
       "content_layer": "body",
@@ -271,17 +277,17 @@
     {
       "self_ref": "#/groups/10",
       "parent": {
-        "$ref": "#/texts/33"
+        "$ref": "#/texts/35"
       },
       "children": [
         {
-          "$ref": "#/texts/34"
+          "$ref": "#/texts/36"
         },
         {
-          "$ref": "#/texts/35"
+          "$ref": "#/texts/37"
         },
         {
-          "$ref": "#/texts/38"
+          "$ref": "#/texts/40"
         }
       ],
       "content_layer": "body",
@@ -291,14 +297,14 @@
     {
       "self_ref": "#/groups/11",
       "parent": {
-        "$ref": "#/texts/35"
+        "$ref": "#/texts/37"
       },
       "children": [
         {
-          "$ref": "#/texts/36"
+          "$ref": "#/texts/38"
         },
         {
-          "$ref": "#/texts/37"
+          "$ref": "#/texts/39"
         }
       ],
       "content_layer": "body",
@@ -509,8 +515,8 @@
       "content_layer": "body",
       "label": "code",
       "prov": [],
-      "orig": "<p>Hello world</p>",
-      "text": "<p>Hello world</p>",
+      "orig": "print(\"Hello world\")",
+      "text": "print(\"Hello world\")",
       "captions": [],
       "references": [],
       "footnotes": [],
@@ -643,7 +649,9 @@
         "bold": true,
         "italic": false,
         "underline": false,
-        "strikethrough": false
+        "strikethrough": false,
+        "subscript": false,
+        "superscript": false
       }
     },
     {
@@ -661,7 +669,9 @@
         "bold": false,
         "italic": true,
         "underline": false,
-        "strikethrough": false
+        "strikethrough": false,
+        "subscript": false,
+        "superscript": false
       }
     },
     {
@@ -679,7 +689,9 @@
         "bold": false,
         "italic": false,
         "underline": true,
-        "strikethrough": false
+        "strikethrough": false,
+        "subscript": false,
+        "superscript": false
       }
     },
     {
@@ -697,11 +709,53 @@
         "bold": false,
         "italic": false,
         "underline": false,
-        "strikethrough": true
+        "strikethrough": true,
+        "subscript": false,
+        "superscript": false
       }
     },
     {
       "self_ref": "#/texts/28",
+      "parent": {
+        "$ref": "#/groups/8"
+      },
+      "children": [],
+      "content_layer": "body",
+      "label": "text",
+      "prov": [],
+      "orig": "subscript",
+      "text": "subscript",
+      "formatting": {
+        "bold": false,
+        "italic": false,
+        "underline": false,
+        "strikethrough": false,
+        "subscript": true,
+        "superscript": false
+      }
+    },
+    {
+      "self_ref": "#/texts/29",
+      "parent": {
+        "$ref": "#/groups/8"
+      },
+      "children": [],
+      "content_layer": "body",
+      "label": "text",
+      "prov": [],
+      "orig": "superscript",
+      "text": "superscript",
+      "formatting": {
+        "bold": false,
+        "italic": false,
+        "underline": false,
+        "strikethrough": false,
+        "subscript": false,
+        "superscript": true
+      }
+    },
+    {
+      "self_ref": "#/texts/30",
       "parent": {
         "$ref": "#/groups/8"
       },
@@ -714,7 +768,7 @@
       "hyperlink": "."
     },
     {
-      "self_ref": "#/texts/29",
+      "self_ref": "#/texts/31",
       "parent": {
         "$ref": "#/groups/8"
       },
@@ -726,7 +780,7 @@
       "text": "&"
     },
     {
-      "self_ref": "#/texts/30",
+      "self_ref": "#/texts/32",
       "parent": {
         "$ref": "#/groups/8"
       },
@@ -740,12 +794,14 @@
         "bold": true,
         "italic": true,
         "underline": true,
-        "strikethrough": true
+        "strikethrough": true,
+        "subscript": false,
+        "superscript": false
       },
       "hyperlink": "https://github.com/DS4SD/docling"
     },
     {
-      "self_ref": "#/texts/31",
+      "self_ref": "#/texts/33",
       "parent": {
         "$ref": "#/groups/9"
       },
@@ -759,7 +815,7 @@
       "marker": "-"
     },
     {
-      "self_ref": "#/texts/32",
+      "self_ref": "#/texts/34",
       "parent": {
         "$ref": "#/groups/9"
       },
@@ -773,7 +829,7 @@
       "marker": "-"
     },
     {
-      "self_ref": "#/texts/33",
+      "self_ref": "#/texts/35",
       "parent": {
         "$ref": "#/groups/9"
       },
@@ -791,7 +847,7 @@
       "marker": "-"
     },
     {
-      "self_ref": "#/texts/34",
+      "self_ref": "#/texts/36",
       "parent": {
         "$ref": "#/groups/10"
       },
@@ -805,7 +861,7 @@
       "marker": "-"
     },
     {
-      "self_ref": "#/texts/35",
+      "self_ref": "#/texts/37",
       "parent": {
         "$ref": "#/groups/10"
       },
@@ -823,7 +879,7 @@
       "marker": "-"
     },
     {
-      "self_ref": "#/texts/36",
+      "self_ref": "#/texts/38",
       "parent": {
         "$ref": "#/groups/11"
       },
@@ -837,7 +893,7 @@
       "marker": "-"
     },
     {
-      "self_ref": "#/texts/37",
+      "self_ref": "#/texts/39",
       "parent": {
         "$ref": "#/groups/11"
       },
@@ -851,7 +907,7 @@
       "marker": "-"
     },
     {
-      "self_ref": "#/texts/38",
+      "self_ref": "#/texts/40",
       "parent": {
         "$ref": "#/groups/10"
       },
@@ -865,7 +921,7 @@
       "marker": "-"
     },
     {
-      "self_ref": "#/texts/39",
+      "self_ref": "#/texts/41",
       "parent": {
         "$ref": "#/groups/9"
       },
@@ -879,7 +935,7 @@
       "marker": "-"
     },
     {
-      "self_ref": "#/texts/40",
+      "self_ref": "#/texts/42",
       "parent": {
         "$ref": "#/body"
       },

--- a/test/data/doc/constructed_doc.deleted_text.json.gt
+++ b/test/data/doc/constructed_doc.deleted_text.json.gt
@@ -76,7 +76,7 @@
         "$ref": "#/groups/13"
       },
       {
-        "$ref": "#/texts/49"
+        "$ref": "#/texts/51"
       }
     ],
     "content_layer": "body",
@@ -151,10 +151,10 @@
           "$ref": "#/texts/9"
         },
         {
-          "$ref": "#/texts/50"
+          "$ref": "#/texts/52"
         },
         {
-          "$ref": "#/texts/51"
+          "$ref": "#/texts/53"
         },
         {
           "$ref": "#/texts/10"
@@ -325,6 +325,12 @@
         },
         {
           "$ref": "#/texts/39"
+        },
+        {
+          "$ref": "#/texts/40"
+        },
+        {
+          "$ref": "#/texts/41"
         }
       ],
       "content_layer": "body",
@@ -338,16 +344,16 @@
       },
       "children": [
         {
-          "$ref": "#/texts/40"
-        },
-        {
-          "$ref": "#/texts/41"
-        },
-        {
           "$ref": "#/texts/42"
         },
         {
-          "$ref": "#/texts/48"
+          "$ref": "#/texts/43"
+        },
+        {
+          "$ref": "#/texts/44"
+        },
+        {
+          "$ref": "#/texts/50"
         }
       ],
       "content_layer": "body",
@@ -357,17 +363,17 @@
     {
       "self_ref": "#/groups/14",
       "parent": {
-        "$ref": "#/texts/42"
+        "$ref": "#/texts/44"
       },
       "children": [
         {
-          "$ref": "#/texts/43"
+          "$ref": "#/texts/45"
         },
         {
-          "$ref": "#/texts/44"
+          "$ref": "#/texts/46"
         },
         {
-          "$ref": "#/texts/47"
+          "$ref": "#/texts/49"
         }
       ],
       "content_layer": "body",
@@ -377,14 +383,14 @@
     {
       "self_ref": "#/groups/15",
       "parent": {
-        "$ref": "#/texts/44"
+        "$ref": "#/texts/46"
       },
       "children": [
         {
-          "$ref": "#/texts/45"
+          "$ref": "#/texts/47"
         },
         {
-          "$ref": "#/texts/46"
+          "$ref": "#/texts/48"
         }
       ],
       "content_layer": "body",
@@ -726,8 +732,8 @@
       "content_layer": "body",
       "label": "code",
       "prov": [],
-      "orig": "<p>Hello world</p>",
-      "text": "<p>Hello world</p>",
+      "orig": "print(\"Hello world\")",
+      "text": "print(\"Hello world\")",
       "captions": [],
       "references": [],
       "footnotes": [],
@@ -860,7 +866,9 @@
         "bold": true,
         "italic": false,
         "underline": false,
-        "strikethrough": false
+        "strikethrough": false,
+        "subscript": false,
+        "superscript": false
       }
     },
     {
@@ -878,7 +886,9 @@
         "bold": false,
         "italic": true,
         "underline": false,
-        "strikethrough": false
+        "strikethrough": false,
+        "subscript": false,
+        "superscript": false
       }
     },
     {
@@ -896,7 +906,9 @@
         "bold": false,
         "italic": false,
         "underline": true,
-        "strikethrough": false
+        "strikethrough": false,
+        "subscript": false,
+        "superscript": false
       }
     },
     {
@@ -914,11 +926,53 @@
         "bold": false,
         "italic": false,
         "underline": false,
-        "strikethrough": true
+        "strikethrough": true,
+        "subscript": false,
+        "superscript": false
       }
     },
     {
       "self_ref": "#/texts/37",
+      "parent": {
+        "$ref": "#/groups/12"
+      },
+      "children": [],
+      "content_layer": "body",
+      "label": "text",
+      "prov": [],
+      "orig": "subscript",
+      "text": "subscript",
+      "formatting": {
+        "bold": false,
+        "italic": false,
+        "underline": false,
+        "strikethrough": false,
+        "subscript": true,
+        "superscript": false
+      }
+    },
+    {
+      "self_ref": "#/texts/38",
+      "parent": {
+        "$ref": "#/groups/12"
+      },
+      "children": [],
+      "content_layer": "body",
+      "label": "text",
+      "prov": [],
+      "orig": "superscript",
+      "text": "superscript",
+      "formatting": {
+        "bold": false,
+        "italic": false,
+        "underline": false,
+        "strikethrough": false,
+        "subscript": false,
+        "superscript": true
+      }
+    },
+    {
+      "self_ref": "#/texts/39",
       "parent": {
         "$ref": "#/groups/12"
       },
@@ -931,7 +985,7 @@
       "hyperlink": "."
     },
     {
-      "self_ref": "#/texts/38",
+      "self_ref": "#/texts/40",
       "parent": {
         "$ref": "#/groups/12"
       },
@@ -943,7 +997,7 @@
       "text": "&"
     },
     {
-      "self_ref": "#/texts/39",
+      "self_ref": "#/texts/41",
       "parent": {
         "$ref": "#/groups/12"
       },
@@ -957,12 +1011,14 @@
         "bold": true,
         "italic": true,
         "underline": true,
-        "strikethrough": true
+        "strikethrough": true,
+        "subscript": false,
+        "superscript": false
       },
       "hyperlink": "https://github.com/DS4SD/docling"
     },
     {
-      "self_ref": "#/texts/40",
+      "self_ref": "#/texts/42",
       "parent": {
         "$ref": "#/groups/13"
       },
@@ -976,7 +1032,7 @@
       "marker": "-"
     },
     {
-      "self_ref": "#/texts/41",
+      "self_ref": "#/texts/43",
       "parent": {
         "$ref": "#/groups/13"
       },
@@ -990,7 +1046,7 @@
       "marker": "-"
     },
     {
-      "self_ref": "#/texts/42",
+      "self_ref": "#/texts/44",
       "parent": {
         "$ref": "#/groups/13"
       },
@@ -1008,7 +1064,7 @@
       "marker": "-"
     },
     {
-      "self_ref": "#/texts/43",
+      "self_ref": "#/texts/45",
       "parent": {
         "$ref": "#/groups/14"
       },
@@ -1022,7 +1078,7 @@
       "marker": "-"
     },
     {
-      "self_ref": "#/texts/44",
+      "self_ref": "#/texts/46",
       "parent": {
         "$ref": "#/groups/14"
       },
@@ -1040,7 +1096,7 @@
       "marker": "-"
     },
     {
-      "self_ref": "#/texts/45",
+      "self_ref": "#/texts/47",
       "parent": {
         "$ref": "#/groups/15"
       },
@@ -1054,7 +1110,7 @@
       "marker": "-"
     },
     {
-      "self_ref": "#/texts/46",
+      "self_ref": "#/texts/48",
       "parent": {
         "$ref": "#/groups/15"
       },
@@ -1068,7 +1124,7 @@
       "marker": "-"
     },
     {
-      "self_ref": "#/texts/47",
+      "self_ref": "#/texts/49",
       "parent": {
         "$ref": "#/groups/14"
       },
@@ -1082,7 +1138,7 @@
       "marker": "-"
     },
     {
-      "self_ref": "#/texts/48",
+      "self_ref": "#/texts/50",
       "parent": {
         "$ref": "#/groups/13"
       },
@@ -1096,7 +1152,7 @@
       "marker": "-"
     },
     {
-      "self_ref": "#/texts/49",
+      "self_ref": "#/texts/51",
       "parent": {
         "$ref": "#/body"
       },
@@ -1108,7 +1164,7 @@
       "text": "The end."
     },
     {
-      "self_ref": "#/texts/50",
+      "self_ref": "#/texts/52",
       "parent": {
         "$ref": "#/groups/3"
       },
@@ -1122,7 +1178,7 @@
       "marker": "-"
     },
     {
-      "self_ref": "#/texts/51",
+      "self_ref": "#/texts/53",
       "parent": {
         "$ref": "#/groups/3"
       },

--- a/test/data/doc/constructed_doc.dt
+++ b/test/data/doc/constructed_doc.dt
@@ -30,7 +30,7 @@ Affiliation 2</text>
 <list_item>item 2 of neighboring list</list_item>
 <list_item><unordered_list><list_item>item 1 of sub list</list_item>
 <list_item><inline><text>Here a code snippet:</text>
-<code><_unknown_><p>Hello world</p></code>
+<code><_unknown_>print("Hello world")</code>
 <text>(to be displayed inline)</text>
 </inline></list_item>
 <list_item><inline><text>Here a formula:</text>
@@ -49,6 +49,8 @@ Affiliation 2</text>
 <text>italic</text>
 <text>underline</text>
 <text>strikethrough</text>
+<text>subscript</text>
+<text>superscript</text>
 <text>hyperlink</text>
 <text>&</text>
 <text>everything at the same time.</text>

--- a/test/data/doc/constructed_doc.dt.gt
+++ b/test/data/doc/constructed_doc.dt.gt
@@ -30,7 +30,7 @@ Affiliation 2</text>
 <list_item>item 2 of neighboring list</list_item>
 <list_item><unordered_list><list_item>item 1 of sub list</list_item>
 <list_item><inline><text>Here a code snippet:</text>
-<code><_unknown_><p>Hello world</p></code>
+<code><_unknown_>print("Hello world")</code>
 <text>(to be displayed inline)</text>
 </inline></list_item>
 <list_item><inline><text>Here a formula:</text>
@@ -49,6 +49,8 @@ Affiliation 2</text>
 <text>italic</text>
 <text>underline</text>
 <text>strikethrough</text>
+<text>subscript</text>
+<text>superscript</text>
 <text>hyperlink</text>
 <text>&</text>
 <text>everything at the same time.</text>

--- a/test/data/doc/constructed_doc.embedded.html.gt
+++ b/test/data/doc/constructed_doc.embedded.html.gt
@@ -161,7 +161,7 @@
 <li>item 2 of neighboring list</li>
 <ul>
 <li>item 1 of sub list</li>
-<li><span class='inline-group'>Here a code snippet: <code><p>Hello world</p></code> (to be displayed inline)</span></li>
+<li><span class='inline-group'>Here a code snippet: <code>print("Hello world")</code> (to be displayed inline)</span></li>
 <li><span class='inline-group'>Here a formula: <math xmlns="http://www.w3.org/1998/Math/MathML" display="inline"><mrow><mi>E</mi><mo>&#x0003D;</mo><mi>m</mi><msup><mi>c</mi><mn>2</mn></msup></mrow><annotation encoding="TeX">E=mc^2</annotation></math> (to be displayed inline)</span></li>
 </ul>
 </ul>
@@ -181,7 +181,7 @@
 
 </ul>
 </div>
-<span class='inline-group'>Some formatting chops: <strong>bold</strong> <em>italic</em> <u>underline</u> <del>strikethrough</del> <a href=".">hyperlink</a> &amp; <a href="https://github.com/DS4SD/docling"><del><u><em><strong>everything at the same time.</strong></em></u></del></a></span>
+<span class='inline-group'>Some formatting chops: <strong>bold</strong> <em>italic</em> <u>underline</u> <del>strikethrough</del> <sub>subscript</sub> <sup>superscript</sup> <a href=".">hyperlink</a> &amp; <a href="https://github.com/DS4SD/docling"><del><u><em><strong>everything at the same time.</strong></em></u></del></a></span>
 <ol>
 <li>Item 1 in A</li>
 <li>Item 2 in A</li>

--- a/test/data/doc/constructed_doc.embedded.json.gt
+++ b/test/data/doc/constructed_doc.embedded.json.gt
@@ -76,7 +76,7 @@
         "$ref": "#/groups/13"
       },
       {
-        "$ref": "#/texts/50"
+        "$ref": "#/texts/52"
       }
     ],
     "content_layer": "body",
@@ -322,6 +322,12 @@
         },
         {
           "$ref": "#/texts/40"
+        },
+        {
+          "$ref": "#/texts/41"
+        },
+        {
+          "$ref": "#/texts/42"
         }
       ],
       "content_layer": "body",
@@ -335,16 +341,16 @@
       },
       "children": [
         {
-          "$ref": "#/texts/41"
-        },
-        {
-          "$ref": "#/texts/42"
-        },
-        {
           "$ref": "#/texts/43"
         },
         {
-          "$ref": "#/texts/49"
+          "$ref": "#/texts/44"
+        },
+        {
+          "$ref": "#/texts/45"
+        },
+        {
+          "$ref": "#/texts/51"
         }
       ],
       "content_layer": "body",
@@ -354,17 +360,17 @@
     {
       "self_ref": "#/groups/14",
       "parent": {
-        "$ref": "#/texts/43"
+        "$ref": "#/texts/45"
       },
       "children": [
         {
-          "$ref": "#/texts/44"
+          "$ref": "#/texts/46"
         },
         {
-          "$ref": "#/texts/45"
+          "$ref": "#/texts/47"
         },
         {
-          "$ref": "#/texts/48"
+          "$ref": "#/texts/50"
         }
       ],
       "content_layer": "body",
@@ -374,14 +380,14 @@
     {
       "self_ref": "#/groups/15",
       "parent": {
-        "$ref": "#/texts/45"
+        "$ref": "#/texts/47"
       },
       "children": [
         {
-          "$ref": "#/texts/46"
+          "$ref": "#/texts/48"
         },
         {
-          "$ref": "#/texts/47"
+          "$ref": "#/texts/49"
         }
       ],
       "content_layer": "body",
@@ -737,8 +743,8 @@
       "content_layer": "body",
       "label": "code",
       "prov": [],
-      "orig": "<p>Hello world</p>",
-      "text": "<p>Hello world</p>",
+      "orig": "print(\"Hello world\")",
+      "text": "print(\"Hello world\")",
       "captions": [],
       "references": [],
       "footnotes": [],
@@ -871,7 +877,9 @@
         "bold": true,
         "italic": false,
         "underline": false,
-        "strikethrough": false
+        "strikethrough": false,
+        "subscript": false,
+        "superscript": false
       }
     },
     {
@@ -889,7 +897,9 @@
         "bold": false,
         "italic": true,
         "underline": false,
-        "strikethrough": false
+        "strikethrough": false,
+        "subscript": false,
+        "superscript": false
       }
     },
     {
@@ -907,7 +917,9 @@
         "bold": false,
         "italic": false,
         "underline": true,
-        "strikethrough": false
+        "strikethrough": false,
+        "subscript": false,
+        "superscript": false
       }
     },
     {
@@ -925,11 +937,53 @@
         "bold": false,
         "italic": false,
         "underline": false,
-        "strikethrough": true
+        "strikethrough": true,
+        "subscript": false,
+        "superscript": false
       }
     },
     {
       "self_ref": "#/texts/38",
+      "parent": {
+        "$ref": "#/groups/12"
+      },
+      "children": [],
+      "content_layer": "body",
+      "label": "text",
+      "prov": [],
+      "orig": "subscript",
+      "text": "subscript",
+      "formatting": {
+        "bold": false,
+        "italic": false,
+        "underline": false,
+        "strikethrough": false,
+        "subscript": true,
+        "superscript": false
+      }
+    },
+    {
+      "self_ref": "#/texts/39",
+      "parent": {
+        "$ref": "#/groups/12"
+      },
+      "children": [],
+      "content_layer": "body",
+      "label": "text",
+      "prov": [],
+      "orig": "superscript",
+      "text": "superscript",
+      "formatting": {
+        "bold": false,
+        "italic": false,
+        "underline": false,
+        "strikethrough": false,
+        "subscript": false,
+        "superscript": true
+      }
+    },
+    {
+      "self_ref": "#/texts/40",
       "parent": {
         "$ref": "#/groups/12"
       },
@@ -942,7 +996,7 @@
       "hyperlink": "."
     },
     {
-      "self_ref": "#/texts/39",
+      "self_ref": "#/texts/41",
       "parent": {
         "$ref": "#/groups/12"
       },
@@ -954,7 +1008,7 @@
       "text": "&"
     },
     {
-      "self_ref": "#/texts/40",
+      "self_ref": "#/texts/42",
       "parent": {
         "$ref": "#/groups/12"
       },
@@ -968,12 +1022,14 @@
         "bold": true,
         "italic": true,
         "underline": true,
-        "strikethrough": true
+        "strikethrough": true,
+        "subscript": false,
+        "superscript": false
       },
       "hyperlink": "https://github.com/DS4SD/docling"
     },
     {
-      "self_ref": "#/texts/41",
+      "self_ref": "#/texts/43",
       "parent": {
         "$ref": "#/groups/13"
       },
@@ -987,7 +1043,7 @@
       "marker": "-"
     },
     {
-      "self_ref": "#/texts/42",
+      "self_ref": "#/texts/44",
       "parent": {
         "$ref": "#/groups/13"
       },
@@ -1001,7 +1057,7 @@
       "marker": "-"
     },
     {
-      "self_ref": "#/texts/43",
+      "self_ref": "#/texts/45",
       "parent": {
         "$ref": "#/groups/13"
       },
@@ -1019,7 +1075,7 @@
       "marker": "-"
     },
     {
-      "self_ref": "#/texts/44",
+      "self_ref": "#/texts/46",
       "parent": {
         "$ref": "#/groups/14"
       },
@@ -1033,7 +1089,7 @@
       "marker": "-"
     },
     {
-      "self_ref": "#/texts/45",
+      "self_ref": "#/texts/47",
       "parent": {
         "$ref": "#/groups/14"
       },
@@ -1051,7 +1107,7 @@
       "marker": "-"
     },
     {
-      "self_ref": "#/texts/46",
+      "self_ref": "#/texts/48",
       "parent": {
         "$ref": "#/groups/15"
       },
@@ -1065,7 +1121,7 @@
       "marker": "-"
     },
     {
-      "self_ref": "#/texts/47",
+      "self_ref": "#/texts/49",
       "parent": {
         "$ref": "#/groups/15"
       },
@@ -1079,7 +1135,7 @@
       "marker": "-"
     },
     {
-      "self_ref": "#/texts/48",
+      "self_ref": "#/texts/50",
       "parent": {
         "$ref": "#/groups/14"
       },
@@ -1093,7 +1149,7 @@
       "marker": "-"
     },
     {
-      "self_ref": "#/texts/49",
+      "self_ref": "#/texts/51",
       "parent": {
         "$ref": "#/groups/13"
       },
@@ -1107,7 +1163,7 @@
       "marker": "-"
     },
     {
-      "self_ref": "#/texts/50",
+      "self_ref": "#/texts/52",
       "parent": {
         "$ref": "#/body"
       },

--- a/test/data/doc/constructed_doc.embedded.md.gt
+++ b/test/data/doc/constructed_doc.embedded.md.gt
@@ -44,7 +44,7 @@ This is the caption of figure 2.
 - item 1 of neighboring list
 - item 2 of neighboring list
     - item 1 of sub list
-    - Here a code snippet: `<p>Hello world</p>` (to be displayed inline)
+    - Here a code snippet: `print("Hello world")` (to be displayed inline)
     - Here a formula: $E=mc^2$ (to be displayed inline)
 
 Here a code block:
@@ -61,7 +61,7 @@ $$E=mc^2$$
 
 <!-- missing-form-item -->
 
-Some formatting chops: **bold** *italic* underline ~~strikethrough~~ [hyperlink](.) &amp; [~~***everything at the same time.***~~](https://github.com/DS4SD/docling)
+Some formatting chops: **bold** *italic* underline ~~strikethrough~~ subscript superscript [hyperlink](.) &amp; [~~***everything at the same time.***~~](https://github.com/DS4SD/docling)
 
 1. Item 1 in A
 2. Item 2 in A

--- a/test/data/doc/constructed_doc.embedded.yaml.gt
+++ b/test/data/doc/constructed_doc.embedded.yaml.gt
@@ -21,7 +21,7 @@ body:
   - $ref: '#/form_items/0'
   - $ref: '#/groups/12'
   - $ref: '#/groups/13'
-  - $ref: '#/texts/50'
+  - $ref: '#/texts/52'
   content_layer: body
   label: unspecified
   name: _root_
@@ -180,6 +180,8 @@ groups:
   - $ref: '#/texts/38'
   - $ref: '#/texts/39'
   - $ref: '#/texts/40'
+  - $ref: '#/texts/41'
+  - $ref: '#/texts/42'
   content_layer: body
   label: inline
   name: group
@@ -187,10 +189,10 @@ groups:
     $ref: '#/body'
   self_ref: '#/groups/12'
 - children:
-  - $ref: '#/texts/41'
-  - $ref: '#/texts/42'
   - $ref: '#/texts/43'
-  - $ref: '#/texts/49'
+  - $ref: '#/texts/44'
+  - $ref: '#/texts/45'
+  - $ref: '#/texts/51'
   content_layer: body
   label: ordered_list
   name: list A
@@ -198,23 +200,23 @@ groups:
     $ref: '#/body'
   self_ref: '#/groups/13'
 - children:
-  - $ref: '#/texts/44'
-  - $ref: '#/texts/45'
-  - $ref: '#/texts/48'
+  - $ref: '#/texts/46'
+  - $ref: '#/texts/47'
+  - $ref: '#/texts/50'
   content_layer: body
   label: ordered_list
   name: list B
   parent:
-    $ref: '#/texts/43'
+    $ref: '#/texts/45'
   self_ref: '#/groups/14'
 - children:
-  - $ref: '#/texts/46'
-  - $ref: '#/texts/47'
+  - $ref: '#/texts/48'
+  - $ref: '#/texts/49'
   content_layer: body
   label: ordered_list
   name: list C
   parent:
-    $ref: '#/texts/45'
+    $ref: '#/texts/47'
   self_ref: '#/groups/15'
 key_value_items:
 - captions: []
@@ -724,13 +726,13 @@ texts:
   content_layer: body
   footnotes: []
   label: code
-  orig: <p>Hello world</p>
+  orig: print("Hello world")
   parent:
     $ref: '#/groups/10'
   prov: []
   references: []
   self_ref: '#/texts/24'
-  text: <p>Hello world</p>
+  text: print("Hello world")
 - children: []
   content_layer: body
   label: text
@@ -822,6 +824,8 @@ texts:
     bold: true
     italic: false
     strikethrough: false
+    subscript: false
+    superscript: false
     underline: false
   label: text
   orig: bold
@@ -836,6 +840,8 @@ texts:
     bold: false
     italic: true
     strikethrough: false
+    subscript: false
+    superscript: false
     underline: false
   label: text
   orig: italic
@@ -850,6 +856,8 @@ texts:
     bold: false
     italic: false
     strikethrough: false
+    subscript: false
+    superscript: false
     underline: true
   label: text
   orig: underline
@@ -864,6 +872,8 @@ texts:
     bold: false
     italic: false
     strikethrough: true
+    subscript: false
+    superscript: false
     underline: false
   label: text
   orig: strikethrough
@@ -874,13 +884,45 @@ texts:
   text: strikethrough
 - children: []
   content_layer: body
+  formatting:
+    bold: false
+    italic: false
+    strikethrough: false
+    subscript: true
+    superscript: false
+    underline: false
+  label: text
+  orig: subscript
+  parent:
+    $ref: '#/groups/12'
+  prov: []
+  self_ref: '#/texts/38'
+  text: subscript
+- children: []
+  content_layer: body
+  formatting:
+    bold: false
+    italic: false
+    strikethrough: false
+    subscript: false
+    superscript: true
+    underline: false
+  label: text
+  orig: superscript
+  parent:
+    $ref: '#/groups/12'
+  prov: []
+  self_ref: '#/texts/39'
+  text: superscript
+- children: []
+  content_layer: body
   hyperlink: .
   label: text
   orig: hyperlink
   parent:
     $ref: '#/groups/12'
   prov: []
-  self_ref: '#/texts/38'
+  self_ref: '#/texts/40'
   text: hyperlink
 - children: []
   content_layer: body
@@ -889,7 +931,7 @@ texts:
   parent:
     $ref: '#/groups/12'
   prov: []
-  self_ref: '#/texts/39'
+  self_ref: '#/texts/41'
   text: '&'
 - children: []
   content_layer: body
@@ -897,6 +939,8 @@ texts:
     bold: true
     italic: true
     strikethrough: true
+    subscript: false
+    superscript: false
     underline: true
   hyperlink: https://github.com/DS4SD/docling
   label: text
@@ -904,7 +948,7 @@ texts:
   parent:
     $ref: '#/groups/12'
   prov: []
-  self_ref: '#/texts/40'
+  self_ref: '#/texts/42'
   text: everything at the same time.
 - children: []
   content_layer: body
@@ -915,7 +959,7 @@ texts:
   parent:
     $ref: '#/groups/13'
   prov: []
-  self_ref: '#/texts/41'
+  self_ref: '#/texts/43'
   text: Item 1 in A
 - children: []
   content_layer: body
@@ -926,7 +970,7 @@ texts:
   parent:
     $ref: '#/groups/13'
   prov: []
-  self_ref: '#/texts/42'
+  self_ref: '#/texts/44'
   text: Item 2 in A
 - children:
   - $ref: '#/groups/14'
@@ -938,7 +982,7 @@ texts:
   parent:
     $ref: '#/groups/13'
   prov: []
-  self_ref: '#/texts/43'
+  self_ref: '#/texts/45'
   text: Item 3 in A
 - children: []
   content_layer: body
@@ -949,7 +993,7 @@ texts:
   parent:
     $ref: '#/groups/14'
   prov: []
-  self_ref: '#/texts/44'
+  self_ref: '#/texts/46'
   text: Item 1 in B
 - children:
   - $ref: '#/groups/15'
@@ -961,7 +1005,7 @@ texts:
   parent:
     $ref: '#/groups/14'
   prov: []
-  self_ref: '#/texts/45'
+  self_ref: '#/texts/47'
   text: Item 2 in B
 - children: []
   content_layer: body
@@ -972,7 +1016,7 @@ texts:
   parent:
     $ref: '#/groups/15'
   prov: []
-  self_ref: '#/texts/46'
+  self_ref: '#/texts/48'
   text: Item 1 in C
 - children: []
   content_layer: body
@@ -983,7 +1027,7 @@ texts:
   parent:
     $ref: '#/groups/15'
   prov: []
-  self_ref: '#/texts/47'
+  self_ref: '#/texts/49'
   text: Item 2 in C
 - children: []
   content_layer: body
@@ -994,7 +1038,7 @@ texts:
   parent:
     $ref: '#/groups/14'
   prov: []
-  self_ref: '#/texts/48'
+  self_ref: '#/texts/50'
   text: Item 3 in B
 - children: []
   content_layer: body
@@ -1005,7 +1049,7 @@ texts:
   parent:
     $ref: '#/groups/13'
   prov: []
-  self_ref: '#/texts/49'
+  self_ref: '#/texts/51'
   text: Item 4 in A
 - children: []
   content_layer: body
@@ -1014,6 +1058,6 @@ texts:
   parent:
     $ref: '#/body'
   prov: []
-  self_ref: '#/texts/50'
+  self_ref: '#/texts/52'
   text: The end.
 version: 1.4.0

--- a/test/data/doc/constructed_doc.inserted_text.json.gt
+++ b/test/data/doc/constructed_doc.inserted_text.json.gt
@@ -76,7 +76,7 @@
         "$ref": "#/groups/13"
       },
       {
-        "$ref": "#/texts/50"
+        "$ref": "#/texts/52"
       }
     ],
     "content_layer": "body",
@@ -151,13 +151,13 @@
           "$ref": "#/texts/9"
         },
         {
-          "$ref": "#/texts/51"
+          "$ref": "#/texts/53"
         },
         {
           "$ref": "#/texts/10"
         },
         {
-          "$ref": "#/texts/52"
+          "$ref": "#/texts/54"
         },
         {
           "$ref": "#/texts/11"
@@ -328,6 +328,12 @@
         },
         {
           "$ref": "#/texts/40"
+        },
+        {
+          "$ref": "#/texts/41"
+        },
+        {
+          "$ref": "#/texts/42"
         }
       ],
       "content_layer": "body",
@@ -341,16 +347,16 @@
       },
       "children": [
         {
-          "$ref": "#/texts/41"
-        },
-        {
-          "$ref": "#/texts/42"
-        },
-        {
           "$ref": "#/texts/43"
         },
         {
-          "$ref": "#/texts/49"
+          "$ref": "#/texts/44"
+        },
+        {
+          "$ref": "#/texts/45"
+        },
+        {
+          "$ref": "#/texts/51"
         }
       ],
       "content_layer": "body",
@@ -360,17 +366,17 @@
     {
       "self_ref": "#/groups/14",
       "parent": {
-        "$ref": "#/texts/43"
+        "$ref": "#/texts/45"
       },
       "children": [
         {
-          "$ref": "#/texts/44"
+          "$ref": "#/texts/46"
         },
         {
-          "$ref": "#/texts/45"
+          "$ref": "#/texts/47"
         },
         {
-          "$ref": "#/texts/48"
+          "$ref": "#/texts/50"
         }
       ],
       "content_layer": "body",
@@ -380,14 +386,14 @@
     {
       "self_ref": "#/groups/15",
       "parent": {
-        "$ref": "#/texts/45"
+        "$ref": "#/texts/47"
       },
       "children": [
         {
-          "$ref": "#/texts/46"
+          "$ref": "#/texts/48"
         },
         {
-          "$ref": "#/texts/47"
+          "$ref": "#/texts/49"
         }
       ],
       "content_layer": "body",
@@ -743,8 +749,8 @@
       "content_layer": "body",
       "label": "code",
       "prov": [],
-      "orig": "<p>Hello world</p>",
-      "text": "<p>Hello world</p>",
+      "orig": "print(\"Hello world\")",
+      "text": "print(\"Hello world\")",
       "captions": [],
       "references": [],
       "footnotes": [],
@@ -877,7 +883,9 @@
         "bold": true,
         "italic": false,
         "underline": false,
-        "strikethrough": false
+        "strikethrough": false,
+        "subscript": false,
+        "superscript": false
       }
     },
     {
@@ -895,7 +903,9 @@
         "bold": false,
         "italic": true,
         "underline": false,
-        "strikethrough": false
+        "strikethrough": false,
+        "subscript": false,
+        "superscript": false
       }
     },
     {
@@ -913,7 +923,9 @@
         "bold": false,
         "italic": false,
         "underline": true,
-        "strikethrough": false
+        "strikethrough": false,
+        "subscript": false,
+        "superscript": false
       }
     },
     {
@@ -931,11 +943,53 @@
         "bold": false,
         "italic": false,
         "underline": false,
-        "strikethrough": true
+        "strikethrough": true,
+        "subscript": false,
+        "superscript": false
       }
     },
     {
       "self_ref": "#/texts/38",
+      "parent": {
+        "$ref": "#/groups/12"
+      },
+      "children": [],
+      "content_layer": "body",
+      "label": "text",
+      "prov": [],
+      "orig": "subscript",
+      "text": "subscript",
+      "formatting": {
+        "bold": false,
+        "italic": false,
+        "underline": false,
+        "strikethrough": false,
+        "subscript": true,
+        "superscript": false
+      }
+    },
+    {
+      "self_ref": "#/texts/39",
+      "parent": {
+        "$ref": "#/groups/12"
+      },
+      "children": [],
+      "content_layer": "body",
+      "label": "text",
+      "prov": [],
+      "orig": "superscript",
+      "text": "superscript",
+      "formatting": {
+        "bold": false,
+        "italic": false,
+        "underline": false,
+        "strikethrough": false,
+        "subscript": false,
+        "superscript": true
+      }
+    },
+    {
+      "self_ref": "#/texts/40",
       "parent": {
         "$ref": "#/groups/12"
       },
@@ -948,7 +1002,7 @@
       "hyperlink": "."
     },
     {
-      "self_ref": "#/texts/39",
+      "self_ref": "#/texts/41",
       "parent": {
         "$ref": "#/groups/12"
       },
@@ -960,7 +1014,7 @@
       "text": "&"
     },
     {
-      "self_ref": "#/texts/40",
+      "self_ref": "#/texts/42",
       "parent": {
         "$ref": "#/groups/12"
       },
@@ -974,12 +1028,14 @@
         "bold": true,
         "italic": true,
         "underline": true,
-        "strikethrough": true
+        "strikethrough": true,
+        "subscript": false,
+        "superscript": false
       },
       "hyperlink": "https://github.com/DS4SD/docling"
     },
     {
-      "self_ref": "#/texts/41",
+      "self_ref": "#/texts/43",
       "parent": {
         "$ref": "#/groups/13"
       },
@@ -993,7 +1049,7 @@
       "marker": "-"
     },
     {
-      "self_ref": "#/texts/42",
+      "self_ref": "#/texts/44",
       "parent": {
         "$ref": "#/groups/13"
       },
@@ -1007,7 +1063,7 @@
       "marker": "-"
     },
     {
-      "self_ref": "#/texts/43",
+      "self_ref": "#/texts/45",
       "parent": {
         "$ref": "#/groups/13"
       },
@@ -1025,7 +1081,7 @@
       "marker": "-"
     },
     {
-      "self_ref": "#/texts/44",
+      "self_ref": "#/texts/46",
       "parent": {
         "$ref": "#/groups/14"
       },
@@ -1039,7 +1095,7 @@
       "marker": "-"
     },
     {
-      "self_ref": "#/texts/45",
+      "self_ref": "#/texts/47",
       "parent": {
         "$ref": "#/groups/14"
       },
@@ -1057,7 +1113,7 @@
       "marker": "-"
     },
     {
-      "self_ref": "#/texts/46",
+      "self_ref": "#/texts/48",
       "parent": {
         "$ref": "#/groups/15"
       },
@@ -1071,7 +1127,7 @@
       "marker": "-"
     },
     {
-      "self_ref": "#/texts/47",
+      "self_ref": "#/texts/49",
       "parent": {
         "$ref": "#/groups/15"
       },
@@ -1085,7 +1141,7 @@
       "marker": "-"
     },
     {
-      "self_ref": "#/texts/48",
+      "self_ref": "#/texts/50",
       "parent": {
         "$ref": "#/groups/14"
       },
@@ -1099,7 +1155,7 @@
       "marker": "-"
     },
     {
-      "self_ref": "#/texts/49",
+      "self_ref": "#/texts/51",
       "parent": {
         "$ref": "#/groups/13"
       },
@@ -1113,7 +1169,7 @@
       "marker": "-"
     },
     {
-      "self_ref": "#/texts/50",
+      "self_ref": "#/texts/52",
       "parent": {
         "$ref": "#/body"
       },
@@ -1125,7 +1181,7 @@
       "text": "The end."
     },
     {
-      "self_ref": "#/texts/51",
+      "self_ref": "#/texts/53",
       "parent": {
         "$ref": "#/groups/3"
       },
@@ -1139,7 +1195,7 @@
       "marker": "-"
     },
     {
-      "self_ref": "#/texts/52",
+      "self_ref": "#/texts/54",
       "parent": {
         "$ref": "#/groups/3"
       },

--- a/test/data/doc/constructed_doc.placeholder.html.gt
+++ b/test/data/doc/constructed_doc.placeholder.html.gt
@@ -161,7 +161,7 @@
 <li>item 2 of neighboring list</li>
 <ul>
 <li>item 1 of sub list</li>
-<li><span class='inline-group'>Here a code snippet: <code><p>Hello world</p></code> (to be displayed inline)</span></li>
+<li><span class='inline-group'>Here a code snippet: <code>print("Hello world")</code> (to be displayed inline)</span></li>
 <li><span class='inline-group'>Here a formula: <math xmlns="http://www.w3.org/1998/Math/MathML" display="inline"><mrow><mi>E</mi><mo>&#x0003D;</mo><mi>m</mi><msup><mi>c</mi><mn>2</mn></msup></mrow><annotation encoding="TeX">E=mc^2</annotation></math> (to be displayed inline)</span></li>
 </ul>
 </ul>
@@ -181,7 +181,7 @@
 
 </ul>
 </div>
-<span class='inline-group'>Some formatting chops: <strong>bold</strong> <em>italic</em> <u>underline</u> <del>strikethrough</del> <a href=".">hyperlink</a> &amp; <a href="https://github.com/DS4SD/docling"><del><u><em><strong>everything at the same time.</strong></em></u></del></a></span>
+<span class='inline-group'>Some formatting chops: <strong>bold</strong> <em>italic</em> <u>underline</u> <del>strikethrough</del> <sub>subscript</sub> <sup>superscript</sup> <a href=".">hyperlink</a> &amp; <a href="https://github.com/DS4SD/docling"><del><u><em><strong>everything at the same time.</strong></em></u></del></a></span>
 <ol>
 <li>Item 1 in A</li>
 <li>Item 2 in A</li>

--- a/test/data/doc/constructed_doc.placeholder.md.gt
+++ b/test/data/doc/constructed_doc.placeholder.md.gt
@@ -44,7 +44,7 @@ This is the caption of figure 2.
 - item 1 of neighboring list
 - item 2 of neighboring list
     - item 1 of sub list
-    - Here a code snippet: `<p>Hello world</p>` (to be displayed inline)
+    - Here a code snippet: `print("Hello world")` (to be displayed inline)
     - Here a formula: $E=mc^2$ (to be displayed inline)
 
 Here a code block:
@@ -61,7 +61,7 @@ $$E=mc^2$$
 
 <!-- missing-form-item -->
 
-Some formatting chops: **bold** *italic* underline ~~strikethrough~~ [hyperlink](.) &amp; [~~***everything at the same time.***~~](https://github.com/DS4SD/docling)
+Some formatting chops: **bold** *italic* underline ~~strikethrough~~ subscript superscript [hyperlink](.) &amp; [~~***everything at the same time.***~~](https://github.com/DS4SD/docling)
 
 1. Item 1 in A
 2. Item 2 in A

--- a/test/data/doc/constructed_doc.referenced.html.gt
+++ b/test/data/doc/constructed_doc.referenced.html.gt
@@ -161,7 +161,7 @@
 <li>item 2 of neighboring list</li>
 <ul>
 <li>item 1 of sub list</li>
-<li><span class='inline-group'>Here a code snippet: <code><p>Hello world</p></code> (to be displayed inline)</span></li>
+<li><span class='inline-group'>Here a code snippet: <code>print("Hello world")</code> (to be displayed inline)</span></li>
 <li><span class='inline-group'>Here a formula: <math xmlns="http://www.w3.org/1998/Math/MathML" display="inline"><mrow><mi>E</mi><mo>&#x0003D;</mo><mi>m</mi><msup><mi>c</mi><mn>2</mn></msup></mrow><annotation encoding="TeX">E=mc^2</annotation></math> (to be displayed inline)</span></li>
 </ul>
 </ul>
@@ -181,7 +181,7 @@
 
 </ul>
 </div>
-<span class='inline-group'>Some formatting chops: <strong>bold</strong> <em>italic</em> <u>underline</u> <del>strikethrough</del> <a href=".">hyperlink</a> &amp; <a href="https://github.com/DS4SD/docling"><del><u><em><strong>everything at the same time.</strong></em></u></del></a></span>
+<span class='inline-group'>Some formatting chops: <strong>bold</strong> <em>italic</em> <u>underline</u> <del>strikethrough</del> <sub>subscript</sub> <sup>superscript</sup> <a href=".">hyperlink</a> &amp; <a href="https://github.com/DS4SD/docling"><del><u><em><strong>everything at the same time.</strong></em></u></del></a></span>
 <ol>
 <li>Item 1 in A</li>
 <li>Item 2 in A</li>

--- a/test/data/doc/constructed_doc.referenced.json.gt
+++ b/test/data/doc/constructed_doc.referenced.json.gt
@@ -76,7 +76,7 @@
         "$ref": "#/groups/13"
       },
       {
-        "$ref": "#/texts/50"
+        "$ref": "#/texts/52"
       }
     ],
     "content_layer": "body",
@@ -322,6 +322,12 @@
         },
         {
           "$ref": "#/texts/40"
+        },
+        {
+          "$ref": "#/texts/41"
+        },
+        {
+          "$ref": "#/texts/42"
         }
       ],
       "content_layer": "body",
@@ -335,16 +341,16 @@
       },
       "children": [
         {
-          "$ref": "#/texts/41"
-        },
-        {
-          "$ref": "#/texts/42"
-        },
-        {
           "$ref": "#/texts/43"
         },
         {
-          "$ref": "#/texts/49"
+          "$ref": "#/texts/44"
+        },
+        {
+          "$ref": "#/texts/45"
+        },
+        {
+          "$ref": "#/texts/51"
         }
       ],
       "content_layer": "body",
@@ -354,17 +360,17 @@
     {
       "self_ref": "#/groups/14",
       "parent": {
-        "$ref": "#/texts/43"
+        "$ref": "#/texts/45"
       },
       "children": [
         {
-          "$ref": "#/texts/44"
+          "$ref": "#/texts/46"
         },
         {
-          "$ref": "#/texts/45"
+          "$ref": "#/texts/47"
         },
         {
-          "$ref": "#/texts/48"
+          "$ref": "#/texts/50"
         }
       ],
       "content_layer": "body",
@@ -374,14 +380,14 @@
     {
       "self_ref": "#/groups/15",
       "parent": {
-        "$ref": "#/texts/45"
+        "$ref": "#/texts/47"
       },
       "children": [
         {
-          "$ref": "#/texts/46"
+          "$ref": "#/texts/48"
         },
         {
-          "$ref": "#/texts/47"
+          "$ref": "#/texts/49"
         }
       ],
       "content_layer": "body",
@@ -737,8 +743,8 @@
       "content_layer": "body",
       "label": "code",
       "prov": [],
-      "orig": "<p>Hello world</p>",
-      "text": "<p>Hello world</p>",
+      "orig": "print(\"Hello world\")",
+      "text": "print(\"Hello world\")",
       "captions": [],
       "references": [],
       "footnotes": [],
@@ -871,7 +877,9 @@
         "bold": true,
         "italic": false,
         "underline": false,
-        "strikethrough": false
+        "strikethrough": false,
+        "subscript": false,
+        "superscript": false
       }
     },
     {
@@ -889,7 +897,9 @@
         "bold": false,
         "italic": true,
         "underline": false,
-        "strikethrough": false
+        "strikethrough": false,
+        "subscript": false,
+        "superscript": false
       }
     },
     {
@@ -907,7 +917,9 @@
         "bold": false,
         "italic": false,
         "underline": true,
-        "strikethrough": false
+        "strikethrough": false,
+        "subscript": false,
+        "superscript": false
       }
     },
     {
@@ -925,11 +937,53 @@
         "bold": false,
         "italic": false,
         "underline": false,
-        "strikethrough": true
+        "strikethrough": true,
+        "subscript": false,
+        "superscript": false
       }
     },
     {
       "self_ref": "#/texts/38",
+      "parent": {
+        "$ref": "#/groups/12"
+      },
+      "children": [],
+      "content_layer": "body",
+      "label": "text",
+      "prov": [],
+      "orig": "subscript",
+      "text": "subscript",
+      "formatting": {
+        "bold": false,
+        "italic": false,
+        "underline": false,
+        "strikethrough": false,
+        "subscript": true,
+        "superscript": false
+      }
+    },
+    {
+      "self_ref": "#/texts/39",
+      "parent": {
+        "$ref": "#/groups/12"
+      },
+      "children": [],
+      "content_layer": "body",
+      "label": "text",
+      "prov": [],
+      "orig": "superscript",
+      "text": "superscript",
+      "formatting": {
+        "bold": false,
+        "italic": false,
+        "underline": false,
+        "strikethrough": false,
+        "subscript": false,
+        "superscript": true
+      }
+    },
+    {
+      "self_ref": "#/texts/40",
       "parent": {
         "$ref": "#/groups/12"
       },
@@ -942,7 +996,7 @@
       "hyperlink": "."
     },
     {
-      "self_ref": "#/texts/39",
+      "self_ref": "#/texts/41",
       "parent": {
         "$ref": "#/groups/12"
       },
@@ -954,7 +1008,7 @@
       "text": "&"
     },
     {
-      "self_ref": "#/texts/40",
+      "self_ref": "#/texts/42",
       "parent": {
         "$ref": "#/groups/12"
       },
@@ -968,12 +1022,14 @@
         "bold": true,
         "italic": true,
         "underline": true,
-        "strikethrough": true
+        "strikethrough": true,
+        "subscript": false,
+        "superscript": false
       },
       "hyperlink": "https://github.com/DS4SD/docling"
     },
     {
-      "self_ref": "#/texts/41",
+      "self_ref": "#/texts/43",
       "parent": {
         "$ref": "#/groups/13"
       },
@@ -987,7 +1043,7 @@
       "marker": "-"
     },
     {
-      "self_ref": "#/texts/42",
+      "self_ref": "#/texts/44",
       "parent": {
         "$ref": "#/groups/13"
       },
@@ -1001,7 +1057,7 @@
       "marker": "-"
     },
     {
-      "self_ref": "#/texts/43",
+      "self_ref": "#/texts/45",
       "parent": {
         "$ref": "#/groups/13"
       },
@@ -1019,7 +1075,7 @@
       "marker": "-"
     },
     {
-      "self_ref": "#/texts/44",
+      "self_ref": "#/texts/46",
       "parent": {
         "$ref": "#/groups/14"
       },
@@ -1033,7 +1089,7 @@
       "marker": "-"
     },
     {
-      "self_ref": "#/texts/45",
+      "self_ref": "#/texts/47",
       "parent": {
         "$ref": "#/groups/14"
       },
@@ -1051,7 +1107,7 @@
       "marker": "-"
     },
     {
-      "self_ref": "#/texts/46",
+      "self_ref": "#/texts/48",
       "parent": {
         "$ref": "#/groups/15"
       },
@@ -1065,7 +1121,7 @@
       "marker": "-"
     },
     {
-      "self_ref": "#/texts/47",
+      "self_ref": "#/texts/49",
       "parent": {
         "$ref": "#/groups/15"
       },
@@ -1079,7 +1135,7 @@
       "marker": "-"
     },
     {
-      "self_ref": "#/texts/48",
+      "self_ref": "#/texts/50",
       "parent": {
         "$ref": "#/groups/14"
       },
@@ -1093,7 +1149,7 @@
       "marker": "-"
     },
     {
-      "self_ref": "#/texts/49",
+      "self_ref": "#/texts/51",
       "parent": {
         "$ref": "#/groups/13"
       },
@@ -1107,7 +1163,7 @@
       "marker": "-"
     },
     {
-      "self_ref": "#/texts/50",
+      "self_ref": "#/texts/52",
       "parent": {
         "$ref": "#/body"
       },

--- a/test/data/doc/constructed_doc.referenced.md.gt
+++ b/test/data/doc/constructed_doc.referenced.md.gt
@@ -44,7 +44,7 @@ This is the caption of figure 2.
 - item 1 of neighboring list
 - item 2 of neighboring list
     - item 1 of sub list
-    - Here a code snippet: `<p>Hello world</p>` (to be displayed inline)
+    - Here a code snippet: `print("Hello world")` (to be displayed inline)
     - Here a formula: $E=mc^2$ (to be displayed inline)
 
 Here a code block:
@@ -61,7 +61,7 @@ $$E=mc^2$$
 
 <!-- missing-form-item -->
 
-Some formatting chops: **bold** *italic* underline ~~strikethrough~~ [hyperlink](.) &amp; [~~***everything at the same time.***~~](https://github.com/DS4SD/docling)
+Some formatting chops: **bold** *italic* underline ~~strikethrough~~ subscript superscript [hyperlink](.) &amp; [~~***everything at the same time.***~~](https://github.com/DS4SD/docling)
 
 1. Item 1 in A
 2. Item 2 in A

--- a/test/data/doc/constructed_doc.referenced.yaml.gt
+++ b/test/data/doc/constructed_doc.referenced.yaml.gt
@@ -21,7 +21,7 @@ body:
   - $ref: '#/form_items/0'
   - $ref: '#/groups/12'
   - $ref: '#/groups/13'
-  - $ref: '#/texts/50'
+  - $ref: '#/texts/52'
   content_layer: body
   label: unspecified
   name: _root_
@@ -180,6 +180,8 @@ groups:
   - $ref: '#/texts/38'
   - $ref: '#/texts/39'
   - $ref: '#/texts/40'
+  - $ref: '#/texts/41'
+  - $ref: '#/texts/42'
   content_layer: body
   label: inline
   name: group
@@ -187,10 +189,10 @@ groups:
     $ref: '#/body'
   self_ref: '#/groups/12'
 - children:
-  - $ref: '#/texts/41'
-  - $ref: '#/texts/42'
   - $ref: '#/texts/43'
-  - $ref: '#/texts/49'
+  - $ref: '#/texts/44'
+  - $ref: '#/texts/45'
+  - $ref: '#/texts/51'
   content_layer: body
   label: ordered_list
   name: list A
@@ -198,23 +200,23 @@ groups:
     $ref: '#/body'
   self_ref: '#/groups/13'
 - children:
-  - $ref: '#/texts/44'
-  - $ref: '#/texts/45'
-  - $ref: '#/texts/48'
+  - $ref: '#/texts/46'
+  - $ref: '#/texts/47'
+  - $ref: '#/texts/50'
   content_layer: body
   label: ordered_list
   name: list B
   parent:
-    $ref: '#/texts/43'
+    $ref: '#/texts/45'
   self_ref: '#/groups/14'
 - children:
-  - $ref: '#/texts/46'
-  - $ref: '#/texts/47'
+  - $ref: '#/texts/48'
+  - $ref: '#/texts/49'
   content_layer: body
   label: ordered_list
   name: list C
   parent:
-    $ref: '#/texts/45'
+    $ref: '#/texts/47'
   self_ref: '#/groups/15'
 key_value_items:
 - captions: []
@@ -724,13 +726,13 @@ texts:
   content_layer: body
   footnotes: []
   label: code
-  orig: <p>Hello world</p>
+  orig: print("Hello world")
   parent:
     $ref: '#/groups/10'
   prov: []
   references: []
   self_ref: '#/texts/24'
-  text: <p>Hello world</p>
+  text: print("Hello world")
 - children: []
   content_layer: body
   label: text
@@ -822,6 +824,8 @@ texts:
     bold: true
     italic: false
     strikethrough: false
+    subscript: false
+    superscript: false
     underline: false
   label: text
   orig: bold
@@ -836,6 +840,8 @@ texts:
     bold: false
     italic: true
     strikethrough: false
+    subscript: false
+    superscript: false
     underline: false
   label: text
   orig: italic
@@ -850,6 +856,8 @@ texts:
     bold: false
     italic: false
     strikethrough: false
+    subscript: false
+    superscript: false
     underline: true
   label: text
   orig: underline
@@ -864,6 +872,8 @@ texts:
     bold: false
     italic: false
     strikethrough: true
+    subscript: false
+    superscript: false
     underline: false
   label: text
   orig: strikethrough
@@ -874,13 +884,45 @@ texts:
   text: strikethrough
 - children: []
   content_layer: body
+  formatting:
+    bold: false
+    italic: false
+    strikethrough: false
+    subscript: true
+    superscript: false
+    underline: false
+  label: text
+  orig: subscript
+  parent:
+    $ref: '#/groups/12'
+  prov: []
+  self_ref: '#/texts/38'
+  text: subscript
+- children: []
+  content_layer: body
+  formatting:
+    bold: false
+    italic: false
+    strikethrough: false
+    subscript: false
+    superscript: true
+    underline: false
+  label: text
+  orig: superscript
+  parent:
+    $ref: '#/groups/12'
+  prov: []
+  self_ref: '#/texts/39'
+  text: superscript
+- children: []
+  content_layer: body
   hyperlink: .
   label: text
   orig: hyperlink
   parent:
     $ref: '#/groups/12'
   prov: []
-  self_ref: '#/texts/38'
+  self_ref: '#/texts/40'
   text: hyperlink
 - children: []
   content_layer: body
@@ -889,7 +931,7 @@ texts:
   parent:
     $ref: '#/groups/12'
   prov: []
-  self_ref: '#/texts/39'
+  self_ref: '#/texts/41'
   text: '&'
 - children: []
   content_layer: body
@@ -897,6 +939,8 @@ texts:
     bold: true
     italic: true
     strikethrough: true
+    subscript: false
+    superscript: false
     underline: true
   hyperlink: https://github.com/DS4SD/docling
   label: text
@@ -904,7 +948,7 @@ texts:
   parent:
     $ref: '#/groups/12'
   prov: []
-  self_ref: '#/texts/40'
+  self_ref: '#/texts/42'
   text: everything at the same time.
 - children: []
   content_layer: body
@@ -915,7 +959,7 @@ texts:
   parent:
     $ref: '#/groups/13'
   prov: []
-  self_ref: '#/texts/41'
+  self_ref: '#/texts/43'
   text: Item 1 in A
 - children: []
   content_layer: body
@@ -926,7 +970,7 @@ texts:
   parent:
     $ref: '#/groups/13'
   prov: []
-  self_ref: '#/texts/42'
+  self_ref: '#/texts/44'
   text: Item 2 in A
 - children:
   - $ref: '#/groups/14'
@@ -938,7 +982,7 @@ texts:
   parent:
     $ref: '#/groups/13'
   prov: []
-  self_ref: '#/texts/43'
+  self_ref: '#/texts/45'
   text: Item 3 in A
 - children: []
   content_layer: body
@@ -949,7 +993,7 @@ texts:
   parent:
     $ref: '#/groups/14'
   prov: []
-  self_ref: '#/texts/44'
+  self_ref: '#/texts/46'
   text: Item 1 in B
 - children:
   - $ref: '#/groups/15'
@@ -961,7 +1005,7 @@ texts:
   parent:
     $ref: '#/groups/14'
   prov: []
-  self_ref: '#/texts/45'
+  self_ref: '#/texts/47'
   text: Item 2 in B
 - children: []
   content_layer: body
@@ -972,7 +1016,7 @@ texts:
   parent:
     $ref: '#/groups/15'
   prov: []
-  self_ref: '#/texts/46'
+  self_ref: '#/texts/48'
   text: Item 1 in C
 - children: []
   content_layer: body
@@ -983,7 +1027,7 @@ texts:
   parent:
     $ref: '#/groups/15'
   prov: []
-  self_ref: '#/texts/47'
+  self_ref: '#/texts/49'
   text: Item 2 in C
 - children: []
   content_layer: body
@@ -994,7 +1038,7 @@ texts:
   parent:
     $ref: '#/groups/14'
   prov: []
-  self_ref: '#/texts/48'
+  self_ref: '#/texts/50'
   text: Item 3 in B
 - children: []
   content_layer: body
@@ -1005,7 +1049,7 @@ texts:
   parent:
     $ref: '#/groups/13'
   prov: []
-  self_ref: '#/texts/49'
+  self_ref: '#/texts/51'
   text: Item 4 in A
 - children: []
   content_layer: body
@@ -1014,6 +1058,6 @@ texts:
   parent:
     $ref: '#/body'
   prov: []
-  self_ref: '#/texts/50'
+  self_ref: '#/texts/52'
   text: The end.
 version: 1.4.0

--- a/test/data/doc/constructed_doc.replaced_item.json.gt
+++ b/test/data/doc/constructed_doc.replaced_item.json.gt
@@ -70,10 +70,10 @@
         "$ref": "#/groups/9"
       },
       {
-        "$ref": "#/texts/40"
+        "$ref": "#/texts/42"
       },
       {
-        "$ref": "#/texts/42"
+        "$ref": "#/texts/44"
       }
     ],
     "content_layer": "body",
@@ -242,6 +242,12 @@
         },
         {
           "$ref": "#/texts/30"
+        },
+        {
+          "$ref": "#/texts/31"
+        },
+        {
+          "$ref": "#/texts/32"
         }
       ],
       "content_layer": "body",
@@ -255,16 +261,16 @@
       },
       "children": [
         {
-          "$ref": "#/texts/31"
-        },
-        {
-          "$ref": "#/texts/32"
-        },
-        {
           "$ref": "#/texts/33"
         },
         {
-          "$ref": "#/texts/39"
+          "$ref": "#/texts/34"
+        },
+        {
+          "$ref": "#/texts/35"
+        },
+        {
+          "$ref": "#/texts/41"
         }
       ],
       "content_layer": "body",
@@ -273,26 +279,6 @@
     },
     {
       "self_ref": "#/groups/10",
-      "parent": {
-        "$ref": "#/texts/33"
-      },
-      "children": [
-        {
-          "$ref": "#/texts/34"
-        },
-        {
-          "$ref": "#/texts/35"
-        },
-        {
-          "$ref": "#/texts/38"
-        }
-      ],
-      "content_layer": "body",
-      "name": "list B",
-      "label": "ordered_list"
-    },
-    {
-      "self_ref": "#/groups/11",
       "parent": {
         "$ref": "#/texts/35"
       },
@@ -304,7 +290,27 @@
           "$ref": "#/texts/37"
         },
         {
-          "$ref": "#/texts/41"
+          "$ref": "#/texts/40"
+        }
+      ],
+      "content_layer": "body",
+      "name": "list B",
+      "label": "ordered_list"
+    },
+    {
+      "self_ref": "#/groups/11",
+      "parent": {
+        "$ref": "#/texts/37"
+      },
+      "children": [
+        {
+          "$ref": "#/texts/38"
+        },
+        {
+          "$ref": "#/texts/39"
+        },
+        {
+          "$ref": "#/texts/43"
         }
       ],
       "content_layer": "body",
@@ -515,8 +521,8 @@
       "content_layer": "body",
       "label": "code",
       "prov": [],
-      "orig": "<p>Hello world</p>",
-      "text": "<p>Hello world</p>",
+      "orig": "print(\"Hello world\")",
+      "text": "print(\"Hello world\")",
       "captions": [],
       "references": [],
       "footnotes": [],
@@ -649,7 +655,9 @@
         "bold": true,
         "italic": false,
         "underline": false,
-        "strikethrough": false
+        "strikethrough": false,
+        "subscript": false,
+        "superscript": false
       }
     },
     {
@@ -667,7 +675,9 @@
         "bold": false,
         "italic": true,
         "underline": false,
-        "strikethrough": false
+        "strikethrough": false,
+        "subscript": false,
+        "superscript": false
       }
     },
     {
@@ -685,7 +695,9 @@
         "bold": false,
         "italic": false,
         "underline": true,
-        "strikethrough": false
+        "strikethrough": false,
+        "subscript": false,
+        "superscript": false
       }
     },
     {
@@ -703,11 +715,53 @@
         "bold": false,
         "italic": false,
         "underline": false,
-        "strikethrough": true
+        "strikethrough": true,
+        "subscript": false,
+        "superscript": false
       }
     },
     {
       "self_ref": "#/texts/28",
+      "parent": {
+        "$ref": "#/groups/8"
+      },
+      "children": [],
+      "content_layer": "body",
+      "label": "text",
+      "prov": [],
+      "orig": "subscript",
+      "text": "subscript",
+      "formatting": {
+        "bold": false,
+        "italic": false,
+        "underline": false,
+        "strikethrough": false,
+        "subscript": true,
+        "superscript": false
+      }
+    },
+    {
+      "self_ref": "#/texts/29",
+      "parent": {
+        "$ref": "#/groups/8"
+      },
+      "children": [],
+      "content_layer": "body",
+      "label": "text",
+      "prov": [],
+      "orig": "superscript",
+      "text": "superscript",
+      "formatting": {
+        "bold": false,
+        "italic": false,
+        "underline": false,
+        "strikethrough": false,
+        "subscript": false,
+        "superscript": true
+      }
+    },
+    {
+      "self_ref": "#/texts/30",
       "parent": {
         "$ref": "#/groups/8"
       },
@@ -720,7 +774,7 @@
       "hyperlink": "."
     },
     {
-      "self_ref": "#/texts/29",
+      "self_ref": "#/texts/31",
       "parent": {
         "$ref": "#/groups/8"
       },
@@ -732,7 +786,7 @@
       "text": "&"
     },
     {
-      "self_ref": "#/texts/30",
+      "self_ref": "#/texts/32",
       "parent": {
         "$ref": "#/groups/8"
       },
@@ -746,12 +800,14 @@
         "bold": true,
         "italic": true,
         "underline": true,
-        "strikethrough": true
+        "strikethrough": true,
+        "subscript": false,
+        "superscript": false
       },
       "hyperlink": "https://github.com/DS4SD/docling"
     },
     {
-      "self_ref": "#/texts/31",
+      "self_ref": "#/texts/33",
       "parent": {
         "$ref": "#/groups/9"
       },
@@ -765,7 +821,7 @@
       "marker": "-"
     },
     {
-      "self_ref": "#/texts/32",
+      "self_ref": "#/texts/34",
       "parent": {
         "$ref": "#/groups/9"
       },
@@ -779,7 +835,7 @@
       "marker": "-"
     },
     {
-      "self_ref": "#/texts/33",
+      "self_ref": "#/texts/35",
       "parent": {
         "$ref": "#/groups/9"
       },
@@ -797,7 +853,7 @@
       "marker": "-"
     },
     {
-      "self_ref": "#/texts/34",
+      "self_ref": "#/texts/36",
       "parent": {
         "$ref": "#/groups/10"
       },
@@ -811,7 +867,7 @@
       "marker": "-"
     },
     {
-      "self_ref": "#/texts/35",
+      "self_ref": "#/texts/37",
       "parent": {
         "$ref": "#/groups/10"
       },
@@ -829,7 +885,7 @@
       "marker": "-"
     },
     {
-      "self_ref": "#/texts/36",
+      "self_ref": "#/texts/38",
       "parent": {
         "$ref": "#/groups/11"
       },
@@ -843,7 +899,7 @@
       "marker": "-"
     },
     {
-      "self_ref": "#/texts/37",
+      "self_ref": "#/texts/39",
       "parent": {
         "$ref": "#/groups/11"
       },
@@ -857,7 +913,7 @@
       "marker": "-"
     },
     {
-      "self_ref": "#/texts/38",
+      "self_ref": "#/texts/40",
       "parent": {
         "$ref": "#/groups/10"
       },
@@ -871,7 +927,7 @@
       "marker": "-"
     },
     {
-      "self_ref": "#/texts/39",
+      "self_ref": "#/texts/41",
       "parent": {
         "$ref": "#/groups/9"
       },
@@ -885,7 +941,7 @@
       "marker": "-"
     },
     {
-      "self_ref": "#/texts/40",
+      "self_ref": "#/texts/42",
       "parent": {
         "$ref": "#/body"
       },
@@ -897,7 +953,7 @@
       "text": "The end."
     },
     {
-      "self_ref": "#/texts/41",
+      "self_ref": "#/texts/43",
       "parent": {
         "$ref": "#/groups/11"
       },
@@ -911,7 +967,7 @@
       "marker": "-"
     },
     {
-      "self_ref": "#/texts/42",
+      "self_ref": "#/texts/44",
       "parent": {
         "$ref": "#/body"
       },

--- a/test/data/doc/constructed_document.yaml.dt
+++ b/test/data/doc/constructed_document.yaml.dt
@@ -30,7 +30,7 @@ Affiliation 2</text>
 <list_item>item 2 of neighboring list</list_item>
 <list_item><unordered_list><list_item>item 1 of sub list</list_item>
 <list_item><inline><text>Here a code snippet:</text>
-<code><_unknown_><p>Hello world</p></code>
+<code><_unknown_>print("Hello world")</code>
 <text>(to be displayed inline)</text>
 </inline></list_item>
 <list_item><inline><text>Here a formula:</text>
@@ -49,6 +49,8 @@ Affiliation 2</text>
 <text>italic</text>
 <text>underline</text>
 <text>strikethrough</text>
+<text>subscript</text>
+<text>superscript</text>
 <text>hyperlink</text>
 <text>&</text>
 <text>everything at the same time.</text>

--- a/test/data/doc/constructed_document.yaml.et
+++ b/test/data/doc/constructed_document.yaml.et
@@ -58,16 +58,18 @@
   57: text
   58: text
   59: text
- 60: ordered_list with name=list A
-  61: list_item
-  62: list_item
+  60: text
+  61: text
+ 62: ordered_list with name=list A
   63: list_item
-   64: ordered_list with name=list B
-    65: list_item
-    66: list_item
-     67: ordered_list with name=list C
-      68: list_item
-      69: list_item
-    70: list_item
-  71: list_item
- 72: text
+  64: list_item
+  65: list_item
+   66: ordered_list with name=list B
+    67: list_item
+    68: list_item
+     69: ordered_list with name=list C
+      70: list_item
+      71: list_item
+    72: list_item
+  73: list_item
+ 74: text

--- a/test/data/doc/constructed_document.yaml.html
+++ b/test/data/doc/constructed_document.yaml.html
@@ -161,7 +161,7 @@
 <li>item 2 of neighboring list</li>
 <ul>
 <li>item 1 of sub list</li>
-<li><span class='inline-group'>Here a code snippet: <code><p>Hello world</p></code> (to be displayed inline)</span></li>
+<li><span class='inline-group'>Here a code snippet: <code>print("Hello world")</code> (to be displayed inline)</span></li>
 <li><span class='inline-group'>Here a formula: <math xmlns="http://www.w3.org/1998/Math/MathML" display="inline"><mrow><mi>E</mi><mo>&#x0003D;</mo><mi>m</mi><msup><mi>c</mi><mn>2</mn></msup></mrow><annotation encoding="TeX">E=mc^2</annotation></math> (to be displayed inline)</span></li>
 </ul>
 </ul>
@@ -181,7 +181,7 @@
 
 </ul>
 </div>
-<span class='inline-group'>Some formatting chops: <strong>bold</strong> <em>italic</em> <u>underline</u> <del>strikethrough</del> <a href=".">hyperlink</a> &amp; <a href="https://github.com/DS4SD/docling"><del><u><em><strong>everything at the same time.</strong></em></u></del></a></span>
+<span class='inline-group'>Some formatting chops: <strong>bold</strong> <em>italic</em> <u>underline</u> <del>strikethrough</del> <sub>subscript</sub> <sup>superscript</sup> <a href=".">hyperlink</a> &amp; <a href="https://github.com/DS4SD/docling"><del><u><em><strong>everything at the same time.</strong></em></u></del></a></span>
 <ol>
 <li>Item 1 in A</li>
 <li>Item 2 in A</li>

--- a/test/data/doc/constructed_document.yaml.md
+++ b/test/data/doc/constructed_document.yaml.md
@@ -44,7 +44,7 @@ This is the caption of figure 2.
 - item 1 of neighboring list
 - item 2 of neighboring list
     - item 1 of sub list
-    - Here a code snippet: `<p>Hello world</p>` (to be displayed inline)
+    - Here a code snippet: `print("Hello world")` (to be displayed inline)
     - Here a formula: $E=mc^2$ (to be displayed inline)
 
 Here a code block:
@@ -61,7 +61,7 @@ $$E=mc^2$$
 
 <!-- missing-form-item -->
 
-Some formatting chops: **bold** *italic* underline ~~strikethrough~~ [hyperlink](.) &amp; [~~***everything at the same time.***~~](https://github.com/DS4SD/docling)
+Some formatting chops: **bold** *italic* underline ~~strikethrough~~ subscript superscript [hyperlink](.) &amp; [~~***everything at the same time.***~~](https://github.com/DS4SD/docling)
 
 1. Item 1 in A
 2. Item 2 in A

--- a/test/test_docling_doc.py
+++ b/test/test_docling_doc.py
@@ -942,7 +942,7 @@ def _construct_doc() -> DoclingDocument:
         text="Here a code snippet:",
         parent=inline1,
     )
-    doc.add_code(text="<p>Hello world</p>", parent=inline1)
+    doc.add_code(text='print("Hello world")', parent=inline1)
     doc.add_text(
         label=DocItemLabel.TEXT, text="(to be displayed inline)", parent=inline1
     )
@@ -1020,6 +1020,18 @@ def _construct_doc() -> DoclingDocument:
         text="strikethrough",
         parent=inline_fmt,
         formatting=Formatting(strikethrough=True),
+    )
+    doc.add_text(
+        label=DocItemLabel.TEXT,
+        text="subscript",
+        parent=inline_fmt,
+        formatting=Formatting(subscript=True),
+    )
+    doc.add_text(
+        label=DocItemLabel.TEXT,
+        text="superscript",
+        parent=inline_fmt,
+        formatting=Formatting(superscript=True),
     )
     doc.add_text(
         label=DocItemLabel.TEXT,


### PR DESCRIPTION
Added subscript & superscript support, for now only leveraged in HTML (the Markdown syntax seems to be ["uncommon"](https://www.markdownguide.org/extended-syntax/#subscript) & won't render e.g. on VS Code).