### PR TITLE
fix: title item first in items_list

### DIFF
--- a/docling_core/types/doc/document.py
+++ b/docling_core/types/doc/document.py
@@ -2800,7 +2800,7 @@ class DoclingDocument(BaseModel):
             item.content_layer = content_layer
 
         self.texts.append(item)
-        parent.children.append(RefItem(cref=cref))
+        parent.children.insert(0,RefItem(cref=cref))
 
         return item
 


### PR DESCRIPTION
Putting document title first in body makes sure the title
1. will appear at the beginning of the document when exported to markdown or text
2. will be included in the headings list of document chunks