### PR TITLE
feat: add fsspec support

### DIFF
--- a/docling_core/cli/view.py
+++ b/docling_core/cli/view.py
@@ -69,8 +69,7 @@ def view(
         image_mode=ImageRefMode.EMBEDDED,
         split_page_view=split_view,
     )
-    with open(target_path, "w", encoding="utf-8") as f:
-        f.write(html_output)
+    target_path.write_text(html_output, encoding="utf-8")
     webbrowser.open(url=f"file://{target_path.absolute().resolve()}")
 
 

--- a/docling_core/types/doc/document.py
+++ b/docling_core/types/doc/document.py
@@ -6070,6 +6070,39 @@ class DoclingDocument(BaseModel):
 
         return result
 
+    @staticmethod
+    def _save_image_and_resolve_uri(
+        img: PILImage.Image,
+        loc_path: Path,
+        reference_path: Optional[Path],
+    ) -> Union[AnyUrl, Path]:
+        """Save *img* to *loc_path* and return the URI to store on the ImageRef.
+
+        Uses a BytesIO intermediate buffer so that the write is compatible with
+        UPath remote backends (PIL cannot write directly to non-local paths).
+        For remote paths the URI is returned as an absolute AnyUrl string; for
+        local paths it is returned relative to *reference_path* when available,
+        or as the absolute *loc_path* when *reference_path* is None.
+
+        Args:
+            img: The PIL image to save.
+            loc_path: Destination path (local or remote UPath).
+            reference_path: Base path used to compute a relative URI for local
+                storage. Pass ``None`` to store the absolute path instead.
+
+        Returns:
+            An AnyUrl for remote paths, or a Path (relative or absolute) for local paths.
+        """
+        buf = BytesIO()
+        img.save(buf, format="PNG")
+        loc_path.write_bytes(buf.getvalue())
+
+        if is_remote_path(loc_path) or is_remote_path(reference_path):
+            return AnyUrl(str(loc_path))
+        if reference_path is not None:
+            return relative_path(reference_path.resolve(), loc_path.resolve())
+        return loc_path
+
     def _with_pictures_refs(
         self,
         image_dir: Path,
@@ -6088,48 +6121,21 @@ class DoclingDocument(BaseModel):
         """
         result: DoclingDocument = copy.deepcopy(self)
 
-        img_count = 0
         image_dir.mkdir(parents=True, exist_ok=True)
 
+        img_count = 0
         for item, _ in result.iterate_items(page_no=page_no, with_groups=False):
             if isinstance(item, PictureItem):
                 img = item.get_image(doc=self)
                 if img is not None:
                     hexhash = PictureItem._image_to_hexhash(img)
-
-                    # loc_path = image_dir / f"image_{img_count:06}.png"
                     if hexhash is not None:
                         loc_path = image_dir / f"image_{img_count:06}_{hexhash}.png"
-
-                        # Use BytesIO + write_bytes for UPath compatibility
-                        buf = BytesIO()
-                        img.save(buf, format="PNG")
-                        loc_path.write_bytes(buf.getvalue())
-
-                        # For remote paths, use absolute URI string; for local, compute relative
-                        obj_path: Union[AnyUrl, Path]
-                        if is_remote_path(loc_path) or is_remote_path(reference_path):
-                            obj_path = AnyUrl(str(loc_path))
-                        elif reference_path is not None:
-                            obj_path = relative_path(
-                                reference_path.resolve(),
-                                loc_path.resolve(),
-                            )
-                        else:
-                            obj_path = loc_path
-
+                        obj_path = self._save_image_and_resolve_uri(img, loc_path, reference_path)
                         if item.image is None:
                             scale = img.size[0] / item.prov[0].bbox.width
                             item.image = ImageRef.from_pil(image=img, dpi=round(72 * scale))
-                            # For remote paths, store as string URI; for local, store as Path
-                            # Pydantic coerces str to AnyUrl at runtime
-                            item.image.uri = obj_path  # type: ignore[assignment]
-                        else:
-                            item.image.uri = obj_path  # type: ignore[assignment]
-
-                    # if item.image._pil is not None:
-                    #    item.image._pil.close()
-
+                        item.image.uri = obj_path  # type: ignore[assignment]
                 img_count += 1
 
         if include_page_images:
@@ -6144,26 +6150,8 @@ class DoclingDocument(BaseModel):
                 hexhash = PictureItem._image_to_hexhash(img)
                 if hexhash is None:
                     continue
-
                 loc_path = image_dir / f"page_{p_no:06}_{hexhash}.png"
-
-                # Use BytesIO + write_bytes for UPath compatibility
-                buf = BytesIO()
-                img.save(buf, format="PNG")
-                loc_path.write_bytes(buf.getvalue())
-
-                page_obj_path: Union[AnyUrl, Path]
-                if is_remote_path(loc_path) or is_remote_path(reference_path):
-                    page_obj_path = AnyUrl(str(loc_path))
-                elif reference_path is not None:
-                    page_obj_path = relative_path(
-                        reference_path.resolve(),
-                        loc_path.resolve(),
-                    )
-                else:
-                    page_obj_path = loc_path
-
-                page.image.uri = page_obj_path  # type: ignore[assignment]
+                page.image.uri = self._save_image_and_resolve_uri(img, loc_path, reference_path)  # type: ignore[assignment]
 
         return result
 

--- a/docling_core/types/doc/document.py
+++ b/docling_core/types/doc/document.py
@@ -6124,7 +6124,7 @@ class DoclingDocument(BaseModel):
                             # For remote paths, store as string URI; for local, store as Path
                             # Pydantic coerces str to AnyUrl at runtime
                             item.image.uri = obj_path  # type: ignore[assignment]
-                        elif item.image is not None:
+                        else:
                             item.image.uri = obj_path  # type: ignore[assignment]
 
                     # if item.image._pil is not None:
@@ -6132,30 +6132,38 @@ class DoclingDocument(BaseModel):
 
                 img_count += 1
 
-            if include_page_images:
-                for p_no, page in result.pages.items():
-                    if page_no is not None and p_no != page_no:
-                        continue
-                    if page.image is None:
-                        continue
-                    img = page.image.pil_image
-                    if img is None:
-                        continue
-                    hexhash = PictureItem._image_to_hexhash(img)
-                    if hexhash is None:
-                        continue
+        if include_page_images:
+            for p_no, page in result.pages.items():
+                if page_no is not None and p_no != page_no:
+                    continue
+                if page.image is None:
+                    continue
+                img = page.image.pil_image
+                if img is None:
+                    continue
+                hexhash = PictureItem._image_to_hexhash(img)
+                if hexhash is None:
+                    continue
 
-                    loc_path = image_dir / f"page_{p_no:06}_{hexhash}.png"
-                    img.save(loc_path)
-                    if reference_path is not None:
-                        obj_path = relative_path(
-                            reference_path.resolve(),
-                            loc_path.resolve(),
-                        )
-                    else:
-                        obj_path = loc_path
+                loc_path = image_dir / f"page_{p_no:06}_{hexhash}.png"
 
-                    page.image.uri = Path(obj_path)
+                # Use BytesIO + write_bytes for UPath compatibility
+                buf = BytesIO()
+                img.save(buf, format="PNG")
+                loc_path.write_bytes(buf.getvalue())
+
+                page_obj_path: Union[AnyUrl, Path]
+                if is_remote_path(loc_path) or is_remote_path(reference_path):
+                    page_obj_path = AnyUrl(str(loc_path))
+                elif reference_path is not None:
+                    page_obj_path = relative_path(
+                        reference_path.resolve(),
+                        loc_path.resolve(),
+                    )
+                else:
+                    page_obj_path = loc_path
+
+                page.image.uri = page_obj_path  # type: ignore[assignment]
 
         return result
 
@@ -6619,12 +6627,27 @@ class DoclingDocument(BaseModel):
         filename.write_text(html_out, encoding="utf-8")
 
     def _get_output_paths(
-        self, filename: Union[str, Path], artifacts_dir: Optional[Path] = None
+        self,
+        filename: Path,
+        artifacts_dir: Optional[Path] = None,
     ) -> tuple[Path, Optional[Path]]:
-        if isinstance(filename, str):
-            filename = Path(filename)
+        """Resolve output and artifacts directory paths from the given filename.
+
+        Both ``Path`` and ``UPath`` objects are accepted since ``UPath`` is ``Path``-compatible for local paths, and remote ``UPath`` objects implement the same interface used here (``with_suffix``, ``with_name``,
+        ``is_absolute``, ``parent``, ``/``).
+
+        Args:
+            filename: Destination file path.
+            artifacts_dir: Optional explicit artifacts directory. When ``None``, a sibling
+                directory named ``<stem>_artifacts`` is derived from ``filename``.
+
+        Returns:
+            A tuple of ``(artifacts_dir, reference_path)`` where ``reference_path`` is
+            the parent of ``filename`` when ``artifacts_dir`` is relative, or ``None``
+            when it is absolute.
+        """
         if artifacts_dir is None:
-            # Remove the extension and add '_pictures'
+            # Remove the extension and add '_artifacts'
             artifacts_dir = filename.with_suffix("")
             artifacts_dir = artifacts_dir.with_name(artifacts_dir.name + "_artifacts")
         if artifacts_dir.is_absolute():

--- a/docling_core/types/doc/document.py
+++ b/docling_core/types/doc/document.py
@@ -6,7 +6,6 @@ import hashlib
 import json
 import logging
 import mimetypes
-import os
 import re
 import sys
 import tempfile
@@ -15,7 +14,7 @@ import warnings
 from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
 from enum import Enum
-from io import BytesIO
+from io import BytesIO, StringIO
 from pathlib import Path
 from typing import (
     Annotated,
@@ -69,6 +68,7 @@ from docling_core.types.doc.labels import (
 )
 from docling_core.types.doc.tokens import DocumentToken, TableToken
 from docling_core.types.doc.utils import (
+    is_remote_path,
     parse_otsl_table_content,
     relative_path,
     resolve_archive_path,
@@ -6091,37 +6091,49 @@ class DoclingDocument(BaseModel):
         img_count = 0
         image_dir.mkdir(parents=True, exist_ok=True)
 
-        if image_dir.is_dir():
-            for item, _ in result.iterate_items(page_no=page_no, with_groups=False):
-                if isinstance(item, PictureItem):
-                    img = item.get_image(doc=self)
-                    if img is not None:
-                        hexhash = PictureItem._image_to_hexhash(img)
+        # Note: Skip is_dir() check for remote paths since S3/cloud storage
+        # doesn't have real directories - mkdir() is a no-op for remote paths
+        for item, _ in result.iterate_items(page_no=page_no, with_groups=False):
+            if isinstance(item, PictureItem):
+                img = item.get_image(doc=self)
+                if img is not None:
+                    hexhash = PictureItem._image_to_hexhash(img)
 
-                        # loc_path = image_dir / f"image_{img_count:06}.png"
-                        if hexhash is not None:
-                            loc_path = image_dir / f"image_{img_count:06}_{hexhash}.png"
+                    # loc_path = image_dir / f"image_{img_count:06}.png"
+                    if hexhash is not None:
+                        loc_path = image_dir / f"image_{img_count:06}_{hexhash}.png"
 
-                            img.save(loc_path)
-                            if reference_path is not None:
-                                obj_path = relative_path(
-                                    reference_path.resolve(),
-                                    loc_path.resolve(),
-                                )
-                            else:
-                                obj_path = loc_path
+                        # Use BytesIO + write_bytes for UPath compatibility
+                        buf = BytesIO()
+                        img.save(buf, format="PNG")
+                        loc_path.write_bytes(buf.getvalue())
 
-                            if item.image is None:
-                                scale = img.size[0] / item.prov[0].bbox.width
-                                item.image = ImageRef.from_pil(image=img, dpi=round(72 * scale))
-                                item.image.uri = Path(obj_path)
-                            elif item.image is not None:
-                                item.image.uri = Path(obj_path)
+                        # For remote paths, use absolute URI string; for local, compute relative
+                        obj_path: Union[str, Path]
+                        if is_remote_path(loc_path) or is_remote_path(reference_path):
+                            # Convert to string URI for remote paths (Pydantic can't serialize UPath)
+                            obj_path = str(loc_path)
+                        elif reference_path is not None:
+                            obj_path = relative_path(
+                                reference_path.resolve(),
+                                loc_path.resolve(),
+                            )
+                        else:
+                            obj_path = loc_path
 
-                        # if item.image._pil is not None:
-                        #    item.image._pil.close()
+                        if item.image is None:
+                            scale = img.size[0] / item.prov[0].bbox.width
+                            item.image = ImageRef.from_pil(image=img, dpi=round(72 * scale))
+                            # For remote paths, store as string URI; for local, store as Path
+                            # Pydantic coerces str to AnyUrl at runtime
+                            item.image.uri = obj_path  # type: ignore[assignment]
+                        elif item.image is not None:
+                            item.image.uri = obj_path  # type: ignore[assignment]
 
-                    img_count += 1
+                    # if item.image._pil is not None:
+                    #    item.image._pil.close()
+
+                img_count += 1
 
             if include_page_images:
                 for p_no, page in result.pages.items():
@@ -6207,7 +6219,7 @@ class DoclingDocument(BaseModel):
         artifacts_dir, reference_path = self._get_output_paths(filename, artifacts_dir)
 
         if image_mode == ImageRefMode.REFERENCED:
-            os.makedirs(artifacts_dir, exist_ok=True)
+            artifacts_dir.mkdir(parents=True, exist_ok=True)
 
         new_doc = self._make_copy_with_refmode(
             artifacts_dir,
@@ -6218,8 +6230,7 @@ class DoclingDocument(BaseModel):
         )
 
         out = new_doc.export_to_dict(coord_precision=coord_precision, confid_precision=confid_precision)
-        with open(filename, "w", encoding="utf-8") as fw:
-            json.dump(out, fw, indent=indent)
+        filename.write_text(json.dumps(out, indent=indent), encoding="utf-8")
 
     @classmethod
     def load_from_json(cls, filename: Union[str, Path]) -> "DoclingDocument":
@@ -6234,8 +6245,7 @@ class DoclingDocument(BaseModel):
         """
         if isinstance(filename, str):
             filename = Path(filename)
-        with open(filename, encoding="utf-8") as f:
-            return cls.model_validate_json(f.read())
+        return cls.model_validate_json(filename.read_text(encoding="utf-8"))
 
     def save_as_yaml(
         self,
@@ -6252,7 +6262,7 @@ class DoclingDocument(BaseModel):
         artifacts_dir, reference_path = self._get_output_paths(filename, artifacts_dir)
 
         if image_mode == ImageRefMode.REFERENCED:
-            os.makedirs(artifacts_dir, exist_ok=True)
+            artifacts_dir.mkdir(parents=True, exist_ok=True)
 
         new_doc = self._make_copy_with_refmode(
             artifacts_dir,
@@ -6263,8 +6273,9 @@ class DoclingDocument(BaseModel):
         )
 
         out = new_doc.export_to_dict(coord_precision=coord_precision, confid_precision=confid_precision)
-        with open(filename, "w", encoding="utf-8") as fw:
-            yaml.dump(out, fw, default_flow_style=default_flow_style)
+        stream = StringIO()
+        yaml.dump(out, stream, default_flow_style=default_flow_style)
+        filename.write_text(stream.getvalue(), encoding="utf-8")
 
     @classmethod
     def load_from_yaml(cls, filename: Union[str, Path]) -> "DoclingDocument":
@@ -6278,8 +6289,7 @@ class DoclingDocument(BaseModel):
         """
         if isinstance(filename, str):
             filename = Path(filename)
-        with open(filename, encoding="utf-8") as f:
-            data = yaml.load(f, Loader=yaml.SafeLoader)
+        data = yaml.load(filename.read_text(encoding="utf-8"), Loader=yaml.SafeLoader)
         return DoclingDocument.model_validate(data)
 
     def export_to_dict(
@@ -6330,7 +6340,7 @@ class DoclingDocument(BaseModel):
         artifacts_dir, reference_path = self._get_output_paths(filename, artifacts_dir)
 
         if image_mode == ImageRefMode.REFERENCED:
-            os.makedirs(artifacts_dir, exist_ok=True)
+            artifacts_dir.mkdir(parents=True, exist_ok=True)
 
         new_doc = self._make_copy_with_refmode(artifacts_dir, image_mode, page_no, reference_path=reference_path)
 
@@ -6355,8 +6365,7 @@ class DoclingDocument(BaseModel):
             mark_meta=mark_meta,
         )
 
-        with open(filename, "w", encoding="utf-8") as fw:
-            fw.write(md_out)
+        filename.write_text(md_out, encoding="utf-8")
 
     def export_to_markdown(
         self,
@@ -6592,7 +6601,7 @@ class DoclingDocument(BaseModel):
         artifacts_dir, reference_path = self._get_output_paths(filename, artifacts_dir)
 
         if image_mode == ImageRefMode.REFERENCED:
-            os.makedirs(artifacts_dir, exist_ok=True)
+            artifacts_dir.mkdir(parents=True, exist_ok=True)
 
         new_doc = self._make_copy_with_refmode(artifacts_dir, image_mode, page_no, reference_path=reference_path)
 
@@ -6610,8 +6619,7 @@ class DoclingDocument(BaseModel):
             include_annotations=include_annotations,
         )
 
-        with open(filename, "w", encoding="utf-8") as fw:
-            fw.write(html_out)
+        filename.write_text(html_out, encoding="utf-8")
 
     def _get_output_paths(
         self, filename: Union[str, Path], artifacts_dir: Optional[Path] = None
@@ -6767,8 +6775,7 @@ class DoclingDocument(BaseModel):
             omit_voice_end=omit_voice_end,
         )
 
-        with open(filename, "w", encoding="utf-8") as fw:
-            fw.write(vtt_out)
+        filename.write_text(vtt_out, encoding="utf-8")
 
     @staticmethod
     def load_from_doctags(  # noqa: C901
@@ -7379,8 +7386,7 @@ class DoclingDocument(BaseModel):
             minified=minified,
         )
 
-        with open(filename, "w", encoding="utf-8") as fw:
-            fw.write(out)
+        filename.write_text(out, encoding="utf-8")
 
     @deprecated("Use export_to_doctags() instead.")
     def export_to_document_tokens(self, *args, **kwargs):
@@ -7470,9 +7476,10 @@ class DoclingDocument(BaseModel):
         filename: Union[str, Path],
     ) -> None:
         """Save the document as DocLang."""
+        if isinstance(filename, str):
+            filename = Path(filename)
         out = self.export_to_doclang()
-        with open(filename, "w", encoding="utf-8") as fw:
-            fw.write(f"{out}\n")
+        filename.write_text(f"{out}\n", encoding="utf-8")
 
     def save_as_doclang_archive(
         self,

--- a/docling_core/types/doc/document.py
+++ b/docling_core/types/doc/document.py
@@ -6107,10 +6107,9 @@ class DoclingDocument(BaseModel):
                         loc_path.write_bytes(buf.getvalue())
 
                         # For remote paths, use absolute URI string; for local, compute relative
-                        obj_path: Union[str, Path]
+                        obj_path: Union[AnyUrl, Path]
                         if is_remote_path(loc_path) or is_remote_path(reference_path):
-                            # Convert to string URI for remote paths (Pydantic can't serialize UPath)
-                            obj_path = str(loc_path)
+                            obj_path = AnyUrl(str(loc_path))
                         elif reference_path is not None:
                             obj_path = relative_path(
                                 reference_path.resolve(),

--- a/docling_core/types/doc/document.py
+++ b/docling_core/types/doc/document.py
@@ -6091,8 +6091,6 @@ class DoclingDocument(BaseModel):
         img_count = 0
         image_dir.mkdir(parents=True, exist_ok=True)
 
-        # Note: Skip is_dir() check for remote paths since S3/cloud storage
-        # doesn't have real directories - mkdir() is a no-op for remote paths
         for item, _ in result.iterate_items(page_no=page_no, with_groups=False):
             if isinstance(item, PictureItem):
                 img = item.get_image(doc=self)

--- a/docling_core/types/doc/page.py
+++ b/docling_core/types/doc/page.py
@@ -688,8 +688,7 @@ class SegmentedPdfPage(SegmentedPage):
         if isinstance(filename, str):
             filename = Path(filename)
         out = self.export_to_dict()
-        with open(filename, "w", encoding="utf-8") as fw:
-            json.dump(out, fw, indent=indent)
+        filename.write_text(json.dumps(out, indent=indent), encoding="utf-8")
 
     @classmethod
     def load_from_json(cls, filename: Union[str, Path]) -> "SegmentedPdfPage":
@@ -703,8 +702,7 @@ class SegmentedPdfPage(SegmentedPage):
         """
         if isinstance(filename, str):
             filename = Path(filename)
-        with open(filename, encoding="utf-8") as f:
-            return cls.model_validate_json(f.read())
+        return cls.model_validate_json(filename.read_text(encoding="utf-8"))
 
     def crop_text(self, cell_unit: TextCellUnit, bbox: BoundingBox, eps: float = 1.0) -> str:
         """Extract text from cells within the specified bounding box.
@@ -1390,8 +1388,7 @@ class PdfTableOfContents(BaseModel):
         if isinstance(filename, str):
             filename = Path(filename)
         out = self.export_to_dict()
-        with open(filename, "w", encoding="utf-8") as fw:
-            json.dump(out, fw, indent=indent)
+        filename.write_text(json.dumps(out, indent=indent), encoding="utf-8")
 
     @classmethod
     def load_from_json(cls, filename: Union[str, Path]) -> "PdfTableOfContents":
@@ -1405,8 +1402,7 @@ class PdfTableOfContents(BaseModel):
         """
         if isinstance(filename, str):
             filename = Path(filename)
-        with open(filename, encoding="utf-8") as f:
-            return cls.model_validate_json(f.read())
+        return cls.model_validate_json(filename.read_text(encoding="utf-8"))
 
 
 class ParsedPdfDocument(BaseModel):
@@ -1451,8 +1447,7 @@ class ParsedPdfDocument(BaseModel):
         if isinstance(filename, str):
             filename = Path(filename)
         out = self.export_to_dict()
-        with open(filename, "w", encoding="utf-8") as fw:
-            json.dump(out, fw, indent=indent)
+        filename.write_text(json.dumps(out, indent=indent), encoding="utf-8")
 
     @classmethod
     def load_from_json(cls, filename: Union[str, Path]) -> "ParsedPdfDocument":
@@ -1466,5 +1461,4 @@ class ParsedPdfDocument(BaseModel):
         """
         if isinstance(filename, str):
             filename = Path(filename)
-        with open(filename, encoding="utf-8") as f:
-            return cls.model_validate_json(f.read())
+        return cls.model_validate_json(filename.read_text(encoding="utf-8"))

--- a/docling_core/types/doc/utils.py
+++ b/docling_core/types/doc/utils.py
@@ -56,8 +56,14 @@ def relative_path(src: str | Path, target: str | Path) -> Path:
     if isinstance(target, str):
         target = Path(target)
 
-    src = src.resolve()
-    target = target.resolve()
+    try:
+        src = src.resolve()
+        target = target.resolve()
+    except (AttributeError, NotImplementedError, OSError) as e:
+        raise ValueError(
+            f"Cannot resolve paths. This function only supports local filesystem paths. "
+            f"Remote paths should use absolute URIs. Error: {e}"
+        ) from e
 
     # Ensure both paths are absolute
     if not src.is_absolute():

--- a/docling_core/types/doc/utils.py
+++ b/docling_core/types/doc/utils.py
@@ -28,9 +28,7 @@ def is_remote_path(p: Any) -> bool:
     """
     # UPath objects have a 'protocol' attribute
     protocol = getattr(p, "protocol", None)
-    if protocol is not None and protocol not in ("file", ""):
-        return True
-    return False
+    return protocol is not None and protocol not in ("file", "")
 
 
 def relative_path(src: str | Path, target: str | Path) -> Path:
@@ -48,7 +46,7 @@ def relative_path(src: str | Path, target: str | Path) -> Path:
 
     Note:
         For remote paths (UPath with non-file protocols), this function cannot
-        compute relative paths. Use is_remote_path() to check before calling.
+            compute relative paths. Use is_remote_path() to check before calling.
     """
     # Convert to Path only if string, otherwise keep original type
     if isinstance(src, str):

--- a/docling_core/types/doc/utils.py
+++ b/docling_core/types/doc/utils.py
@@ -7,7 +7,7 @@ import shutil
 import unicodedata
 import zipfile
 from pathlib import Path
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Any
 
 from docling_core.types.doc.tokens import _LOC_PREFIX, DocumentToken, TableToken
 
@@ -15,21 +15,49 @@ if TYPE_CHECKING:
     from docling_core.types.doc.document import TableCell, TableData
 
 
-def relative_path(src: Path, target: Path) -> Path:
+def is_remote_path(p: Any) -> bool:
+    """Check if a path is a remote/cloud path (e.g., S3, GCS, Azure).
+
+    Works with UPath objects from universal-pathlib. Local paths return False.
+
+    Args:
+        p: A path object (Path, UPath, or similar)
+
+    Returns:
+        bool: True if the path is a remote/cloud path, False otherwise.
+    """
+    # UPath objects have a 'protocol' attribute
+    protocol = getattr(p, "protocol", None)
+    if protocol is not None and protocol not in ("file", ""):
+        return True
+    return False
+
+
+def relative_path(src: str | Path, target: str | Path) -> Path:
     """Compute the relative path from `src` to `target`.
 
     Args:
-        src (str | Path): The source directory or file path (must be absolute).
-        target (str | Path): The target directory or file path (must be absolute).
+        src: The source directory or file path (must be absolute).
+        target: The target directory or file path (must be absolute).
 
     Returns:
         Path: The relative path from `src` to `target`.
 
     Raises:
         ValueError: If either `src` or `target` is not an absolute path.
+
+    Note:
+        For remote paths (UPath with non-file protocols), this function cannot
+        compute relative paths. Use is_remote_path() to check before calling.
     """
-    src = Path(src).resolve()
-    target = Path(target).resolve()
+    # Convert to Path only if string, otherwise keep original type
+    if isinstance(src, str):
+        src = Path(src)
+    if isinstance(target, str):
+        target = Path(target)
+
+    src = src.resolve()
+    target = target.resolve()
 
     # Ensure both paths are absolute
     if not src.is_absolute():
@@ -93,7 +121,7 @@ def safe_extract_zip_archive(archive: Path, destination: Path) -> None:
                 shutil.copyfileobj(src, dst)
 
 
-def get_html_tag_with_text_direction(html_tag: str, text: str, attrs: Optional[dict] = None) -> str:
+def get_html_tag_with_text_direction(html_tag: str, text: str, attrs: dict | None = None) -> str:
     """Form the HTML element with tag, text, and optional dir attribute."""
     my_attrs = attrs or {}
     if (dir := my_attrs.get("dir")) is not None and dir != "ltr":

--- a/docling_core/utils/generate_docs.py
+++ b/docling_core/utils/generate_docs.py
@@ -6,7 +6,6 @@ Example:
 
 import argparse
 import json
-import os
 from argparse import BooleanOptionalAction
 from pathlib import Path
 from shutil import rmtree
@@ -24,15 +23,16 @@ def _prepare_directory(folder: str, clean: bool = False) -> None:
         folder: The name of the directory.
         clean: Whether any existing content in the directory should be removed.
     """
-    if os.path.isdir(folder):
+    folder_path = Path(folder)
+    if folder_path.is_dir():
         if clean:
-            for path in Path(folder).glob("**/*"):
+            for path in folder_path.glob("**/*"):
                 if path.is_file():
                     path.unlink()
                 elif path.is_dir():
                     rmtree(path)
     else:
-        os.makedirs(folder, exist_ok=True)
+        folder_path.mkdir(parents=True, exist_ok=True)
 
 
 def generate_collection_jsonschema(folder: str):
@@ -41,10 +41,11 @@ def generate_collection_jsonschema(folder: str):
     Args:
         folder: The name of the directory.
     """
+    folder_path = Path(folder)
     for item in MODELS:
         json_schema = generate_json_schema(item)
-        with open(os.path.join(folder, f"{item}.json"), mode="w", encoding="utf8") as json_file:
-            json.dump(json_schema, json_file, ensure_ascii=False, indent=2)
+        output_file = folder_path / f"{item}.json"
+        output_file.write_text(json.dumps(json_schema, ensure_ascii=False, indent=2), encoding="utf-8")
 
 
 def main() -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,6 +116,7 @@ dev = [
     "ruff>=0.14.11",
     "types-defusedxml (>=0.7.0.20250822, <0.8.0)",
     "opencv-python-headless>=4.6.0.66,<5.0.0.0",
+    "universal-pathlib>=0.3.10",
 ]
 constraints = [
     'pandas (>=2.1.4,<3.0.0); python_version < "3.11"',

--- a/test/test_upath_support.py
+++ b/test/test_upath_support.py
@@ -21,15 +21,16 @@ def memory_base():
 # =============================================================================
 
 
-def test_is_remote_path_local_paths_return_false():
+def test_is_remote_path():
+    """Test is_remote_path() function with various path types."""
+    # Local paths should return False
     assert is_remote_path(Path("/local/path")) is False
     assert is_remote_path(Path(".")) is False
     assert is_remote_path(None) is False
     assert is_remote_path("/some/path") is False
     assert is_remote_path(object()) is False
 
-
-def test_is_remote_path_file_protocol_returns_false():
+    # File protocol should return False
     class MockFilePath:
         protocol = "file"
 
@@ -39,17 +40,16 @@ def test_is_remote_path_file_protocol_returns_false():
     assert is_remote_path(MockFilePath()) is False
     assert is_remote_path(MockEmptyProtocol()) is False
 
+    # Cloud protocols should return True
+    for protocol in ["s3", "gcs", "az", "http", "https"]:
 
-@pytest.mark.parametrize("protocol", ["s3", "gcs", "az", "http", "https"])
-def test_is_remote_path_cloud_protocols_return_true(protocol):
-    class MockCloudPath:
-        pass
+        class MockCloudPath:
+            pass
 
-    MockCloudPath.protocol = protocol
-    assert is_remote_path(MockCloudPath()) is True
+        MockCloudPath.protocol = protocol
+        assert is_remote_path(MockCloudPath()) is True
 
-
-def test_is_remote_path_real_upath():
+    # Real UPath objects
     assert is_remote_path(UPath("/tmp/test")) is False
     assert is_remote_path(UPath("memory://test/path")) is True
 
@@ -59,19 +59,19 @@ def test_is_remote_path_real_upath():
 # =============================================================================
 
 
-def test_relative_path_basic():
+def test_relative_path():
+    """Test relative_path() function with various scenarios."""
+    # Basic relative path computation
     assert relative_path(Path("/a/b"), Path("/a/b/c/d.txt")) == Path("c/d.txt")
     assert relative_path("/a/b", "/a/b/c.txt") == Path("c.txt")
 
-
-def test_relative_path_navigation():
+    # Navigation with parent directories
     # Sibling directory
     assert relative_path(Path("/a/b/c"), Path("/a/b/d/e.txt")) == Path("../d/e.txt")
     # Parent directory
     assert relative_path(Path("/a/b/c/d"), Path("/a/b/e.txt")) == Path("../../e.txt")
 
-
-def test_relative_path_with_upath():
+    # UPath with local file protocol
     src = UPath("/home/user/docs")
     target = UPath("/home/user/docs/images/img.png")
     assert relative_path(src, target) == Path("images/img.png")
@@ -82,74 +82,62 @@ def test_relative_path_with_upath():
 # =============================================================================
 
 
-def test_upath_json_roundtrip(sample_doc, memory_base):
-    path = memory_base / "doc.json"
-    sample_doc.save_as_json(path)
-    assert path.exists()
-
-    loaded = DoclingDocument.load_from_json(path)
-    assert sample_doc.export_to_dict() == loaded.export_to_dict()
-
-
-def test_upath_yaml_roundtrip(sample_doc, memory_base):
-    path = memory_base / "doc.yaml"
-    sample_doc.save_as_yaml(path)
-    assert path.exists()
-
-    loaded = DoclingDocument.load_from_yaml(path)
-    assert sample_doc.export_to_dict() == loaded.export_to_dict()
-
-
-def test_upath_markdown(sample_doc, memory_base):
-    path = memory_base / "doc.md"
-    sample_doc.save_as_markdown(path)
-    assert path.exists()
-    assert len(path.read_text()) > 0
-
-
-def test_upath_html(sample_doc, memory_base):
-    path = memory_base / "doc.html"
-    sample_doc.save_as_html(path)
-    assert path.exists()
-    assert "<html" in path.read_text().lower()
-
-
-def test_upath_doctags(sample_doc, memory_base):
-    path = memory_base / "doc.dt"
-    sample_doc.save_as_doctags(path)
-    assert path.exists()
-
-
-def test_upath_referenced_mode(sample_doc, memory_base):
+def test_upath_integration(sample_doc, memory_base):
+    """Test UPath integration with various document operations."""
+    # JSON roundtrip
     json_path = memory_base / "doc.json"
-    artifacts_dir = memory_base / "artifacts"
-
-    sample_doc.save_as_json(json_path, artifacts_dir=artifacts_dir, image_mode=ImageRefMode.REFERENCED)
+    sample_doc.save_as_json(json_path)
     assert json_path.exists()
+    loaded = DoclingDocument.load_from_json(json_path)
+    assert sample_doc.export_to_dict() == loaded.export_to_dict()
 
+    # YAML roundtrip
+    yaml_path = memory_base / "doc.yaml"
+    sample_doc.save_as_yaml(yaml_path)
+    assert yaml_path.exists()
+    loaded = DoclingDocument.load_from_yaml(yaml_path)
+    assert sample_doc.export_to_dict() == loaded.export_to_dict()
 
-def test_upath_referenced_images_use_string_uri(sample_doc, memory_base):
+    # Markdown export
+    md_path = memory_base / "doc.md"
+    sample_doc.save_as_markdown(md_path)
+    assert md_path.exists()
+    assert len(md_path.read_text()) > 0
+
+    # HTML export
+    html_path = memory_base / "doc.html"
+    sample_doc.save_as_html(html_path)
+    assert html_path.exists()
+    assert "<html" in html_path.read_text().lower()
+
+    # Doctags export
+    dt_path = memory_base / "doc.dt"
+    sample_doc.save_as_doctags(dt_path)
+    assert dt_path.exists()
+
+    # Referenced mode
+    json_ref_path = memory_base / "doc_ref.json"
+    artifacts_dir = memory_base / "artifacts"
+    sample_doc.save_as_json(json_ref_path, artifacts_dir=artifacts_dir, image_mode=ImageRefMode.REFERENCED)
+    assert json_ref_path.exists()
+
+    # Referenced images use string URI
     image_dir = memory_base / "images"
     doc_with_refs = sample_doc._with_pictures_refs(image_dir=image_dir, page_no=None)
-
     for pic in doc_with_refs.pictures:
         if pic.image is not None and pic.image.uri is not None:
             # For remote storage, URI should not be a UPath (can't serialize)
             assert not is_remote_path(pic.image.uri)
 
+    # Nested path support
+    nested_path = memory_base / "a" / "b" / "c" / "doc.json"
+    sample_doc.save_as_json(nested_path)
+    assert nested_path.exists()
 
-def test_upath_nested_path(sample_doc, memory_base):
-    path = memory_base / "a" / "b" / "c" / "doc.json"
-    sample_doc.save_as_json(path)
-    assert path.exists()
-
-
-def test_upath_empty_document(memory_base):
-    doc = DoclingDocument(name="Empty")
-    path = memory_base / "empty.json"
-
-    doc.save_as_json(path)
-    loaded = DoclingDocument.load_from_json(path)
-
-    assert loaded.name == "Empty"
-    assert len(loaded.texts) == 0
+    # Empty document
+    empty_doc = DoclingDocument(name="Empty")
+    empty_path = memory_base / "empty.json"
+    empty_doc.save_as_json(empty_path)
+    loaded_empty = DoclingDocument.load_from_json(empty_path)
+    assert loaded_empty.name == "Empty"
+    assert len(loaded_empty.texts) == 0

--- a/test/test_upath_support.py
+++ b/test/test_upath_support.py
@@ -4,9 +4,13 @@ import uuid
 from pathlib import Path
 
 import pytest
+from PIL import Image as PILImage
+from pydantic import AnyUrl
 from upath import UPath
 
 from docling_core.types.doc import DoclingDocument, ImageRefMode
+from docling_core.types.doc.base import Size
+from docling_core.types.doc.document import ImageRef
 from docling_core.types.doc.utils import is_remote_path, relative_path
 
 
@@ -141,3 +145,38 @@ def test_upath_integration(sample_doc, memory_base):
     loaded_empty = DoclingDocument.load_from_json(empty_path)
     assert loaded_empty.name == "Empty"
     assert len(loaded_empty.texts) == 0
+
+
+def test_upath_include_page_images(memory_base):
+    """Test _with_pictures_refs() with include_page_images=True on a remote path.
+
+    Ensures that page images are saved via BytesIO (UPath-compatible) and that
+    page.image.uri is stored as an AnyUrl, not a Path, for remote storage.
+    """
+    page_img = PILImage.new("RGB", (64, 64), "blue")
+    image_ref = ImageRef.from_pil(image=page_img, dpi=72)
+
+    doc = DoclingDocument(name="PageImageDoc")
+    doc.add_page(page_no=1, size=Size(width=64, height=64), image=image_ref)
+
+    image_dir = memory_base / "page_images"
+
+    result = doc._with_pictures_refs(
+        image_dir=image_dir,
+        page_no=None,
+        include_page_images=True,
+    )
+
+    # The image directory must have been created and contain the page image file
+    assert image_dir.exists()
+    saved_files = list(image_dir.iterdir())
+    assert len(saved_files) == 1, "Expected exactly one page image to be saved"
+    assert saved_files[0].name.endswith(".png")
+
+    # For a remote path the URI must be an AnyUrl, not a plain Path or UPath,
+    # so that the document remains JSON-serialisable
+    page = result.pages[1]
+    assert page.image is not None
+    assert page.image.uri is not None
+    assert isinstance(page.image.uri, AnyUrl), f"Expected AnyUrl for remote page image URI, got {type(page.image.uri)}"
+    assert not is_remote_path(page.image.uri)

--- a/test/test_upath_support.py
+++ b/test/test_upath_support.py
@@ -20,6 +20,7 @@ def memory_base():
 # Tests for is_remote_path()
 # =============================================================================
 
+
 def test_is_remote_path_local_paths_return_false():
     assert is_remote_path(Path("/local/path")) is False
     assert is_remote_path(Path(".")) is False
@@ -52,6 +53,7 @@ def test_is_remote_path_real_upath():
     assert is_remote_path(UPath("/tmp/test")) is False
     assert is_remote_path(UPath("memory://test/path")) is True
 
+
 # =============================================================================
 # Tests for relative_path()
 # =============================================================================
@@ -73,6 +75,7 @@ def test_relative_path_with_upath():
     src = UPath("/home/user/docs")
     target = UPath("/home/user/docs/images/img.png")
     assert relative_path(src, target) == Path("images/img.png")
+
 
 # =============================================================================
 # UPath integration tests (memory filesystem)

--- a/test/test_upath_support.py
+++ b/test/test_upath_support.py
@@ -1,0 +1,173 @@
+"""Tests for UPath/fsspec support for cloud storage compatibility."""
+
+import uuid
+from pathlib import Path
+
+import pytest
+
+from docling_core.types.doc import DoclingDocument, ImageRefMode
+from docling_core.types.doc.utils import is_remote_path, relative_path
+
+# Check if universal-pathlib is available
+try:
+    from upath import UPath
+
+    HAS_UPATH = True
+except ImportError:
+    HAS_UPATH = False
+
+
+@pytest.fixture
+def memory_base():
+    """Provide a unique memory:// base path for each test."""
+    return UPath(f"memory://test-{uuid.uuid4()}")
+
+
+# =============================================================================
+# Tests for is_remote_path()
+# =============================================================================
+
+
+def test_is_remote_path_local_paths_return_false():
+    assert is_remote_path(Path("/local/path")) is False
+    assert is_remote_path(Path(".")) is False
+    assert is_remote_path(None) is False
+    assert is_remote_path("/some/path") is False
+    assert is_remote_path(object()) is False
+
+
+def test_is_remote_path_file_protocol_returns_false():
+    class MockFilePath:
+        protocol = "file"
+
+    class MockEmptyProtocol:
+        protocol = ""
+
+    assert is_remote_path(MockFilePath()) is False
+    assert is_remote_path(MockEmptyProtocol()) is False
+
+
+@pytest.mark.parametrize("protocol", ["s3", "gcs", "az", "http", "https"])
+def test_is_remote_path_cloud_protocols_return_true(protocol):
+    class MockCloudPath:
+        pass
+
+    MockCloudPath.protocol = protocol
+    assert is_remote_path(MockCloudPath()) is True
+
+
+@pytest.mark.skipif(not HAS_UPATH, reason="universal-pathlib not installed")
+def test_is_remote_path_real_upath():
+    assert is_remote_path(UPath("/tmp/test")) is False
+    assert is_remote_path(UPath("memory://test/path")) is True
+
+
+# =============================================================================
+# Tests for relative_path()
+# =============================================================================
+
+
+def test_relative_path_basic():
+    assert relative_path(Path("/a/b"), Path("/a/b/c/d.txt")) == Path("c/d.txt")
+    assert relative_path("/a/b", "/a/b/c.txt") == Path("c.txt")
+
+
+def test_relative_path_navigation():
+    # Sibling directory
+    assert relative_path(Path("/a/b/c"), Path("/a/b/d/e.txt")) == Path("../d/e.txt")
+    # Parent directory
+    assert relative_path(Path("/a/b/c/d"), Path("/a/b/e.txt")) == Path("../../e.txt")
+
+
+@pytest.mark.skipif(not HAS_UPATH, reason="universal-pathlib not installed")
+def test_relative_path_with_upath():
+    src = UPath("/home/user/docs")
+    target = UPath("/home/user/docs/images/img.png")
+    assert relative_path(src, target) == Path("images/img.png")
+
+
+# =============================================================================
+# UPath integration tests (memory filesystem)
+# =============================================================================
+
+
+@pytest.mark.skipif(not HAS_UPATH, reason="universal-pathlib not installed")
+def test_upath_json_roundtrip(sample_doc, memory_base):
+    path = memory_base / "doc.json"
+    sample_doc.save_as_json(path)
+    assert path.exists()
+
+    loaded = DoclingDocument.load_from_json(path)
+    assert sample_doc.export_to_dict() == loaded.export_to_dict()
+
+
+@pytest.mark.skipif(not HAS_UPATH, reason="universal-pathlib not installed")
+def test_upath_yaml_roundtrip(sample_doc, memory_base):
+    path = memory_base / "doc.yaml"
+    sample_doc.save_as_yaml(path)
+    assert path.exists()
+
+    loaded = DoclingDocument.load_from_yaml(path)
+    assert sample_doc.export_to_dict() == loaded.export_to_dict()
+
+
+@pytest.mark.skipif(not HAS_UPATH, reason="universal-pathlib not installed")
+def test_upath_markdown(sample_doc, memory_base):
+    path = memory_base / "doc.md"
+    sample_doc.save_as_markdown(path)
+    assert path.exists()
+    assert len(path.read_text()) > 0
+
+
+@pytest.mark.skipif(not HAS_UPATH, reason="universal-pathlib not installed")
+def test_upath_html(sample_doc, memory_base):
+    path = memory_base / "doc.html"
+    sample_doc.save_as_html(path)
+    assert path.exists()
+    assert "<html" in path.read_text().lower()
+
+
+@pytest.mark.skipif(not HAS_UPATH, reason="universal-pathlib not installed")
+def test_upath_doctags(sample_doc, memory_base):
+    path = memory_base / "doc.dt"
+    sample_doc.save_as_doctags(path)
+    assert path.exists()
+
+
+@pytest.mark.skipif(not HAS_UPATH, reason="universal-pathlib not installed")
+def test_upath_referenced_mode(sample_doc, memory_base):
+    json_path = memory_base / "doc.json"
+    artifacts_dir = memory_base / "artifacts"
+
+    sample_doc.save_as_json(json_path, artifacts_dir=artifacts_dir, image_mode=ImageRefMode.REFERENCED)
+    assert json_path.exists()
+
+
+@pytest.mark.skipif(not HAS_UPATH, reason="universal-pathlib not installed")
+def test_upath_referenced_images_use_string_uri(sample_doc, memory_base):
+    image_dir = memory_base / "images"
+    doc_with_refs = sample_doc._with_pictures_refs(image_dir=image_dir, page_no=None)
+
+    for pic in doc_with_refs.pictures:
+        if pic.image is not None and pic.image.uri is not None:
+            # For remote storage, URI should not be a UPath (can't serialize)
+            assert not is_remote_path(pic.image.uri)
+
+
+@pytest.mark.skipif(not HAS_UPATH, reason="universal-pathlib not installed")
+def test_upath_nested_path(sample_doc, memory_base):
+    path = memory_base / "a" / "b" / "c" / "doc.json"
+    sample_doc.save_as_json(path)
+    assert path.exists()
+
+
+@pytest.mark.skipif(not HAS_UPATH, reason="universal-pathlib not installed")
+def test_upath_empty_document(memory_base):
+    doc = DoclingDocument(name="Empty")
+    path = memory_base / "empty.json"
+
+    doc.save_as_json(path)
+    loaded = DoclingDocument.load_from_json(path)
+
+    assert loaded.name == "Empty"
+    assert len(loaded.texts) == 0

--- a/test/test_upath_support.py
+++ b/test/test_upath_support.py
@@ -4,17 +4,10 @@ import uuid
 from pathlib import Path
 
 import pytest
+from upath import UPath
 
 from docling_core.types.doc import DoclingDocument, ImageRefMode
 from docling_core.types.doc.utils import is_remote_path, relative_path
-
-# Check if universal-pathlib is available
-try:
-    from upath import UPath
-
-    HAS_UPATH = True
-except ImportError:
-    HAS_UPATH = False
 
 
 @pytest.fixture
@@ -26,7 +19,6 @@ def memory_base():
 # =============================================================================
 # Tests for is_remote_path()
 # =============================================================================
-
 
 def test_is_remote_path_local_paths_return_false():
     assert is_remote_path(Path("/local/path")) is False
@@ -56,11 +48,9 @@ def test_is_remote_path_cloud_protocols_return_true(protocol):
     assert is_remote_path(MockCloudPath()) is True
 
 
-@pytest.mark.skipif(not HAS_UPATH, reason="universal-pathlib not installed")
 def test_is_remote_path_real_upath():
     assert is_remote_path(UPath("/tmp/test")) is False
     assert is_remote_path(UPath("memory://test/path")) is True
-
 
 # =============================================================================
 # Tests for relative_path()
@@ -79,19 +69,16 @@ def test_relative_path_navigation():
     assert relative_path(Path("/a/b/c/d"), Path("/a/b/e.txt")) == Path("../../e.txt")
 
 
-@pytest.mark.skipif(not HAS_UPATH, reason="universal-pathlib not installed")
 def test_relative_path_with_upath():
     src = UPath("/home/user/docs")
     target = UPath("/home/user/docs/images/img.png")
     assert relative_path(src, target) == Path("images/img.png")
-
 
 # =============================================================================
 # UPath integration tests (memory filesystem)
 # =============================================================================
 
 
-@pytest.mark.skipif(not HAS_UPATH, reason="universal-pathlib not installed")
 def test_upath_json_roundtrip(sample_doc, memory_base):
     path = memory_base / "doc.json"
     sample_doc.save_as_json(path)
@@ -101,7 +88,6 @@ def test_upath_json_roundtrip(sample_doc, memory_base):
     assert sample_doc.export_to_dict() == loaded.export_to_dict()
 
 
-@pytest.mark.skipif(not HAS_UPATH, reason="universal-pathlib not installed")
 def test_upath_yaml_roundtrip(sample_doc, memory_base):
     path = memory_base / "doc.yaml"
     sample_doc.save_as_yaml(path)
@@ -111,7 +97,6 @@ def test_upath_yaml_roundtrip(sample_doc, memory_base):
     assert sample_doc.export_to_dict() == loaded.export_to_dict()
 
 
-@pytest.mark.skipif(not HAS_UPATH, reason="universal-pathlib not installed")
 def test_upath_markdown(sample_doc, memory_base):
     path = memory_base / "doc.md"
     sample_doc.save_as_markdown(path)
@@ -119,7 +104,6 @@ def test_upath_markdown(sample_doc, memory_base):
     assert len(path.read_text()) > 0
 
 
-@pytest.mark.skipif(not HAS_UPATH, reason="universal-pathlib not installed")
 def test_upath_html(sample_doc, memory_base):
     path = memory_base / "doc.html"
     sample_doc.save_as_html(path)
@@ -127,14 +111,12 @@ def test_upath_html(sample_doc, memory_base):
     assert "<html" in path.read_text().lower()
 
 
-@pytest.mark.skipif(not HAS_UPATH, reason="universal-pathlib not installed")
 def test_upath_doctags(sample_doc, memory_base):
     path = memory_base / "doc.dt"
     sample_doc.save_as_doctags(path)
     assert path.exists()
 
 
-@pytest.mark.skipif(not HAS_UPATH, reason="universal-pathlib not installed")
 def test_upath_referenced_mode(sample_doc, memory_base):
     json_path = memory_base / "doc.json"
     artifacts_dir = memory_base / "artifacts"
@@ -143,7 +125,6 @@ def test_upath_referenced_mode(sample_doc, memory_base):
     assert json_path.exists()
 
 
-@pytest.mark.skipif(not HAS_UPATH, reason="universal-pathlib not installed")
 def test_upath_referenced_images_use_string_uri(sample_doc, memory_base):
     image_dir = memory_base / "images"
     doc_with_refs = sample_doc._with_pictures_refs(image_dir=image_dir, page_no=None)
@@ -154,14 +135,12 @@ def test_upath_referenced_images_use_string_uri(sample_doc, memory_base):
             assert not is_remote_path(pic.image.uri)
 
 
-@pytest.mark.skipif(not HAS_UPATH, reason="universal-pathlib not installed")
 def test_upath_nested_path(sample_doc, memory_base):
     path = memory_base / "a" / "b" / "c" / "doc.json"
     sample_doc.save_as_json(path)
     assert path.exists()
 
 
-@pytest.mark.skipif(not HAS_UPATH, reason="universal-pathlib not installed")
 def test_upath_empty_document(memory_base):
     doc = DoclingDocument(name="Empty")
     path = memory_base / "empty.json"

--- a/uv.lock
+++ b/uv.lock
@@ -1057,6 +1057,7 @@ dev = [
     { name = "tree-sitter-java-orchard" },
     { name = "types-defusedxml" },
     { name = "types-setuptools" },
+    { name = "universal-pathlib" },
 ]
 
 [package.metadata]
@@ -1115,6 +1116,7 @@ dev = [
     { name = "tree-sitter-java-orchard", marker = "python_full_version >= '3.10'", specifier = ">=0.3.0,<1.0.0" },
     { name = "types-defusedxml", specifier = ">=0.7.0.20250822,<0.8.0" },
     { name = "types-setuptools", specifier = "~=70.3" },
+    { name = "universal-pathlib", specifier = ">=0.3.10" },
 ]
 
 [[package]]
@@ -2974,6 +2976,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/30/4b/90c937815137d43ce71ba043cd3566221e9df6b9c805f24b5d138c9d40a7/parso-0.8.7.tar.gz", hash = "sha256:eaaac4c9fdd5e9e8852dc778d2d7405897ec510f2a298071453e5e3a07914bb1", size = 401824, upload-time = "2026-05-01T23:13:02.138Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/99/5d/8268b644392ee874ee82a635cd0df1773de230bde356c38de28e298392cc/parso-0.8.7-py2.py3-none-any.whl", hash = "sha256:a8926eb2a1b915486941fdbd31e86a4baf88fe8c210f25f2f35ecec5b574ca1c", size = 107025, upload-time = "2026-05-01T23:12:58.867Z" },
+]
+
+[[package]]
+name = "pathlib-abc"
+version = "0.5.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/cb/448649d7f25d228bf0be3a04590ab7afa77f15e056f8fa976ed05ec9a78f/pathlib_abc-0.5.2.tar.gz", hash = "sha256:fcd56f147234645e2c59c7ae22808b34c364bb231f685ddd9f96885aed78a94c", size = 33342, upload-time = "2025-10-10T18:37:20.524Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b1/29/c028a0731e202035f0e2e0bfbf1a3e46ad6c628cbb17f6f1cc9eea5d9ff1/pathlib_abc-0.5.2-py3-none-any.whl", hash = "sha256:4c9d94cf1b23af417ce7c0417b43333b06a106c01000b286c99de230d95eefbb", size = 19070, upload-time = "2025-10-10T18:37:19.437Z" },
 ]
 
 [[package]]
