### PR TITLE
fix: Remove Extra Space Before and After Group Items

### DIFF
--- a/docling_core/transforms/serializer/html.py
+++ b/docling_core/transforms/serializer/html.py
@@ -871,7 +871,7 @@ class HTMLInlineSerializer(BaseInlineSerializer):
         )
 
         # Join all parts without separators
-        inline_html = " ".join([p.text for p in parts if p.text])
+        inline_html = "".join([p.text for p in parts if p.text])
 
         # Wrap in span if needed
         if inline_html:

--- a/docling_core/transforms/serializer/markdown.py
+++ b/docling_core/transforms/serializer/markdown.py
@@ -803,7 +803,7 @@ class MarkdownInlineSerializer(BaseInlineSerializer):
             visited=my_visited,
             **kwargs,
         )
-        text_res = " ".join([p.text for p in parts if p.text])
+        text_res = "".join([p.text for p in parts if p.text])
         return create_ser_result(text=text_res, span_source=parts)
 
 

--- a/test/data/doc/2408.09869v3_enriched_p2_p3_p5.gt.html
+++ b/test/data/doc/2408.09869v3_enriched_p2_p3_p5.gt.html
@@ -105,7 +105,7 @@
 <li style="list-style-type: '· ';">Can leverage different accelerators (GPU, MPS, etc).</li>
 </ul>
 <h2>2 Getting Started</h2>
-<span class='inline-group'>To use Docling, you can simply install the docling package from PyPI. Documentation and examples are available in our GitHub repository at  <a href="https://github.com/DS4SD/docling">github.com/DS4SD/docling</a> . All required model assets 1 are downloaded to a local huggingface datasets cache on first use, unless you choose to pre-install the model assets in advance.</span>
+<span class='inline-group'>To use Docling, you can simply install the docling package from PyPI. Documentation and examples are available in our GitHub repository at <a href="https://github.com/DS4SD/docling">github.com/DS4SD/docling</a>. All required model assets 1 are downloaded to a local huggingface datasets cache on first use, unless you choose to pre-install the model assets in advance.</span>
 <p>Docling provides an easy code interface to convert PDF documents from file system, URLs or binary streams, and retrieve the output in either JSON or Markdown format. For convenience, separate methods are offered to convert single documents or batches of documents. A basic usage example is illustrated below. Further examples are available in the Doclign code repository.</p>
 <pre><code>from docling.document_converter import DocumentConverter Large</code></pre>
 <pre><code>source = "https://arxiv.org/pdf/2206.01062" # PDF path or URL converter = DocumentConverter() result = converter.convert_single(source) print(result.render_as_markdown()) # output: "## DocLayNet: A Human -Annotated Dataset for Document -Layout Analysis [...]"</code></pre>

--- a/test/data/doc/2408.09869v3_enriched_split_p2.gt.html
+++ b/test/data/doc/2408.09869v3_enriched_split_p2.gt.html
@@ -106,7 +106,7 @@
 <li style="list-style-type: '· ';">Can leverage different accelerators (GPU, MPS, etc).</li>
 </ul>
 <h2>2 Getting Started</h2>
-<span class='inline-group'>To use Docling, you can simply install the docling package from PyPI. Documentation and examples are available in our GitHub repository at  <a href="https://github.com/DS4SD/docling">github.com/DS4SD/docling</a> . All required model assets 1 are downloaded to a local huggingface datasets cache on first use, unless you choose to pre-install the model assets in advance.</span>
+<span class='inline-group'>To use Docling, you can simply install the docling package from PyPI. Documentation and examples are available in our GitHub repository at <a href="https://github.com/DS4SD/docling">github.com/DS4SD/docling</a>. All required model assets 1 are downloaded to a local huggingface datasets cache on first use, unless you choose to pre-install the model assets in advance.</span>
 <p>Docling provides an easy code interface to convert PDF documents from file system, URLs or binary streams, and retrieve the output in either JSON or Markdown format. For convenience, separate methods are offered to convert single documents or batches of documents. A basic usage example is illustrated below. Further examples are available in the Doclign code repository.</p>
 <pre><code>from docling.document_converter import DocumentConverter Large</code></pre>
 <pre><code>source = "https://arxiv.org/pdf/2206.01062" # PDF path or URL converter = DocumentConverter() result = converter.convert_single(source) print(result.render_as_markdown()) # output: "## DocLayNet: A Human -Annotated Dataset for Document -Layout Analysis [...]"</code></pre>

--- a/test/data/doc/constructed_doc.embedded.html.gt
+++ b/test/data/doc/constructed_doc.embedded.html.gt
@@ -167,10 +167,10 @@ item 2 of neighboring list
 <ul>
 <li style="list-style-type: '□ ';">item 1 of sub list</li>
 <li style="list-style-type: '□ ';">
-<span class='inline-group'>Here a code snippet: <code>print("Hello world")</code> (to be displayed inline)</span>
+<span class='inline-group'>Here a code snippet:<code>print("Hello world")</code>(to be displayed inline)</span>
 </li>
 <li style="list-style-type: '□ ';">
-<span class='inline-group'>Here a formula: <math xmlns="http://www.w3.org/1998/Math/MathML" display="inline"><mrow><mi>E</mi><mo>&#x0003D;</mo><mi>m</mi><msup><mi>c</mi><mn>2</mn></msup></mrow><annotation encoding="TeX">E=mc^2</annotation></math> (to be displayed inline)</span>
+<span class='inline-group'>Here a formula:<math xmlns="http://www.w3.org/1998/Math/MathML" display="inline"><mrow><mi>E</mi><mo>&#x0003D;</mo><mi>m</mi><msup><mi>c</mi><mn>2</mn></msup></mrow><annotation encoding="TeX">E=mc^2</annotation></math>(to be displayed inline)</span>
 </li>
 </ul>
 </li>
@@ -191,7 +191,7 @@ item 2 of neighboring list
 
 </ul>
 </div>
-<span class='inline-group'>Some formatting chops: <strong>bold</strong> <em>italic</em> <u>underline</u> <del>strikethrough</del> <sub>subscript</sub> <sup>superscript</sup> <a href=".">hyperlink</a> &amp; <a href="https://github.com/DS4SD/docling"><del><u><em><strong>everything at the same time.</strong></em></u></del></a></span>
+<span class='inline-group'>Some formatting chops:<strong>bold</strong><em>italic</em><u>underline</u><del>strikethrough</del><sub>subscript</sub><sup>superscript</sup><a href=".">hyperlink</a>&amp;<a href="https://github.com/DS4SD/docling"><del><u><em><strong>everything at the same time.</strong></em></u></del></a></span>
 <ol>
 <li style="list-style-type: '(i) ';">Item 1 in A</li>
 <li style="list-style-type: '(ii) ';">Item 2 in A</li>

