### PR TITLE
fix: add missing mimetypes for asr inputs

### DIFF
--- a/docling_core/types/doc/document.py
+++ b/docling_core/types/doc/document.py
@@ -540,6 +540,9 @@ class DocumentOrigin(BaseModel):
         "text/asciidoc",
         "text/markdown",
         "text/csv",
+        "audio/x-wav",
+        "audio/wav",
+        "audio/mp3",
     ]
 
     @field_validator("binary_hash", mode="before")


### PR DESCRIPTION
Resolves https://github.com/docling-project/docling/issues/1848