### PR TITLE
fix: BoundingRectangle angle computation when in `CoordOrigin.TOPLEFT`

### DIFF
--- a/docling_core/types/doc/page.py
+++ b/docling_core/types/doc/page.py
@@ -122,6 +122,8 @@ class BoundingRectangle(BaseModel):
         p_1 = ((self.r_x1 + self.r_x2) / 2.0, (self.r_y1 + self.r_y2) / 2.0)
 
         delta_x, delta_y = p_1[0] - p_0[0], p_1[1] - p_0[1]
+        if self.coord_origin == CoordOrigin.TOPLEFT:
+            delta_y = -delta_y
 
         if abs(delta_y) < 1.0e-3:
             angle = 0.0
@@ -131,8 +133,7 @@ class BoundingRectangle(BaseModel):
             angle = math.atan(delta_y / delta_x)
         if delta_x < 0:
             angle += np.pi
-        if angle < 0:
-            angle += 2 * np.pi
+        angle = angle % (2 * np.pi)
         return angle
 
     @property

--- a/test/test_page.py
+++ b/test/test_page.py
@@ -3,12 +3,34 @@ import math
 import numpy as np
 import pytest
 
+from docling_core.types.doc import CoordOrigin
 from docling_core.types.doc.page import BoundingRectangle
 
 SQRT_2 = math.sqrt(2)
 
