### PR TITLE
fix: referenced artifacts relative to the document location

### DIFF
--- a/docling_core/types/doc/document.py
+++ b/docling_core/types/doc/document.py
@@ -1373,11 +1373,11 @@ class PictureItem(FloatingItem):
         )  # Encode to Base64 and decode to string
         return img_base64
 
-    def _image_to_hexhash(self) -> Optional[str]:
+    def _image_to_hexhash(self, img: Optional[PILImage.Image]) -> Optional[str]:
         """Hexash from the image."""
-        if self.image is not None and self.image._pil is not None:
+        if img is not None:
             # Convert the image to raw bytes
-            image_bytes = self.image._pil.tobytes()
+            image_bytes = img.tobytes()
 
             # Create a hash object (e.g., SHA-256)
             hasher = hashlib.sha256(usedforsecurity=False)
@@ -4116,16 +4116,10 @@ class DoclingDocument(BaseModel):
         if image_dir.is_dir():
             for item, level in result.iterate_items(page_no=page_no, with_groups=False):
                 if isinstance(item, PictureItem):
+                    img = item.get_image(doc=self)
+                    if img is not None:
 
-                    if (
-                        item.image is not None
-                        and isinstance(item.image.uri, AnyUrl)
-                        and item.image.uri.scheme == "data"
-                        and item.image.pil_image is not None
-                    ):
-                        img = item.image.pil_image
-
-                        hexhash = item._image_to_hexhash()
+                        hexhash = item._image_to_hexhash(img)
 
                         # loc_path = image_dir / f"image_{img_count:06}.png"
                         if hexhash is not None:
@@ -4140,6 +4134,11 @@ class DoclingDocument(BaseModel):
                             else:
                                 obj_path = loc_path
 
+                            if item.image is None:
+                                scale = img.size[0] / item.prov[0].bbox.width
+                                item.image = ImageRef.from_pil(
+                                    image=img, dpi=round(72 * scale)
+                                )
                             item.image.uri = Path(obj_path)
 
                         # if item.image._pil is not None:
@@ -4539,6 +4538,8 @@ class DoclingDocument(BaseModel):
             reference_path = None
         else:
             reference_path = filename.parent
+            artifacts_dir = reference_path / artifacts_dir
+
         return artifacts_dir, reference_path
 
     def _make_copy_with_refmode(

--- a/docling_core/types/doc/document.py
+++ b/docling_core/types/doc/document.py
@@ -1373,7 +1373,8 @@ class PictureItem(FloatingItem):
         )  # Encode to Base64 and decode to string
         return img_base64
 
-    def _image_to_hexhash(self, img: Optional[PILImage.Image]) -> Optional[str]:
+    @staticmethod
+    def _image_to_hexhash(img: Optional[PILImage.Image]) -> Optional[str]:
         """Hexash from the image."""
         if img is not None:
             # Convert the image to raw bytes
@@ -4119,7 +4120,7 @@ class DoclingDocument(BaseModel):
                     img = item.get_image(doc=self)
                     if img is not None:
 
-                        hexhash = item._image_to_hexhash(img)
+                        hexhash = PictureItem._image_to_hexhash(img)
 
                         # loc_path = image_dir / f"image_{img_count:06}.png"
                         if hexhash is not None:

--- a/test/test_docling_doc.py
+++ b/test/test_docling_doc.py
@@ -1442,10 +1442,11 @@ def test_save_to_disk():
 
     doc: DoclingDocument = _construct_doc()
 
-    image_dir = Path("./test/data/doc/constructed_images/")
+    test_dir = Path("./test/data/doc")
+    image_dir = Path("constructed_images/")  # will be relative to test_dir
 
     doc_with_references = doc._with_pictures_refs(
-        image_dir=image_dir,  # Path("./test/data/constructed_images/")
+        image_dir=(test_dir / image_dir),
         page_no=None,
     )
 
@@ -1455,19 +1456,19 @@ def test_save_to_disk():
 
     ### MarkDown
 
-    filename = Path("test/data/doc/constructed_doc.placeholder.md")
+    filename = test_dir / "constructed_doc.placeholder.md"
     doc.save_as_markdown(
         filename=filename, artifacts_dir=image_dir, image_mode=ImageRefMode.PLACEHOLDER
     )
     _verify_saved_output(filename=filename, paths=paths)
 
