### PR TITLE
fix: correct extract_items_range method for rich tables

### DIFF
--- a/docling_core/types/doc/document.py
+++ b/docling_core/types/doc/document.py
@@ -4293,12 +4293,15 @@ class DoclingDocument(BaseModel):
                 "Start NodeItem must come before or be the same as the end NodeItem in the document structure."
             )
 
-        new_doc = DoclingDocument(name=f"{self.name}- Extracted Range")
-
         ref_items = start_parent.children[start_index:end_index]
         node_items = [ref.resolve(self) for ref in ref_items]
 
-        new_doc.add_node_items(node_items=node_items, doc=self)
+        doc_index = DoclingDocument._DocIndex()
+        for node_item in node_items:
+            doc_index.index(doc=self, root=node_item)
+
+        new_doc = DoclingDocument(name="")
+        new_doc._update_from_index(doc_index)
 
         if delete:
             self.delete_items_range(

--- a/test/test_docling_doc.py
+++ b/test/test_docling_doc.py
@@ -1643,6 +1643,12 @@ def test_rich_tables(rich_table_doc):
 
 
 def test_doc_manipulation_with_rich_tables(rich_table_doc):
+    rich_table = rich_table_doc.tables[0]
+    extracted_doc = rich_table_doc.extract_items_range(start=rich_table, end=rich_table)
+    extracted_md = extracted_doc.export_to_markdown()
+    assert len(extracted_md) > 0
+    assert len(extracted_doc.tables) == 2
+
     rich_table_doc.delete_items(node_items=[rich_table_doc.texts[0]])
 
     exp_file = Path("test/data/doc/rich_table_post_text_del.out.yaml")


### PR DESCRIPTION
The purpose of this PR is to solve issue #427 (rich table items extraction issue).

A way to extract rich table items from a DoclingDocument is given in #427 by copying the items as-is and then using _DocIndex.index. Here, we propose another solution:

- We add a "root" parameter to _DocIndex.index to extract only this "root" element (and all his descendants) from a document.
- We use this new "root" parameter of _DocIndex.index in the DoclingDocument method extract_items_range to support extracting a range of items, including rich table items.