### PR TITLE
chore: Silencing info logging on "delete_items" by moving it to debug level

### DIFF
--- a/docling_core/types/doc/document.py
+++ b/docling_core/types/doc/document.py
@@ -2267,7 +2267,7 @@ class DoclingDocument(BaseModel):
             if not success:
                 del to_be_deleted_items[stack_]
             else:
-                _logger.info(f"deleted item in tree at stack: {stack_} => {ref_}")
+                _logger.debug(f"deleted item in tree at stack: {stack_} => {ref_}")
 
         # Create a new lookup of the orphans:
         # dict of item_label (`texts`, `tables`, ...) to a


### PR DESCRIPTION
Moving log of deleting elements from info level to debug.
This is due to support of rich tables, while constructing them backends (docx, html) manipulate docling document tree, and sometimes need to delete elements, this creates excessive logging.

Note from the user: https://github.com/docling-project/docling/issues/2360#issuecomment-3372942862