### PR TITLE
perf: cache grid property in HTMLTableSerializer

### DIFF
--- a/docling_core/transforms/serializer/html.py
+++ b/docling_core/transforms/serializer/html.py
@@ -66,7 +66,6 @@ from docling_core.types.doc.document import (
     PictureMoleculeData,
     PictureTabularChartData,
     SectionHeaderItem,
-    TableCell,
     TableItem,
     TextItem,
     TitleItem,
@@ -346,9 +345,6 @@ class HTMLTableSerializer(BaseTableSerializer):
         **kwargs: Any,
     ) -> SerializationResult:
         """Serializes the passed table item to HTML."""
-        nrows = item.data.num_rows
-        ncols = item.data.num_cols
-
         res_parts: list[SerializationResult] = []
         cap_res = doc_serializer.serialize_captions(item=item, tag="caption", **kwargs)
         if cap_res.text:

--- a/docling_core/transforms/serializer/html.py
+++ b/docling_core/transforms/serializer/html.py
@@ -357,10 +357,9 @@ class HTMLTableSerializer(BaseTableSerializer):
         if item.self_ref not in doc_serializer.get_excluded_refs(**kwargs):
             body = ""
 
-            for i in range(nrows):
+            for i, row in enumerate(item.data.grid):
                 body += "<tr>"
-                for j in range(ncols):
-                    cell: TableCell = item.data.grid[i][j]
+                for j, cell in enumerate(row):
 
                     rowspan, rowstart = (
                         cell.row_span,


### PR DESCRIPTION
### Problem
Nested `grid[i][j]` access in `HTMLTableSerializer.serialize` caused performance issues on large tables.

### Change
Replaced double indexing with row-level iteration (`for row in grid: for cell in row:`). Fixes #372

### Impact
Removes repeated Pydantic lookups and improves serialization speed without changing output.