-    filename = Path("test/data/doc/constructed_doc.embedded.md")
+    filename = test_dir / "constructed_doc.embedded.md"
     doc.save_as_markdown(
         filename=filename, artifacts_dir=image_dir, image_mode=ImageRefMode.EMBEDDED
     )
     _verify_saved_output(filename=filename, paths=paths)
 
-    filename = Path("test/data/doc/constructed_doc.referenced.md")
+    filename = test_dir / "constructed_doc.referenced.md"
     doc.save_as_markdown(
         filename=filename, artifacts_dir=image_dir, image_mode=ImageRefMode.REFERENCED
     )
@@ -1475,19 +1476,19 @@ def test_save_to_disk():
 
     ### HTML
 
-    filename = Path("test/data/doc/constructed_doc.placeholder.html")
+    filename = test_dir / "constructed_doc.placeholder.html"
     doc.save_as_html(
         filename=filename, artifacts_dir=image_dir, image_mode=ImageRefMode.PLACEHOLDER
     )
     _verify_saved_output(filename=filename, paths=paths)
 
-    filename = Path("test/data/doc/constructed_doc.embedded.html")
+    filename = test_dir / "constructed_doc.embedded.html"
     doc.save_as_html(
         filename=filename, artifacts_dir=image_dir, image_mode=ImageRefMode.EMBEDDED
     )
     _verify_saved_output(filename=filename, paths=paths)
 
-    filename = Path("test/data/doc/constructed_doc.referenced.html")
+    filename = test_dir / "constructed_doc.referenced.html"
     doc.save_as_html(
         filename=filename, artifacts_dir=image_dir, image_mode=ImageRefMode.REFERENCED
     )
@@ -1495,13 +1496,13 @@ def test_save_to_disk():
 
     ### Document Tokens
 
-    filename = Path("test/data/doc/constructed_doc.dt")
+    filename = test_dir / "constructed_doc.dt"
     doc.save_as_doctags(filename=filename)
     _verify_saved_output(filename=filename, paths=paths)
 
     ### JSON
 
-    filename = Path("test/data/doc/constructed_doc.embedded.json")
+    filename = test_dir / "constructed_doc.embedded.json"
     doc.save_as_json(
         filename=filename,
         artifacts_dir=image_dir,
@@ -1512,7 +1513,7 @@ def test_save_to_disk():
     doc_emb_loaded = DoclingDocument.load_from_json(filename)
     _verify_loaded_output(filename=filename, pred=doc_emb_loaded)
 
-    filename = Path("test/data/doc/constructed_doc.referenced.json")
+    filename = test_dir / "constructed_doc.referenced.json"
     doc.save_as_json(
         filename=filename,
         artifacts_dir=image_dir,
@@ -1525,7 +1526,7 @@ def test_save_to_disk():
 
     ### YAML
 
-    filename = Path("test/data/doc/constructed_doc.embedded.yaml")
+    filename = test_dir / "constructed_doc.embedded.yaml"
     doc.save_as_yaml(
         filename=filename,
         artifacts_dir=image_dir,
@@ -1533,7 +1534,7 @@ def test_save_to_disk():
     )
     _verify_saved_output(filename=filename, paths=paths)
 
-    filename = Path("test/data/doc/constructed_doc.referenced.yaml")
+    filename = test_dir / "constructed_doc.referenced.yaml"
     doc.save_as_yaml(
         filename=filename,
         artifacts_dir=image_dir,


### PR DESCRIPTION
This PR is fixing two issues related to the creation of referenced images.

### Relative paths

The management of input directory was only interpreting "non-absolute directories" relative to the current working directory.

It failed to work in the actual setup it was designed, i.e. the artifacts location relative to the target document output.


### Loading a docling document with embedded pages images

The logic saving the picture images relied on the old version, before the page images were introduced.

It failed when doing
- save a DoclingDocument with embedded images
- load the DoclingDocument
- save as markdown/html with referenced images
    - no image was found and exported


Refs https://github.com/docling-project/docling-serve/issues/245