--- a/test/data/doc/constructed_doc.embedded.md.gt
+++ b/test/data/doc/constructed_doc.embedded.md.gt
@@ -44,8 +44,8 @@ This is the caption of figure 2.
 - item 1 of neighboring list
 - item 2 of neighboring list
     - item 1 of sub list
-    - Here a code snippet: `print("Hello world")` (to be displayed inline)
-    - Here a formula: $E=mc^2$ (to be displayed inline)
+    - Here a code snippet:`print("Hello world")`(to be displayed inline)
+    - Here a formula:$E=mc^2$(to be displayed inline)
 
 Here a code block:
 
@@ -61,7 +61,7 @@ $$E=mc^2$$
 
 <!-- missing-form-item -->
 
-Some formatting chops: **bold** *italic* underline ~~strikethrough~~ subscript superscript [hyperlink](.) &amp; [~~***everything at the same time.***~~](https://github.com/DS4SD/docling)
+Some formatting chops:**bold***italic*underline~~strikethrough~~subscriptsuperscript[hyperlink](.)&amp;[~~***everything at the same time.***~~](https://github.com/DS4SD/docling)
 
 - (i) Item 1 in A
 - (ii) Item 2 in A

--- a/test/data/doc/constructed_doc.placeholder.html.gt
+++ b/test/data/doc/constructed_doc.placeholder.html.gt
@@ -167,10 +167,10 @@ item 2 of neighboring list
 <ul>
 <li style="list-style-type: '□ ';">item 1 of sub list</li>
 <li style="list-style-type: '□ ';">
-<span class='inline-group'>Here a code snippet: <code>print("Hello world")</code> (to be displayed inline)</span>
+<span class='inline-group'>Here a code snippet:<code>print("Hello world")</code>(to be displayed inline)</span>
 </li>
 <li style="list-style-type: '□ ';">
-<span class='inline-group'>Here a formula: <math xmlns="http://www.w3.org/1998/Math/MathML" display="inline"><mrow><mi>E</mi><mo>&#x0003D;</mo><mi>m</mi><msup><mi>c</mi><mn>2</mn></msup></mrow><annotation encoding="TeX">E=mc^2</annotation></math> (to be displayed inline)</span>
+<span class='inline-group'>Here a formula:<math xmlns="http://www.w3.org/1998/Math/MathML" display="inline"><mrow><mi>E</mi><mo>&#x0003D;</mo><mi>m</mi><msup><mi>c</mi><mn>2</mn></msup></mrow><annotation encoding="TeX">E=mc^2</annotation></math>(to be displayed inline)</span>
 </li>
 </ul>
 </li>
@@ -191,7 +191,7 @@ item 2 of neighboring list
 
 </ul>
 </div>
-<span class='inline-group'>Some formatting chops: <strong>bold</strong> <em>italic</em> <u>underline</u> <del>strikethrough</del> <sub>subscript</sub> <sup>superscript</sup> <a href=".">hyperlink</a> &amp; <a href="https://github.com/DS4SD/docling"><del><u><em><strong>everything at the same time.</strong></em></u></del></a></span>
+<span class='inline-group'>Some formatting chops:<strong>bold</strong><em>italic</em><u>underline</u><del>strikethrough</del><sub>subscript</sub><sup>superscript</sup><a href=".">hyperlink</a>&amp;<a href="https://github.com/DS4SD/docling"><del><u><em><strong>everything at the same time.</strong></em></u></del></a></span>
 <ol>
 <li style="list-style-type: '(i) ';">Item 1 in A</li>
 <li style="list-style-type: '(ii) ';">Item 2 in A</li>

--- a/test/data/doc/constructed_doc.placeholder.md.gt
+++ b/test/data/doc/constructed_doc.placeholder.md.gt
@@ -44,8 +44,8 @@ This is the caption of figure 2.
 - item 1 of neighboring list
 - item 2 of neighboring list
     - item 1 of sub list
-    - Here a code snippet: `print("Hello world")` (to be displayed inline)
-    - Here a formula: $E=mc^2$ (to be displayed inline)
+    - Here a code snippet:`print("Hello world")`(to be displayed inline)
+    - Here a formula:$E=mc^2$(to be displayed inline)
 
 Here a code block:
 
@@ -61,7 +61,7 @@ $$E=mc^2$$
 
 <!-- missing-form-item -->
 
-Some formatting chops: **bold** *italic* underline ~~strikethrough~~ subscript superscript [hyperlink](.) &amp; [~~***everything at the same time.***~~](https://github.com/DS4SD/docling)
+Some formatting chops:**bold***italic*underline~~strikethrough~~subscriptsuperscript[hyperlink](.)&amp;[~~***everything at the same time.***~~](https://github.com/DS4SD/docling)
 
 - (i) Item 1 in A
 - (ii) Item 2 in A

--- a/test/data/doc/constructed_doc.referenced.html.gt
+++ b/test/data/doc/constructed_doc.referenced.html.gt
@@ -167,10 +167,10 @@ item 2 of neighboring list
 <ul>
 <li style="list-style-type: '□ ';">item 1 of sub list</li>
 <li style="list-style-type: '□ ';">
-<span class='inline-group'>Here a code snippet: <code>print("Hello world")</code> (to be displayed inline)</span>
+<span class='inline-group'>Here a code snippet:<code>print("Hello world")</code>(to be displayed inline)</span>
 </li>
 <li style="list-style-type: '□ ';">
-<span class='inline-group'>Here a formula: <math xmlns="http://www.w3.org/1998/Math/MathML" display="inline"><mrow><mi>E</mi><mo>&#x0003D;</mo><mi>m</mi><msup><mi>c</mi><mn>2</mn></msup></mrow><annotation encoding="TeX">E=mc^2</annotation></math> (to be displayed inline)</span>
+<span class='inline-group'>Here a formula:<math xmlns="http://www.w3.org/1998/Math/MathML" display="inline"><mrow><mi>E</mi><mo>&#x0003D;</mo><mi>m</mi><msup><mi>c</mi><mn>2</mn></msup></mrow><annotation encoding="TeX">E=mc^2</annotation></math>(to be displayed inline)</span>
 </li>
 </ul>
 </li>
@@ -191,7 +191,7 @@ item 2 of neighboring list
 
 </ul>
 </div>
-<span class='inline-group'>Some formatting chops: <strong>bold</strong> <em>italic</em> <u>underline</u> <del>strikethrough</del> <sub>subscript</sub> <sup>superscript</sup> <a href=".">hyperlink</a> &amp; <a href="https://github.com/DS4SD/docling"><del><u><em><strong>everything at the same time.</strong></em></u></del></a></span>
+<span class='inline-group'>Some formatting chops:<strong>bold</strong><em>italic</em><u>underline</u><del>strikethrough</del><sub>subscript</sub><sup>superscript</sup><a href=".">hyperlink</a>&amp;<a href="https://github.com/DS4SD/docling"><del><u><em><strong>everything at the same time.</strong></em></u></del></a></span>
 <ol>
 <li style="list-style-type: '(i) ';">Item 1 in A</li>
 <li style="list-style-type: '(ii) ';">Item 2 in A</li>

--- a/test/data/doc/constructed_doc.referenced.md.gt
+++ b/test/data/doc/constructed_doc.referenced.md.gt
@@ -44,8 +44,8 @@ This is the caption of figure 2.
 - item 1 of neighboring list
 - item 2 of neighboring list
     - item 1 of sub list
-    - Here a code snippet: `print("Hello world")` (to be displayed inline)
-    - Here a formula: $E=mc^2$ (to be displayed inline)
+    - Here a code snippet:`print("Hello world")`(to be displayed inline)
+    - Here a formula:$E=mc^2$(to be displayed inline)
 
 Here a code block:
 
@@ -61,7 +61,7 @@ $$E=mc^2$$
 
 <!-- missing-form-item -->
 
-Some formatting chops: **bold** *italic* underline ~~strikethrough~~ subscript superscript [hyperlink](.) &amp; [~~***everything at the same time.***~~](https://github.com/DS4SD/docling)
+Some formatting chops:**bold***italic*underline~~strikethrough~~subscriptsuperscript[hyperlink](.)&amp;[~~***everything at the same time.***~~](https://github.com/DS4SD/docling)
 
 - (i) Item 1 in A
 - (ii) Item 2 in A

--- a/test/data/doc/constructed_document.yaml.html
+++ b/test/data/doc/constructed_document.yaml.html
@@ -167,10 +167,10 @@ item 2 of neighboring list
 <ul>
 <li style="list-style-type: '□ ';">item 1 of sub list</li>
 <li style="list-style-type: '□ ';">
-<span class='inline-group'>Here a code snippet: <code>print("Hello world")</code> (to be displayed inline)</span>
+<span class='inline-group'>Here a code snippet:<code>print("Hello world")</code>(to be displayed inline)</span>
 </li>
 <li style="list-style-type: '□ ';">
-<span class='inline-group'>Here a formula: <math xmlns="http://www.w3.org/1998/Math/MathML" display="inline"><mrow><mi>E</mi><mo>&#x0003D;</mo><mi>m</mi><msup><mi>c</mi><mn>2</mn></msup></mrow><annotation encoding="TeX">E=mc^2</annotation></math> (to be displayed inline)</span>
+<span class='inline-group'>Here a formula:<math xmlns="http://www.w3.org/1998/Math/MathML" display="inline"><mrow><mi>E</mi><mo>&#x0003D;</mo><mi>m</mi><msup><mi>c</mi><mn>2</mn></msup></mrow><annotation encoding="TeX">E=mc^2</annotation></math>(to be displayed inline)</span>
 </li>
 </ul>
 </li>
@@ -191,7 +191,7 @@ item 2 of neighboring list
 
 </ul>
 </div>
-<span class='inline-group'>Some formatting chops: <strong>bold</strong> <em>italic</em> <u>underline</u> <del>strikethrough</del> <sub>subscript</sub> <sup>superscript</sup> <a href=".">hyperlink</a> &amp; <a href="https://github.com/DS4SD/docling"><del><u><em><strong>everything at the same time.</strong></em></u></del></a></span>
+<span class='inline-group'>Some formatting chops:<strong>bold</strong><em>italic</em><u>underline</u><del>strikethrough</del><sub>subscript</sub><sup>superscript</sup><a href=".">hyperlink</a>&amp;<a href="https://github.com/DS4SD/docling"><del><u><em><strong>everything at the same time.</strong></em></u></del></a></span>
 <ol>
 <li style="list-style-type: '(i) ';">Item 1 in A</li>
 <li style="list-style-type: '(ii) ';">Item 2 in A</li>

--- a/test/data/doc/constructed_document.yaml.md
+++ b/test/data/doc/constructed_document.yaml.md
@@ -44,8 +44,8 @@ This is the caption of figure 2.
 - item 1 of neighboring list
 - item 2 of neighboring list
     - item 1 of sub list
-    - Here a code snippet: `print("Hello world")` (to be displayed inline)
-    - Here a formula: $E=mc^2$ (to be displayed inline)
+    - Here a code snippet:`print("Hello world")`(to be displayed inline)
+    - Here a formula:$E=mc^2$(to be displayed inline)
 
 Here a code block:
 
@@ -61,7 +61,7 @@ $$E=mc^2$$
 
 <!-- missing-form-item -->
 
-Some formatting chops: **bold** *italic* underline ~~strikethrough~~ subscript superscript [hyperlink](.) &amp; [~~***everything at the same time.***~~](https://github.com/DS4SD/docling)
+Some formatting chops:**bold***italic*underline~~strikethrough~~subscriptsuperscript[hyperlink](.)&amp;[~~***everything at the same time.***~~](https://github.com/DS4SD/docling)
 
 - (i) Item 1 in A
 - (ii) Item 2 in A

--- a/test/data/doc/constructed_legacy_annot_mark_false.gt.md
+++ b/test/data/doc/constructed_legacy_annot_mark_false.gt.md
@@ -46,8 +46,8 @@ This is the caption of figure 2.
 - item 1 of neighboring list
 - item 2 of neighboring list
     - item 1 of sub list
-    - Here a code snippet: `print("Hello world")` (to be displayed inline)
-    - Here a formula: $E=mc^2$ (to be displayed inline)
+    - Here a code snippet:`print("Hello world")`(to be displayed inline)
+    - Here a formula:$E=mc^2$(to be displayed inline)
 
 Here a code block:
 
@@ -63,7 +63,7 @@ $$E=mc^2$$
 
 <!-- missing-form-item -->
 
-Some formatting chops: **bold** *italic* underline ~~strikethrough~~ subscript superscript [hyperlink](.) &amp; [~~***everything at the same time.***~~](https://github.com/DS4SD/docling)
+Some formatting chops:**bold***italic*underline~~strikethrough~~subscriptsuperscript[hyperlink](.)&amp;[~~***everything at the same time.***~~](https://github.com/DS4SD/docling)
 
 - (i) Item 1 in A
 - (ii) Item 2 in A

--- a/test/data/doc/constructed_legacy_annot_mark_true.gt.md
+++ b/test/data/doc/constructed_legacy_annot_mark_true.gt.md
@@ -46,8 +46,8 @@ This is the caption of figure 2.
 - item 1 of neighboring list
 - item 2 of neighboring list
     - item 1 of sub list
-    - Here a code snippet: `print("Hello world")` (to be displayed inline)
-    - Here a formula: $E=mc^2$ (to be displayed inline)
+    - Here a code snippet:`print("Hello world")`(to be displayed inline)
+    - Here a formula:$E=mc^2$(to be displayed inline)
 
 Here a code block:
 
@@ -63,7 +63,7 @@ $$E=mc^2$$
 
 <!-- missing-form-item -->
 
-Some formatting chops: **bold** *italic* underline ~~strikethrough~~ subscript superscript [hyperlink](.) &amp; [~~***everything at the same time.***~~](https://github.com/DS4SD/docling)
+Some formatting chops:**bold***italic*underline~~strikethrough~~subscriptsuperscript[hyperlink](.)&amp;[~~***everything at the same time.***~~](https://github.com/DS4SD/docling)
 
 - (i) Item 1 in A
 - (ii) Item 2 in A

--- a/test/data/doc/constructed_mode_always_valid_false.gt.md
+++ b/test/data/doc/constructed_mode_always_valid_false.gt.md
@@ -44,8 +44,8 @@ item 2 of list after empty list
 ■ item 1 of neighboring list
 ■ item 2 of neighboring list
     □ item 1 of sub list
-    □ Here a code snippet: `print("Hello world")` (to be displayed inline)
-    □ Here a formula: $E=mc^2$ (to be displayed inline)
+    □ Here a code snippet:`print("Hello world")`(to be displayed inline)
+    □ Here a formula:$E=mc^2$(to be displayed inline)
 
 Here a code block:
 
@@ -61,7 +61,7 @@ $$E=mc^2$$
 
 <!-- missing-form-item -->
 
-Some formatting chops: **bold** *italic* underline ~~strikethrough~~ subscript superscript [hyperlink](.) &amp; [~~***everything at the same time.***~~](https://github.com/DS4SD/docling)
+Some formatting chops:**bold***italic*underline~~strikethrough~~subscriptsuperscript[hyperlink](.)&amp;[~~***everything at the same time.***~~](https://github.com/DS4SD/docling)
 
 (i) Item 1 in A
 (ii) Item 2 in A

--- a/test/data/doc/constructed_mode_always_valid_true.gt.md
+++ b/test/data/doc/constructed_mode_always_valid_true.gt.md
@@ -44,8 +44,8 @@ This is the caption of figure 2.
 - ■ item 1 of neighboring list
 - ■ item 2 of neighboring list
     - □ item 1 of sub list
-    - □ Here a code snippet: `print("Hello world")` (to be displayed inline)
-    - □ Here a formula: $E=mc^2$ (to be displayed inline)
+    - □ Here a code snippet:`print("Hello world")`(to be displayed inline)
+    - □ Here a formula:$E=mc^2$(to be displayed inline)
 
 Here a code block:
 
@@ -61,7 +61,7 @@ $$E=mc^2$$
 
 <!-- missing-form-item -->
 
-Some formatting chops: **bold** *italic* underline ~~strikethrough~~ subscript superscript [hyperlink](.) &amp; [~~***everything at the same time.***~~](https://github.com/DS4SD/docling)
+Some formatting chops:**bold***italic*underline~~strikethrough~~subscriptsuperscript[hyperlink](.)&amp;[~~***everything at the same time.***~~](https://github.com/DS4SD/docling)
 
 1. (i) Item 1 in A
 2. (ii) Item 2 in A

--- a/test/data/doc/constructed_mode_auto_valid_false.gt.md
+++ b/test/data/doc/constructed_mode_auto_valid_false.gt.md
@@ -44,8 +44,8 @@ item 2 of list after empty list
 item 1 of neighboring list
 item 2 of neighboring list
     item 1 of sub list
-    Here a code snippet: `print("Hello world")` (to be displayed inline)
-    Here a formula: $E=mc^2$ (to be displayed inline)
+    Here a code snippet:`print("Hello world")`(to be displayed inline)
+    Here a formula:$E=mc^2$(to be displayed inline)
 
 Here a code block:
 
@@ -61,7 +61,7 @@ $$E=mc^2$$
 
 <!-- missing-form-item -->
 
-Some formatting chops: **bold** *italic* underline ~~strikethrough~~ subscript superscript [hyperlink](.) &amp; [~~***everything at the same time.***~~](https://github.com/DS4SD/docling)
+Some formatting chops:**bold***italic*underline~~strikethrough~~subscriptsuperscript[hyperlink](.)&amp;[~~***everything at the same time.***~~](https://github.com/DS4SD/docling)
 
 (i) Item 1 in A
 (ii) Item 2 in A

--- a/test/data/doc/constructed_mode_auto_valid_true.gt.md
+++ b/test/data/doc/constructed_mode_auto_valid_true.gt.md
@@ -44,8 +44,8 @@ This is the caption of figure 2.
 - item 1 of neighboring list
 - item 2 of neighboring list
     - item 1 of sub list
-    - Here a code snippet: `print("Hello world")` (to be displayed inline)
-    - Here a formula: $E=mc^2$ (to be displayed inline)
+    - Here a code snippet:`print("Hello world")`(to be displayed inline)
+    - Here a formula:$E=mc^2$(to be displayed inline)
 
 Here a code block:
 
@@ -61,7 +61,7 @@ $$E=mc^2$$
 
 <!-- missing-form-item -->
 
-Some formatting chops: **bold** *italic* underline ~~strikethrough~~ subscript superscript [hyperlink](.) &amp; [~~***everything at the same time.***~~](https://github.com/DS4SD/docling)
+Some formatting chops:**bold***italic*underline~~strikethrough~~subscriptsuperscript[hyperlink](.)&amp;[~~***everything at the same time.***~~](https://github.com/DS4SD/docling)
 
 - (i) Item 1 in A
 - (ii) Item 2 in A

--- a/test/data/doc/constructed_mode_never_valid_false.gt.md
+++ b/test/data/doc/constructed_mode_never_valid_false.gt.md
@@ -44,8 +44,8 @@ item 2 of list after empty list
 item 1 of neighboring list
 item 2 of neighboring list
     item 1 of sub list
-    Here a code snippet: `print("Hello world")` (to be displayed inline)
-    Here a formula: $E=mc^2$ (to be displayed inline)
+    Here a code snippet:`print("Hello world")`(to be displayed inline)
+    Here a formula:$E=mc^2$(to be displayed inline)
 
 Here a code block:
 
@@ -61,7 +61,7 @@ $$E=mc^2$$
 
 <!-- missing-form-item -->
 
-Some formatting chops: **bold** *italic* underline ~~strikethrough~~ subscript superscript [hyperlink](.) &amp; [~~***everything at the same time.***~~](https://github.com/DS4SD/docling)
+Some formatting chops:**bold***italic*underline~~strikethrough~~subscriptsuperscript[hyperlink](.)&amp;[~~***everything at the same time.***~~](https://github.com/DS4SD/docling)
 
 Item 1 in A
 Item 2 in A

--- a/test/data/doc/constructed_mode_never_valid_true.gt.md
+++ b/test/data/doc/constructed_mode_never_valid_true.gt.md
@@ -44,8 +44,8 @@ This is the caption of figure 2.
 - item 1 of neighboring list
 - item 2 of neighboring list
     - item 1 of sub list
-    - Here a code snippet: `print("Hello world")` (to be displayed inline)
-    - Here a formula: $E=mc^2$ (to be displayed inline)
+    - Here a code snippet:`print("Hello world")`(to be displayed inline)
+    - Here a formula:$E=mc^2$(to be displayed inline)
 
 Here a code block:
 
@@ -61,7 +61,7 @@ $$E=mc^2$$
 
 <!-- missing-form-item -->
 
-Some formatting chops: **bold** *italic* underline ~~strikethrough~~ subscript superscript [hyperlink](.) &amp; [~~***everything at the same time.***~~](https://github.com/DS4SD/docling)
+Some formatting chops:**bold***italic*underline~~strikethrough~~subscriptsuperscript[hyperlink](.)&amp;[~~***everything at the same time.***~~](https://github.com/DS4SD/docling)
 
 1. Item 1 in A
 2. Item 2 in A

--- a/test/data/doc/constructed_orig_false.gt.html
+++ b/test/data/doc/constructed_orig_false.gt.html
@@ -167,10 +167,10 @@ item 2 of neighboring list
 <ul>
 <li>item 1 of sub list</li>
 <li>
-<span class='inline-group'>Here a code snippet: <code>print("Hello world")</code> (to be displayed inline)</span>
+<span class='inline-group'>Here a code snippet:<code>print("Hello world")</code>(to be displayed inline)</span>
 </li>
 <li>
-<span class='inline-group'>Here a formula: <math xmlns="http://www.w3.org/1998/Math/MathML" display="inline"><mrow><mi>E</mi><mo>&#x0003D;</mo><mi>m</mi><msup><mi>c</mi><mn>2</mn></msup></mrow><annotation encoding="TeX">E=mc^2</annotation></math> (to be displayed inline)</span>
+<span class='inline-group'>Here a formula:<math xmlns="http://www.w3.org/1998/Math/MathML" display="inline"><mrow><mi>E</mi><mo>&#x0003D;</mo><mi>m</mi><msup><mi>c</mi><mn>2</mn></msup></mrow><annotation encoding="TeX">E=mc^2</annotation></math>(to be displayed inline)</span>
 </li>
 </ul>
 </li>
@@ -191,7 +191,7 @@ item 2 of neighboring list
 
 </ul>
 </div>
-<span class='inline-group'>Some formatting chops: <strong>bold</strong> <em>italic</em> <u>underline</u> <del>strikethrough</del> <sub>subscript</sub> <sup>superscript</sup> <a href=".">hyperlink</a> &amp; <a href="https://github.com/DS4SD/docling"><del><u><em><strong>everything at the same time.</strong></em></u></del></a></span>
+<span class='inline-group'>Some formatting chops:<strong>bold</strong><em>italic</em><u>underline</u><del>strikethrough</del><sub>subscript</sub><sup>superscript</sup><a href=".">hyperlink</a>&amp;<a href="https://github.com/DS4SD/docling"><del><u><em><strong>everything at the same time.</strong></em></u></del></a></span>
 <ol>
 <li>Item 1 in A</li>
 <li>Item 2 in A</li>

--- a/test/data/doc/constructed_orig_true.gt.html
+++ b/test/data/doc/constructed_orig_true.gt.html
@@ -167,10 +167,10 @@ item 2 of neighboring list
 <ul>
 <li style="list-style-type: '□ ';">item 1 of sub list</li>
 <li style="list-style-type: '□ ';">
-<span class='inline-group'>Here a code snippet: <code>print("Hello world")</code> (to be displayed inline)</span>
+<span class='inline-group'>Here a code snippet:<code>print("Hello world")</code>(to be displayed inline)</span>
 </li>
 <li style="list-style-type: '□ ';">
-<span class='inline-group'>Here a formula: <math xmlns="http://www.w3.org/1998/Math/MathML" display="inline"><mrow><mi>E</mi><mo>&#x0003D;</mo><mi>m</mi><msup><mi>c</mi><mn>2</mn></msup></mrow><annotation encoding="TeX">E=mc^2</annotation></math> (to be displayed inline)</span>
+<span class='inline-group'>Here a formula:<math xmlns="http://www.w3.org/1998/Math/MathML" display="inline"><mrow><mi>E</mi><mo>&#x0003D;</mo><mi>m</mi><msup><mi>c</mi><mn>2</mn></msup></mrow><annotation encoding="TeX">E=mc^2</annotation></math>(to be displayed inline)</span>
 </li>
 </ul>
 </li>
@@ -191,7 +191,7 @@ item 2 of neighboring list
 
 </ul>
 </div>
-<span class='inline-group'>Some formatting chops: <strong>bold</strong> <em>italic</em> <u>underline</u> <del>strikethrough</del> <sub>subscript</sub> <sup>superscript</sup> <a href=".">hyperlink</a> &amp; <a href="https://github.com/DS4SD/docling"><del><u><em><strong>everything at the same time.</strong></em></u></del></a></span>
+<span class='inline-group'>Some formatting chops:<strong>bold</strong><em>italic</em><u>underline</u><del>strikethrough</del><sub>subscript</sub><sup>superscript</sup><a href=".">hyperlink</a>&amp;<a href="https://github.com/DS4SD/docling"><del><u><em><strong>everything at the same time.</strong></em></u></del></a></span>
 <ol>
 <li style="list-style-type: '(i) ';">Item 1 in A</li>
 <li style="list-style-type: '(ii) ';">Item 2 in A</li>

--- a/test/data/doc/inline_and_formatting.gt.html
+++ b/test/data/doc/inline_and_formatting.gt.html
@@ -126,31 +126,31 @@
 <div class='page'>
 <h1>Contribution guideline example</h1>
 <p>This is simple.</p>
-<span class='inline-group'>Foo <em>emphasis</em> <strong>strong emphasis</strong> <em><strong>both</strong></em> .</span>
-<span class='inline-group'>Create your feature branch: <code>git checkout -b feature/AmazingFeature</code> .</span>
+<span class='inline-group'>Foo<em>emphasis</em><strong>strong emphasis</strong><em><strong>both</strong></em>.</span>
+<span class='inline-group'>Create your feature branch:<code>git checkout -b feature/AmazingFeature</code>.</span>
 <ol>
 <li style="list-style-type: '1. ';">
-<span class='inline-group'>Pull the <a href="https://github.com/docling-project/docling"><strong>repository</strong></a> .</span>
+<span class='inline-group'>Pull the<a href="https://github.com/docling-project/docling"><strong>repository</strong></a>.</span>
 </li>
 <li style="list-style-type: '2. ';">
-<span class='inline-group'>Create your feature branch ( <code>git checkout -b feature/AmazingFeature</code> )</span>
+<span class='inline-group'>Create your feature branch (<code>git checkout -b feature/AmazingFeature</code>)</span>
 </li>
 <li style="list-style-type: '3. ';">
-<span class='inline-group'>Commit your changes ( <code>git commit -m 'Add some AmazingFeature'</code> )</span>
+<span class='inline-group'>Commit your changes (<code>git commit -m 'Add some AmazingFeature'</code>)</span>
 </li>
 <li style="list-style-type: '4. ';">
-<span class='inline-group'>Push to the branch ( <code>git push origin feature/AmazingFeature</code> )</span>
+<span class='inline-group'>Push to the branch (<code>git push origin feature/AmazingFeature</code>)</span>
 </li>
 <li style="list-style-type: '5. ';">Open a Pull Request</li>
 <li style="list-style-type: '6. ';"><strong>Whole list item has same formatting</strong></li>
 <li style="list-style-type: '7. ';">
-<span class='inline-group'>List item has <em>mixed or partial</em> formatting</span>
+<span class='inline-group'>List item has<em>mixed or partial</em>formatting</span>
 </li>
 </ol>
 <em><h1>Whole heading is italic</h1></em>
-<span class='inline-group'>Some <em><code>formatted_code</code></em></span>
-<h2><span class='inline-group'><em>Partially formatted</em> heading to_escape <code>not_to_escape</code> <a href="https://en.wikipedia.org/wiki/Albert_Einstein"><math xmlns="http://www.w3.org/1998/Math/MathML" display="inline"><mrow><mi>E</mi><mo>&#x0003D;</mo><mi>m</mi><msup><mi>c</mi><mn>2</mn></msup></mrow><annotation encoding="TeX">E=mc^2</annotation></math></a> &amp; ampersand</span></h2>
-<span class='inline-group'>A hyperlink on <a href="#link"><code>code in a line</code></a></span>
+<span class='inline-group'>Some<em><code>formatted_code</code></em></span>
+<h2><span class='inline-group'><em>Partially formatted</em>heading to_escape<code>not_to_escape</code><a href="https://en.wikipedia.org/wiki/Albert_Einstein"><math xmlns="http://www.w3.org/1998/Math/MathML" display="inline"><mrow><mi>E</mi><mo>&#x0003D;</mo><mi>m</mi><msup><mi>c</mi><mn>2</mn></msup></mrow><annotation encoding="TeX">E=mc^2</annotation></math></a>&amp; ampersand</span></h2>
+<span class='inline-group'>A hyperlink on<a href="#link"><code>code in a line</code></a></span>
 <a href="#test"><pre><code>A hyperlink on code as paragraph</code></pre></a>
 <p>The end.</p>
 </div>

--- a/test/data/doc/inline_and_formatting.gt.md
+++ b/test/data/doc/inline_and_formatting.gt.md
@@ -2,25 +2,25 @@
 
 This is simple.
 
-Foo *emphasis* **strong emphasis** ***both*** .
+Foo*emphasis***strong emphasis*****both***.
 
-Create your feature branch: `git checkout -b feature/AmazingFeature` .
+Create your feature branch:`git checkout -b feature/AmazingFeature`.
 
-1. Pull the [**repository**](https://github.com/docling-project/docling) .
-2. Create your feature branch ( `git checkout -b feature/AmazingFeature` )
-3. Commit your changes ( `git commit -m 'Add some AmazingFeature'` )
-4. Push to the branch ( `git push origin feature/AmazingFeature` )
+1. Pull the[**repository**](https://github.com/docling-project/docling).
+2. Create your feature branch (`git checkout -b feature/AmazingFeature`)
+3. Commit your changes (`git commit -m 'Add some AmazingFeature'`)
+4. Push to the branch (`git push origin feature/AmazingFeature`)
 5. Open a Pull Request
 6. **Whole list item has same formatting**
-7. List item has *mixed or partial* formatting
+7. List item has*mixed or partial*formatting
 
 # *Whole heading is italic*
 
-Some *`formatted_code`*
+Some*`formatted_code`*
 
-## *Partially formatted* heading to\_escape `not_to_escape` [$E=mc^2$](https://en.wikipedia.org/wiki/Albert_Einstein) &amp; ampersand
+## *Partially formatted*heading to\_escape`not_to_escape`[$E=mc^2$](https://en.wikipedia.org/wiki/Albert_Einstein)&amp; ampersand
 
-A hyperlink on [`code in a line`](#link)
+A hyperlink on[`code in a line`](#link)
 
 [`A hyperlink on code as paragraph`](#test)
 

--- a/test/data/doc/polymers.gt.html
+++ b/test/data/doc/polymers.gt.html
@@ -188,10 +188,10 @@
 <span class='inline-group'><strong>Extraction in food simulants</strong></span>
 <ul>
 <li>
-<span class='inline-group'><em>What it is</em> : Samples of the packaging material are immersed in a liquid that mimics the chemical properties of a specific food type (e.g., aqueous, acidic, fatty).</span>
+<span class='inline-group'><em>What it is</em>: Samples of the packaging material are immersed in a liquid that mimics the chemical properties of a specific food type (e.g., aqueous, acidic, fatty).</span>
 </li>
 <li>
-<span class='inline-group'><em>Typical simulants</em> :</span>
+<span class='inline-group'><em>Typical simulants</em>:</span>
 <ul>
 <li>3% acetic acid (for acidic foods)</li>
 <li>50% ethanol (for alcohol‑based foods)</li>
@@ -200,7 +200,7 @@
 </ul>
 </li>
 <li>
-<span class='inline-group'><em>Procedure</em> :</span>
+<span class='inline-group'><em>Procedure</em>:</span>
 <ul>
 <li>Prepare a defined volume of simulant in a sealed vessel.</li>
 <li>Immerse the material for a set time at a controlled temperature (often 50 °C–70 °C).</li>
@@ -208,13 +208,13 @@
 </ul>
 </li>
 <li>
-<span class='inline-group'><em>Analysis</em> : GC‑MS, LC‑MS, or HPLC depending on the analyte class.</span>
+<span class='inline-group'><em>Analysis</em>: GC‑MS, LC‑MS, or HPLC depending on the analyte class.</span>
 </li>
 <li>
-<span class='inline-group'><em>Advantages</em> : Direct assessment of potential migration into a realistic medium; scalable for routine testing.</span>
+<span class='inline-group'><em>Advantages</em>: Direct assessment of potential migration into a realistic medium; scalable for routine testing.</span>
 </li>
 <li>
-<span class='inline-group'><em>Limitations</em> : Does not account for headspace gas migration; may underestimate migration of highly volatile substances.</span>
+<span class='inline-group'><em>Limitations</em>: Does not account for headspace gas migration; may underestimate migration of highly volatile substances.</span>
 </li>
 </ul>
 </li>
@@ -222,10 +222,10 @@
 <span class='inline-group'><strong>Headspace analysis</strong></span>
 <ul>
 <li>
-<span class='inline-group'><em>What it is</em> : Measurement of volatile substances that migrate from the material into the surrounding gas phase.</span>
+<span class='inline-group'><em>What it is</em>: Measurement of volatile substances that migrate from the material into the surrounding gas phase.</span>
 </li>
 <li>
-<span class='inline-group'><em>Procedure</em> :</span>
+<span class='inline-group'><em>Procedure</em>:</span>
 <ul>
 <li>Seal the material in a headspace vial or chamber.</li>
 <li>Equilibrate at a defined temperature (commonly 25 °C–60 °C).</li>
@@ -234,13 +234,13 @@
 </ul>
 </li>
 <li>
-<span class='inline-group'><em>Applications</em> : Assessment of aromas, flavor compounds, or volatile contaminants.</span>
+<span class='inline-group'><em>Applications</em>: Assessment of aromas, flavor compounds, or volatile contaminants.</span>
 </li>
 <li>
-<span class='inline-group'><em>Advantages</em> : Sensitive to low‑concentration volatiles; minimal sample preparation.</span>
+<span class='inline-group'><em>Advantages</em>: Sensitive to low‑concentration volatiles; minimal sample preparation.</span>
 </li>
 <li>
-<span class='inline-group'><em>Limitations</em> : Does not capture non‑volatile migration; results depend on equilibrium time and temperature.</span>
+<span class='inline-group'><em>Limitations</em>: Does not capture non‑volatile migration; results depend on equilibrium time and temperature.</span>
 </li>
 </ul>
 </li>
@@ -248,10 +248,10 @@
 <span class='inline-group'><strong>Direct contact tests</strong></span>
 <ul>
 <li>
-<span class='inline-group'><em>What it is</em> : The packaging material is placed in direct contact with the food or food simulant, often using a defined food‑packaging configuration.</span>
+<span class='inline-group'><em>What it is</em>: The packaging material is placed in direct contact with the food or food simulant, often using a defined food‑packaging configuration.</span>
 </li>
 <li>
-<span class='inline-group'><em>Procedure</em> :</span>
+<span class='inline-group'><em>Procedure</em>:</span>
 <ul>
 <li>Assemble the material and food (or simulant) in a mold or container that simulates real usage (e.g., sealed pouch, jar).</li>
 <li>Incubate for the intended storage time at the relevant temperature.</li>
@@ -260,10 +260,10 @@
 </ul>
 </li>
 <li>
-<span class='inline-group'><em>Advantages</em> : Mimics real consumer exposure; captures both liquid and vapor migration pathways.</span>
+<span class='inline-group'><em>Advantages</em>: Mimics real consumer exposure; captures both liquid and vapor migration pathways.</span>
 </li>
 <li>
-<span class='inline-group'><em>Limitations</em> : More labor‑intensive; requires careful control of contact area, thickness, and sealing integrity.</span>
+<span class='inline-group'><em>Limitations</em>: More labor‑intensive; requires careful control of contact area, thickness, and sealing integrity.</span>
 </li>
 </ul>
 </li>

--- a/test/data/doc/polymers.gt.md
+++ b/test/data/doc/polymers.gt.md
@@ -50,38 +50,38 @@
 **Common migration testing methods**
 
 - **Extraction in food simulants**
-    - *What it is* : Samples of the packaging material are immersed in a liquid that mimics the chemical properties of a specific food type (e.g., aqueous, acidic, fatty).
-    - *Typical simulants* :
+    - *What it is*: Samples of the packaging material are immersed in a liquid that mimics the chemical properties of a specific food type (e.g., aqueous, acidic, fatty).
+    - *Typical simulants*:
         - 3% acetic acid (for acidic foods)
         - 50% ethanol (for alcohol‑based foods)
         - 95% ethanol (for high‑fat foods)
         - Distilled water (for aqueous foods)
-    - *Procedure* :
+    - *Procedure*:
         - Prepare a defined volume of simulant in a sealed vessel.
         - Immerse the material for a set time at a controlled temperature (often 50 °C–70 °C).
         - Remove, filter, and concentrate the extract for analysis.
-    - *Analysis* : GC‑MS, LC‑MS, or HPLC depending on the analyte class.
-    - *Advantages* : Direct assessment of potential migration into a realistic medium; scalable for routine testing.
-    - *Limitations* : Does not account for headspace gas migration; may underestimate migration of highly volatile substances.
+    - *Analysis*: GC‑MS, LC‑MS, or HPLC depending on the analyte class.
+    - *Advantages*: Direct assessment of potential migration into a realistic medium; scalable for routine testing.
+    - *Limitations*: Does not account for headspace gas migration; may underestimate migration of highly volatile substances.
 - **Headspace analysis**
-    - *What it is* : Measurement of volatile substances that migrate from the material into the surrounding gas phase.
-    - *Procedure* :
+    - *What it is*: Measurement of volatile substances that migrate from the material into the surrounding gas phase.
+    - *Procedure*:
         - Seal the material in a headspace vial or chamber.
         - Equilibrate at a defined temperature (commonly 25 °C–60 °C).
         - Sample the gas phase with a gas sampling needle or syringe.
         - Analyze via GC‑FID, GC‑MS, or PTR‑MS.
-    - *Applications* : Assessment of aromas, flavor compounds, or volatile contaminants.
-    - *Advantages* : Sensitive to low‑concentration volatiles; minimal sample preparation.
-    - *Limitations* : Does not capture non‑volatile migration; results depend on equilibrium time and temperature.
+    - *Applications*: Assessment of aromas, flavor compounds, or volatile contaminants.
+    - *Advantages*: Sensitive to low‑concentration volatiles; minimal sample preparation.
+    - *Limitations*: Does not capture non‑volatile migration; results depend on equilibrium time and temperature.
 - **Direct contact tests**
-    - *What it is* : The packaging material is placed in direct contact with the food or food simulant, often using a defined food‑packaging configuration.
-    - *Procedure* :
+    - *What it is*: The packaging material is placed in direct contact with the food or food simulant, often using a defined food‑packaging configuration.
+    - *Procedure*:
         - Assemble the material and food (or simulant) in a mold or container that simulates real usage (e.g., sealed pouch, jar).
         - Incubate for the intended storage time at the relevant temperature.
         - Extract or sample the food directly (e.g., through the material or by taking a portion of the food).
         - Analyze for migrated substances.
-    - *Advantages* : Mimics real consumer exposure; captures both liquid and vapor migration pathways.
-    - *Limitations* : More labor‑intensive; requires careful control of contact area, thickness, and sealing integrity.
+    - *Advantages*: Mimics real consumer exposure; captures both liquid and vapor migration pathways.
+    - *Limitations*: More labor‑intensive; requires careful control of contact area, thickness, and sealing integrity.
 
 These three approaches—extraction in food simulants, headspace analysis, and direct contact tests—complement each other to provide a comprehensive assessment of potential migration from packaging into food.
 

--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -28,6 +28,7 @@ from docling_core.types.doc.document import (
     DoclingDocument,
     RefItem,
     RichTableCell,
+    Formatting,
     TableCell,
     TableData,
     TextItem,
@@ -964,3 +965,151 @@ def test_webvtt_params():
     actual_default = ser_default.serialize().text
     assert len(actual) <= len(actual_default) or actual != actual_default
 
+    verify(exp_file=src.with_suffix(".gt.idt.xml"), actual=actual)
+
+
+# ===============================
+# Tests for inline group join behavior without spaces
+# ===============================
+
+
+def test_md_inline_group_no_spaces():
+    """Test that inline groups join text parts without spaces for continuous text."""
+    doc = DoclingDocument(name="test")
+
+    # Create an inline group with multiple text items that should be joined without spaces
+    # Simulating the case where "Docling" is split into "D" (bold) and "ocling" (normal)
+    group = doc.add_inline_group()
+    doc.add_text(
+        label="text",
+        parent=group,
+        text="D",
+        formatting=Formatting(bold=True, italic=False, underline=False, strikethrough=False, script="baseline")
+    )
+    doc.add_text(
+        label="text",
+        parent=group,
+        text="ocling",
+        formatting=Formatting(bold=False, italic=False, underline=False, strikethrough=False, script="baseline")
+    )
+
+    # This should serialize as "**D**ocling" without space
+    ser = MarkdownDocSerializer(doc=doc)
+    actual = ser.serialize().text.strip()
+
+    expected = "**D**ocling"
+    assert actual == expected
+
+
+def test_html_inline_group_no_spaces():
+    """Test that inline groups join text parts without spaces for continuous text."""
+    doc = DoclingDocument(name="test")
+
+    # Create an inline group with multiple text items that should be joined without spaces
+    group = doc.add_inline_group()
+    doc.add_text(
+        label="text",
+        parent=group,
+        text="Project",
+        formatting=Formatting(bold=True, italic=False, underline=False, strikethrough=False, script="baseline")
+    )
+    doc.add_text(
+        label="text",
+        parent=group,
+        text="ing",
+        formatting=Formatting(bold=False, italic=False, underline=False, strikethrough=False, script="baseline")
+    )
+
+    # This should serialize as <strong>Project</strong>ing without space
+    ser = HTMLDocSerializer(doc=doc, params=HTMLParams(html_head="<head></head>", prettify=False))
+    actual = ser.serialize().text
+
+    # Extract the body content between <body> and </body>
+    start = actual.find("<body>") + 6
+    end = actual.find("</body>")
+    body_content = actual[start:end].strip()
+
+    # Check that the span contains the expected content
+    assert '<strong>Project</strong>ing' in body_content
+
+
+
+
+def test_md_inline_group_mixed_formatting_mid_word():
+    """Test inline group with different formatting mid-word."""
+    doc = DoclingDocument(name="test")
+
+    # Simulate "Parsing" with "Pars" normal and "ing" italic
+    group = doc.add_inline_group()
+    doc.add_text(label="text", parent=group, text="Pars")
+    doc.add_text(
+        label="text",
+        parent=group,
+        text="ing",
+        formatting=Formatting(bold=False, italic=True, underline=False, strikethrough=False, script="baseline")
+    )
+
+    ser = MarkdownDocSerializer(doc=doc)
+    actual = ser.serialize().text.strip()
+
+    expected = "Pars*ing*"
+    assert actual == expected
+
+
+def test_html_inline_group_mixed_formatting_mid_word():
+    """Test inline group with different formatting mid-word."""
+    doc = DoclingDocument(name="test")
+
+    # Simulate "Parsing" with "Pars" normal and "ing" italic
+    group = doc.add_inline_group()
+    doc.add_text(label="text", parent=group, text="Pars")
+    doc.add_text(
+        label="text",
+        parent=group,
+        text="ing",
+        formatting=Formatting(bold=False, italic=True, underline=False, strikethrough=False, script="baseline")
+    )
+
+    ser = HTMLDocSerializer(doc=doc, params=HTMLParams(html_head="<head></head>", prettify=False))
+    actual = ser.serialize().text
+
+    # Extract the body content between <body> and </body>
+    start = actual.find("<body>") + 6
+    end = actual.find("</body>")
+    body_content = actual[start:end].strip()
+
+    # Check that both parts are present without spaces between
+    assert 'Pars<em>ing</em>' in body_content.replace('\n', ' ')
+
+
+def test_md_inline_group_single_part():
+    """Test inline group with single text part (no joining needed)."""
+    doc = DoclingDocument(name="test")
+
+    group = doc.add_inline_group()
+    doc.add_text(label="text", parent=group, text="Single")
+
+    ser = MarkdownDocSerializer(doc=doc)
+    actual = ser.serialize().text.strip()
+
+    expected = "Single"
+    assert actual == expected
+
+
+def test_html_inline_group_single_part():
+    """Test inline group with single text part (no joining needed)."""
+    doc = DoclingDocument(name="test")
+
+    group = doc.add_inline_group()
+    doc.add_text(label="text", parent=group, text="Single")
+
+    ser = HTMLDocSerializer(doc=doc, params=HTMLParams(html_head="<head></head>", prettify=False))
+    actual = ser.serialize().text
+
+    # Extract the body content between <body> and </body>
+    start = actual.find("<body>") + 6
+    end = actual.find("</body>")
+    body_content = actual[start:end].strip()
+
+    # Check that the single part content is present
+    assert 'Single' in body_content


### PR DESCRIPTION
Removing extra space before and after group items to resolve the issue raised in #2745

Resolves https://github.com/docling-project/docling-core/issues/371
Resolves https://github.com/docling-project/docling/issues/2745