### PR TITLE
fix: item numbering in document

### DIFF
--- a/docling_core/types/doc/document.py
+++ b/docling_core/types/doc/document.py
@@ -5668,6 +5668,7 @@ class DoclingDocument(BaseModel):
     ):
         """Export the document to indented text to expose hierarchy."""
         result = []
+        item_counter = 0
 
         def get_text(text: str, max_text_len: int):
 
@@ -5687,59 +5688,72 @@ class DoclingDocument(BaseModel):
             if isinstance(item, GroupItem):
                 result.append(
                     indent * level
-                    + f"item-{i} at level {level}: {item.label}: group {item.name}"
+                    + f"item-{item_counter} at level {level}: {item.label}: group {item.name}"
                 )
+                item_counter += 1
 
             elif isinstance(item, TextItem) and item.label in [DocItemLabel.TITLE]:
                 text = get_text(text=item.text, max_text_len=max_text_len)
 
                 result.append(
-                    indent * level + f"item-{i} at level {level}: {item.label}: {text}"
+                    indent * level
+                    + f"item-{item_counter} at level {level}: {item.label}: {text}"
                 )
+                item_counter += 1
 
             elif isinstance(item, SectionHeaderItem):
                 text = get_text(text=item.text, max_text_len=max_text_len)
 
                 result.append(
-                    indent * level + f"item-{i} at level {level}: {item.label}: {text}"
+                    indent * level
+                    + f"item-{item_counter} at level {level}: {item.label}: {text}"
                 )
+                item_counter += 1
 
             elif isinstance(item, TextItem) and item.label in [DocItemLabel.CODE]:
                 text = get_text(text=item.text, max_text_len=max_text_len)
 
                 result.append(
-                    indent * level + f"item-{i} at level {level}: {item.label}: {text}"
+                    indent * level
+                    + f"item-{item_counter} at level {level}: {item.label}: {text}"
                 )
+                item_counter += 1
 
             elif isinstance(item, ListItem) and item.label in [DocItemLabel.LIST_ITEM]:
                 text = get_text(text=item.text, max_text_len=max_text_len)
 
                 result.append(
-                    indent * level + f"item-{i} at level {level}: {item.label}: {text}"
+                    indent * level
+                    + f"item-{item_counter} at level {level}: {item.label}: {text}"
                 )
+                item_counter += 1
 
             elif isinstance(item, TextItem):
                 text = get_text(text=item.text, max_text_len=max_text_len)
 
                 result.append(
-                    indent * level + f"item-{i} at level {level}: {item.label}: {text}"
+                    indent * level
+                    + f"item-{item_counter} at level {level}: {item.label}: {text}"
                 )
+                item_counter += 1
 
             elif isinstance(item, TableItem):
 
                 result.append(
                     indent * level
-                    + f"item-{i} at level {level}: {item.label} with "
+                    + f"item-{item_counter} at level {level}: {item.label} with "
                     + f"[{item.data.num_rows}x{item.data.num_cols}]"
                 )
+                item_counter += 1
 
                 for _ in item.captions:
                     caption = _.resolve(self)
                     result.append(
                         indent * (level + 1)
-                        + f"item-{i} at level {level + 1}: {caption.label}: "
+                        + f"item-{item_counter} at level {level + 1}: {caption.label}: "
                         + f"{caption.text}"
                     )
+                    item_counter += 1
 
                 if explicit_tables:
                     grid: list[list[str]] = []
@@ -5757,22 +5771,26 @@ class DoclingDocument(BaseModel):
             elif isinstance(item, PictureItem):
 
                 result.append(
-                    indent * level + f"item-{i} at level {level}: {item.label}"
+                    indent * level
+                    + f"item-{item_counter} at level {level}: {item.label}"
                 )
+                item_counter += 1
 
                 for _ in item.captions:
                     caption = _.resolve(self)
                     result.append(
                         indent * (level + 1)
-                        + f"item-{i} at level {level + 1}: {caption.label}: "
+                        + f"item-{item_counter} at level {level + 1}: {caption.label}: "
                         + f"{caption.text}"
                     )
+                    item_counter += 1
 
             elif isinstance(item, DocItem):
                 result.append(
                     indent * (level + 1)
-                    + f"item-{i} at level {level}: {item.label}: ignored"
+                    + f"item-{item_counter} at level {level}: {item.label}: ignored"
                 )
+                item_counter += 1
 
         return "\n".join(result)
 


### PR DESCRIPTION
The PR https://github.com/docling-project/docling/pull/2589 revealed a bug, the caption is having the same number as the table here in https://github.com/docling-project/docling/pull/2589/files#diff-0ff184cc09560c89eb50dc9cf939c40bdf55d372d26823c956b55fb8f6c5e16fR1-R5.

This introduces a global numbering with increment at each item.