-R_0 = BoundingRectangle(r_x0=0, r_y0=0, r_x1=1, r_y1=0, r_x2=1, r_y2=1, r_x3=0, r_y3=1)
-R_45 = BoundingRectangle(
+R_0_BL = BoundingRectangle(
+    r_x0=0,
+    r_y0=0,
+    r_x1=1,
+    r_y1=0,
+    r_x2=1,
+    r_y2=1,
+    r_x3=0,
+    r_y3=1,
+    coord_origin=CoordOrigin.BOTTOMLEFT,
+)
+R_0_TL = BoundingRectangle(
+    r_x0=0,
+    r_y0=0,
+    r_x1=1,
+    r_y1=0,
+    r_x2=1,
+    r_y2=1,
+    r_x3=0,
+    r_y3=1,
+    coord_origin=CoordOrigin.TOPLEFT,
+)
+R_45_BL = BoundingRectangle(
     r_x0=0,
     r_y0=0,
     r_x1=SQRT_2 / 2,
@@ -17,11 +39,42 @@ R_45 = BoundingRectangle(
     r_y2=SQRT_2,
     r_x3=-SQRT_2 / 2,
     r_y3=SQRT_2 / 2,
+    coord_origin=CoordOrigin.BOTTOMLEFT,
 )
-R_90 = BoundingRectangle(
-    r_x0=0, r_y0=0, r_x1=0, r_y1=1, r_x2=-1, r_y2=1, r_x3=-1, r_y3=0
+R_45_TL = BoundingRectangle(
+    r_x0=0,
+    r_y0=0,
+    r_x1=SQRT_2 / 2,
+    r_y1=-SQRT_2 / 2,
+    r_x2=0,
+    r_y2=-SQRT_2,
+    r_x3=-SQRT_2 / 2,
+    r_y3=-SQRT_2 / 2,
+    coord_origin=CoordOrigin.TOPLEFT,
 )
-R_135 = BoundingRectangle(
+R_90_BL = BoundingRectangle(
+    r_x0=0,
+    r_y0=0,
+    r_x1=0,
+    r_y1=1,
+    r_x2=-1,
+    r_y2=1,
+    r_x3=-1,
+    r_y3=0,
+    coord_origin=CoordOrigin.BOTTOMLEFT,
+)
+R_90_TL = BoundingRectangle(
+    r_x0=0,
+    r_y0=0,
+    r_x1=0,
+    r_y1=-1,
+    r_x2=-1,
+    r_y2=-1,
+    r_x3=-1,
+    r_y3=0,
+    coord_origin=CoordOrigin.TOPLEFT,
+)
+R_135_BL = BoundingRectangle(
     r_x0=0,
     r_y0=0,
     r_x1=-SQRT_2 / 2,
@@ -30,11 +83,42 @@ R_135 = BoundingRectangle(
     r_y2=0,
     r_x3=-SQRT_2 / 2,
     r_y3=-SQRT_2 / 2,
+    coord_origin=CoordOrigin.BOTTOMLEFT,
 )
-R_180 = BoundingRectangle(
-    r_x0=0, r_y0=0, r_x1=-0, r_y1=0, r_x2=-1, r_y2=-1, r_x3=0, r_y3=-1
+R_135_TL = BoundingRectangle(
+    r_x0=0,
+    r_y0=0,
+    r_x1=-SQRT_2 / 2,
+    r_y1=-SQRT_2 / 2,
+    r_x2=-SQRT_2,
+    r_y2=0,
+    r_x3=-SQRT_2 / 2,
+    r_y3=SQRT_2 / 2,
+    coord_origin=CoordOrigin.TOPLEFT,
 )
-R_MINUS_135 = BoundingRectangle(
+R_180_BL = BoundingRectangle(
+    r_x0=0,
+    r_y0=0,
+    r_x1=-0,
+    r_y1=0,
+    r_x2=-1,
+    r_y2=-1,
+    r_x3=0,
+    r_y3=-1,
+    coord_origin=CoordOrigin.BOTTOMLEFT,
+)
+R_180_TL = BoundingRectangle(
+    r_x0=0,
+    r_y0=0,
+    r_x1=-0,
+    r_y1=0,
+    r_x2=-1,
+    r_y2=1,
+    r_x3=0,
+    r_y3=1,
+    coord_origin=CoordOrigin.TOPLEFT,
+)
+R_225_BL = BoundingRectangle(
     r_x0=0,
     r_y0=0,
     r_x1=-SQRT_2 / 2,
@@ -43,11 +127,42 @@ R_MINUS_135 = BoundingRectangle(
     r_y2=-SQRT_2,
     r_x3=SQRT_2 / 2,
     r_y3=-SQRT_2 / 2,
+    coord_origin=CoordOrigin.BOTTOMLEFT,
 )
-R_MINUS_90 = BoundingRectangle(
-    r_x0=0, r_y0=0, r_x1=0, r_y1=-1, r_x2=1, r_y2=-1, r_x3=1, r_y3=0
+R_225_TL = BoundingRectangle(
+    r_x0=0,
+    r_y0=0,
+    r_x1=-SQRT_2 / 2,
+    r_y1=SQRT_2 / 2,
+    r_x2=0,
+    r_y2=SQRT_2,
+    r_x3=SQRT_2 / 2,
+    r_y3=SQRT_2 / 2,
+    coord_origin=CoordOrigin.TOPLEFT,
 )
-R_MINUS_45 = BoundingRectangle(
+R_270_BL = BoundingRectangle(
+    r_x0=0,
+    r_y0=0,
+    r_x1=0,
+    r_y1=-1,
+    r_x2=1,
+    r_y2=-1,
+    r_x3=1,
+    r_y3=0,
+    coord_origin=CoordOrigin.BOTTOMLEFT,
+)
+R_270_TL = BoundingRectangle(
+    r_x0=0,
+    r_y0=0,
+    r_x1=0,
+    r_y1=1,
+    r_x2=1,
+    r_y2=1,
+    r_x3=1,
+    r_y3=0,
+    coord_origin=CoordOrigin.TOPLEFT,
+)
+R_315_BL = BoundingRectangle(
     r_x0=0,
     r_y0=0,
     r_x1=SQRT_2 / 2,
@@ -56,20 +171,40 @@ R_MINUS_45 = BoundingRectangle(
     r_y2=0,
     r_x3=SQRT_2 / 2,
     r_y3=SQRT_2 / 2,
+    coord_origin=CoordOrigin.BOTTOMLEFT,
+)
+R_315_TL = BoundingRectangle(
+    r_x0=0,
+    r_y0=0,
+    r_x1=SQRT_2 / 2,
+    r_y1=SQRT_2 / 2,
+    r_x2=SQRT_2,
+    r_y2=0,
+    r_x3=SQRT_2 / 2,
+    r_y3=-SQRT_2 / 2,
+    coord_origin=CoordOrigin.TOPLEFT,
 )
 
 
 @pytest.mark.parametrize(
     ("rectangle", "expected_angle", "expected_angle_360"),
     [
-        (R_0, 0, 0.0),
-        (R_45, np.pi / 4, 45),
-        (R_90, np.pi / 2, 90),
-        (R_135, 3 * np.pi / 4, 135),
-        (R_180, np.pi, 180),
-        (R_MINUS_135, 5 * np.pi / 4, 225),
-        (R_MINUS_90, 3 * np.pi / 2, 270),
-        (R_MINUS_45, 7 * np.pi / 4, 315),
+        (R_0_BL, 0, 0.0),
+        (R_45_BL, np.pi / 4, 45),
+        (R_90_BL, np.pi / 2, 90),
+        (R_135_BL, 3 * np.pi / 4, 135),
+        (R_180_BL, np.pi, 180),
+        (R_225_BL, 5 * np.pi / 4, 225),
+        (R_270_BL, 3 * np.pi / 2, 270),
+        (R_315_BL, 7 * np.pi / 4, 315),
+        (R_0_TL, 0, 0.0),
+        (R_45_TL, np.pi / 4, 45),
+        (R_90_TL, np.pi / 2, 90),
+        (R_135_TL, 3 * np.pi / 4, 135),
+        (R_180_TL, np.pi, 180),
+        (R_225_TL, 5 * np.pi / 4, 225),
+        (R_270_TL, 3 * np.pi / 2, 270),
+        (R_315_TL, 7 * np.pi / 4, 315),
     ],
 )
 def test_bounding_rectangle_angle(


### PR DESCRIPTION
# Bug description

When in `CoordOrigin.TOPLEFT`, the computation of the `BoundingRectangle.angle` have to be adapted since the angle between the (x, y), axis is `3*pi / 2` and not `pi / 2`. 

If `BoundingRectangle.angle` describes the angle between (`r_0`, `r_1`) and the `x` axis, angle computation have to be adapted in the `CoordOrigin.TOPLEFT` case:

![IMG_9545](https://github.com/user-attachments/assets/23165d53-e440-4867-8bd4-c27d51127df4)

### Fixed
- fixed the `BoundingRectangle.angle`  computation in the case of the `CoordOrigin.TOPLEFT` case