@@ -4898,6 +4909,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ba/19/1b9b0e29f30c6d35cb345486df41110984ea67ae69dddbc0e8a100999493/tzdata-2026.2.tar.gz", hash = "sha256:9173fde7d80d9018e02a662e168e5a2d04f87c41ea174b139fbef642eda62d10", size = 198254, upload-time = "2026-04-24T15:22:08.651Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl", hash = "sha256:bbe9af844f658da81a5f95019480da3a89415801f6cc966806612cc7169bffe7", size = 349321, upload-time = "2026-04-24T15:22:05.876Z" },
+]
+
+[[package]]
+name = "universal-pathlib"
+version = "0.3.10"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "fsspec" },
+    { name = "pathlib-abc" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3d/6e/d997a70ee8f4c61f9a7e2f4f8af721cf072a3326848fc881b05187e52558/universal_pathlib-0.3.10.tar.gz", hash = "sha256:4487cbc90730a48cfb64f811d99e14b6faed6d738420cd5f93f59f48e6930bfb", size = 261110, upload-time = "2026-02-22T14:40:58.87Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dd/1a/5d9a402b39ec892d856bbdd9db502ff73ce28cdf4aff72eb1ce1d6843506/universal_pathlib-0.3.10-py3-none-any.whl", hash = "sha256:dfaf2fb35683d2eb1287a3ed7b215e4d6016aa6eaf339c607023d22f90821c66", size = 83528, upload-time = "2026-02-22T14:40:57.316Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -3534,16 +3534,16 @@ wheels = [
 
 [[package]]
 name = "pydantic-settings"
-version = "2.14.1"
+version = "2.14.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
     { name = "python-dotenv" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/07/60/1d1e59c9c90d54591469ada7d268251f71c24bdb765f1a8a832cee8c6653/pydantic_settings-2.14.1.tar.gz", hash = "sha256:e874d3bec7e787b0c9958277956ed9b4dd5de6a80e162188fdaff7c5e26fd5fa", size = 235551, upload-time = "2026-05-08T13:40:06.542Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/b5/8f48e906c3e0205276e8bd8cb7512217a87b2685304d64be27cad5b3019f/pydantic_settings-2.14.2.tar.gz", hash = "sha256:c19dd64b19097f1de80184f0cc7b0272a13ae6e170cbf240a3e27e381ed14a5f", size = 237700, upload-time = "2026-06-19T13:44:56.324Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ae/8d/f1af3832f5e6eb13ba94ee809e72b8ecb5eef226d27ee0bef7d963d943c7/pydantic_settings-2.14.1-py3-none-any.whl", hash = "sha256:6e3c7edfd8277687cdc598f56e5cff0e9bfff0910a3749deaa8d4401c3a2b9de", size = 60964, upload-time = "2026-05-08T13:40:04.958Z" },
+    { url = "https://files.pythonhosted.org/packages/77/c1/6e422f34e569cf8e18df68d1939c81c099d2b61e4f7d9621c8a77560799c/pydantic_settings-2.14.2-py3-none-any.whl", hash = "sha256:a20c97b37910b6550d5ea50fbcc2d4187defe58cd57070b73863d069419c9440", size = 61715, upload-time = "2026-06-19T13:44:55.02Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Great project! Thank you :)

Here is a quick and dirty AI sketchup to resolve #443 - still need some tests and polish, but wanted to get some initial feedback. Is this something you're interested in? Is there anything missed?

Cheers :)

some manual test code, instal upath with `pip install universal_pathlib` 
```python
"""
Test if UPath works with Docling's save_as_json artifacts_dir parameter.

Usage:
1. Start MinIO: docker run -d \
    --name minio \
    -p 9000:9000 \
    -p 9001:9001 \
    -e MINIO_ROOT_USER=minioadmin \
    -e MINIO_ROOT_PASSWORD=minioadmin \
    minio/minio server /data --console-address ":9001"
2. Run: python test_upath_save.py
"""

import os
from pathlib import Path

from upath import UPath
from docling_core.types.doc import DoclingDocument, ImageRefMode

from docling.datamodel.base_models import InputFormat
from docling.datamodel.pipeline_options import PdfPipelineOptions
from docling.document_converter import DocumentConverter, PdfFormatOption


def test_type_compatibility():
    """Check if UPath passes isinstance checks."""
    local_path = Path("/tmp/test")
    s3_path = UPath("s3://bucket/test")

    print("=== Type Compatibility ===")
    print(f"Path instance check:     isinstance(Path(...), Path) = {isinstance(local_path, Path)}")
    print(f"UPath instance check:    isinstance(UPath(...), Path) = {isinstance(s3_path, Path)}")
    print(f"UPath has write_bytes:   {hasattr(s3_path, 'write_bytes')}")
    print(f"UPath has mkdir:         {hasattr(s3_path, 'mkdir')}")
    print(f"UPath has __truediv__:   {hasattr(s3_path, '__truediv__')}")
    print()


def convert_doc():
    """Convert a PDF with picture images enabled."""
    pipeline_options = PdfPipelineOptions()
    pipeline_options.generate_page_images = True
    pipeline_options.generate_picture_images = True

    converter = DocumentConverter(
        format_options={
            InputFormat.PDF: PdfFormatOption(pipeline_options=pipeline_options)
        }
    )

    result = converter.convert("../tests/data/pdf/2206.01062.pdf")
    return result.document


def test_local_path(doc: DoclingDocument):
    """Test save_as_json with regular Path."""
    print("=== Test: Local Path ===")
    output_dir = Path("scratch/local_test")
    output_dir.mkdir(parents=True, exist_ok=True)

    json_path = output_dir / "doc.json"
    artifacts_dir = output_dir / "images"

    try:
        doc.save_as_json(
            json_path,
            artifacts_dir=artifacts_dir,
            image_mode=ImageRefMode.REFERENCED
        )
        print(f"SUCCESS: Saved to {json_path}")
        print(f"  Images dir: {artifacts_dir}")
        if artifacts_dir.exists():
            images = list(artifacts_dir.glob("*.png"))
            print(f"  Image count: {len(images)}")
    except Exception as e:
        print(f"FAILED: {e}")
    print()


def test_upath_local(doc: DoclingDocument):
    """Test save_as_json with UPath (local filesystem)."""
    print("=== Test: UPath Local ===")
    output_dir = UPath("scratch/upath_local_test")
    output_dir.mkdir(parents=True, exist_ok=True)

    json_path = output_dir / "doc.json"
    artifacts_dir = output_dir / "images"

    try:
        doc.save_as_json(
            json_path,
            artifacts_dir=artifacts_dir,
            image_mode=ImageRefMode.REFERENCED
        )
        print(f"SUCCESS: Saved to {json_path}")
        print(f"  Images dir: {artifacts_dir}")
        if artifacts_dir.exists():
            images = list(artifacts_dir.glob("*.png"))
            print(f"  Image count: {len(images)}")
    except TypeError as e:
        print(f"TYPE ERROR (expected if Path type check fails): {e}")
    except Exception as e:
        print(f"FAILED: {type(e).__name__}: {e}")
    print()


def test_upath_s3(doc: DoclingDocument):
    """Test save_as_json with UPath pointing to MinIO/S3."""
    print("=== Test: UPath S3 (MinIO) ===")

    # Configure for local MinIO
    os.environ["AWS_ACCESS_KEY_ID"] = "minioadmin"
    os.environ["AWS_SECRET_ACCESS_KEY"] = "minioadmin"
    os.environ["AWS_ENDPOINT_URL"] = "http://localhost:9000"

    # Create bucket first
    bucket_path = UPath("s3://docling-test")
    try:
        bucket_path.mkdir(exist_ok=True)
        print(f"  Created bucket: {bucket_path}")
    except Exception as e:
        print(f"  Bucket creation: {e}")

    output_dir = UPath("s3://docling-test/output")
    json_path = output_dir / "doc.json"
    artifacts_dir = output_dir / "images"

    try:
        doc.save_as_json(
            json_path,
            artifacts_dir=artifacts_dir,
            image_mode=ImageRefMode.REFERENCED
        )
        print(f"SUCCESS: Saved to {json_path}")
        print(f"  Images dir: {artifacts_dir}")

        # List saved files
        print("  Files in S3:")
        for f in output_dir.glob("**/*"):
            if f.is_file():
                print(f"    {f}")
    except TypeError as e:
        print(f"TYPE ERROR (expected if Path type check fails): {e}")
    except Exception as e:
        print(f"FAILED: {type(e).__name__}: {e}")
    print()


def test_upath_s3_roundtrip(doc: DoclingDocument):
    """Test saving and loading document from S3."""
    print("=== Test: UPath S3 Round-trip ===")

    # Configure for local MinIO
    os.environ["AWS_ACCESS_KEY_ID"] = "minioadmin"
    os.environ["AWS_SECRET_ACCESS_KEY"] = "minioadmin"
    os.environ["AWS_ENDPOINT_URL"] = "http://localhost:9000"

    output_dir = UPath("s3://docling-test/roundtrip")
    json_path = output_dir / "doc.json"
    yaml_path = output_dir / "doc.yaml"

    try:
        # Save as JSON
        doc.save_as_json(json_path, image_mode=ImageRefMode.EMBEDDED)
        print(f"  Saved JSON to: {json_path}")

        # Save as YAML
        doc.save_as_yaml(yaml_path, image_mode=ImageRefMode.EMBEDDED)
        print(f"  Saved YAML to: {yaml_path}")

        # Load back from JSON
        loaded_json = DoclingDocument.load_from_json(json_path)
        print(f"  Loaded from JSON: {loaded_json.name}")
        print(f"    Pages: {len(loaded_json.pages)}, Pictures: {len(loaded_json.pictures)}")

        # Load back from YAML
        loaded_yaml = DoclingDocument.load_from_yaml(yaml_path)
        print(f"  Loaded from YAML: {loaded_yaml.name}")
        print(f"    Pages: {len(loaded_yaml.pages)}, Pictures: {len(loaded_yaml.pictures)}")

        # Verify content matches
        assert len(loaded_json.pages) == len(doc.pages), "Page count mismatch (JSON)"
        assert len(loaded_yaml.pages) == len(doc.pages), "Page count mismatch (YAML)"
        assert len(loaded_json.pictures) == len(doc.pictures), "Picture count mismatch (JSON)"
        assert len(loaded_yaml.pictures) == len(doc.pictures), "Picture count mismatch (YAML)"

        print("SUCCESS: Round-trip verified!")
    except Exception as e:
        print(f"FAILED: {type(e).__name__}: {e}")
        import traceback
        traceback.print_exc()
    print()


def test_manual_upath_save(doc: DoclingDocument):
    """If native doesn't work, test manual save with UPath."""
    print("=== Test: Manual UPath S3 Save ===")

    os.environ["AWS_ACCESS_KEY_ID"] = "minioadmin"
    os.environ["AWS_SECRET_ACCESS_KEY"] = "minioadmin"
    os.environ["AWS_ENDPOINT_URL"] = "http://localhost:9000"

    output_dir = UPath("s3://docling-test/manual")

    try:
        output_dir.mkdir(parents=True, exist_ok=True)

        # Save JSON locally first, then upload
        import json
        json_content = doc.model_dump_json(indent=2)
        json_path = output_dir / "doc.json"
        json_path.write_text(json_content)
        print(f"  Saved JSON to: {json_path}")

        # Save images manually
        for i, picture in enumerate(doc.pictures[:3]):  # First 3
            if picture.image and picture.image.pil_image:
                from io import BytesIO
                buf = BytesIO()
                picture.image.pil_image.save(buf, format="PNG")
                img_path = output_dir / f"picture_{i}.png"
                img_path.write_bytes(buf.getvalue())
                print(f"  Saved image: {img_path}")

        print("SUCCESS: Manual save worked")
    except Exception as e:
        print(f"FAILED: {type(e).__name__}: {e}")
    print()


if __name__ == "__main__":
    test_type_compatibility()

    print("Converting document...")
    doc = convert_doc()
    print(f"Document has {len(doc.pages)} pages, {len(doc.pictures)} pictures\n")

    test_local_path(doc)
    test_upath_local(doc)
    test_upath_s3(doc)
    test_upath_s3_roundtrip(doc)
    test_manual_upath_save(doc)
```