### PR TITLE
fix: rich table triplet serialization

### DIFF
--- a/docling_core/transforms/chunker/hierarchical_chunker.py
+++ b/docling_core/transforms/chunker/hierarchical_chunker.py
@@ -69,7 +69,11 @@ class TripletTableSerializer(BaseTableSerializer):
             parts.append(cap_res)
 
         if item.self_ref not in doc_serializer.get_excluded_refs(**kwargs):
-            table_df = item.export_to_dataframe(doc)
+            table_df = item.export_to_dataframe(
+                doc,
+                doc_serializer=doc_serializer,
+                **kwargs,
+            )
             if table_df.shape[0] >= 1 and table_df.shape[1] >= 2:
 
                 # copy header as first row and shift all rows by one

--- a/docling_core/types/doc/document.py
+++ b/docling_core/types/doc/document.py
@@ -1840,7 +1840,9 @@ class TableItem(FloatingItem):
         return self
 
     def export_to_dataframe(
-        self, doc: Optional["DoclingDocument"] = None
+        self,
+        doc: Optional["DoclingDocument"] = None,
+        **kwargs: Any,
     ) -> pd.DataFrame:
         """Export the table as a Pandas DataFrame."""
         if doc is None:
@@ -1876,14 +1878,14 @@ class TableItem(FloatingItem):
             columns = ["" for _ in range(self.data.num_cols)]
             for i in range(num_headers):
                 for j, cell in enumerate(self.data.grid[i]):
-                    col_name = cell._get_text(doc=doc)
+                    col_name = cell._get_text(doc=doc, **kwargs)
                     if columns[j] != "":
                         col_name = f".{col_name}"
                     columns[j] += col_name
 
         # Create table data
         table_data = [
-            [cell._get_text(doc=doc) for cell in row]
+            [cell._get_text(doc=doc, **kwargs) for cell in row]
             for row in self.data.grid[num_headers:]
         ]
 

--- a/test/data/chunker/0c_out_chunks.json
+++ b/test/data/chunker/0c_out_chunks.json
@@ -1,0 +1,39 @@
+{
+    "root": [
+        {
+            "text": "cell 0,0, 1 = cell 0,1. cell 1,0, 1 = <em><p>text in italic</p></em>. <ul>\n<li>list item 1</li>\n<li>list item 2</li>\n</ul>, 1 = cell 2,1. cell 3,0, 1 = inner cell 0,0, 1 = inner cell 0,1. inner cell 0,0, 2 = inner cell 0,2. inner cell 1,0, 1 = inner cell 1,1. inner cell 1,0, 2 = inner cell 1,2. <p>Some text in a generic group.</p>\n<p>More text in the group.</p>, 1 = cell 4,1",
+            "meta": {
+                "schema_name": "docling_core.transforms.chunker.DocMeta",
+                "version": "1.0.0",
+                "doc_items": [
+                    {
+                        "self_ref": "#/tables/0",
+                        "parent": {
+                            "$ref": "#/body"
+                        },
+                        "children": [
+                            {
+                                "$ref": "#/texts/1"
+                            },
+                            {
+                                "$ref": "#/groups/0"
+                            },
+                            {
+                                "$ref": "#/tables/1"
+                            },
+                            {
+                                "$ref": "#/groups/1"
+                            }
+                        ],
+                        "content_layer": "body",
+                        "label": "table",
+                        "prov": []
+                    }
+                ],
+                "headings": [
+                    "Rich tables"
+                ]
+            }
+        }
+    ]
+}


### PR DESCRIPTION
Adds **kwargs to the export_to_dataframe method and passes them to _get_text for the table cell.

In TripletTableSerializer, the method is called with doc_serializer, which solves the problem of incorrect serialization.

Tests for the case have been added.

Resolves #423
