### PR TITLE
feat: enable heading-only chunks for empty-section headings

### DIFF
--- a/test/data/chunker/2h_out_chunks_hier_emit_false.json
+++ b/test/data/chunker/2h_out_chunks_hier_emit_false.json
@@ -1,0 +1,27 @@
+{
+    "root": [
+        {
+            "text": "Foo",
+            "meta": {
+                "schema_name": "docling_core.transforms.chunker.DocMeta",
+                "version": "1.0.0",
+                "doc_items": [
+                    {
+                        "self_ref": "#/texts/8",
+                        "parent": {
+                            "$ref": "#/body"
+                        },
+                        "children": [],
+                        "content_layer": "body",
+                        "label": "text",
+                        "prov": []
+                    }
+                ],
+                "headings": [
+                    "Section 3",
+                    "Section 3.1"
+                ]
+            }
+        }
+    ]
+}

--- a/test/data/chunker/2h_out_chunks_hier_emit_true.json
+++ b/test/data/chunker/2h_out_chunks_hier_emit_true.json
@@ -1,0 +1,170 @@
+{
+    "root": [
+        {
+            "text": "",
+            "meta": {
+                "schema_name": "docling_core.transforms.chunker.DocMeta",
+                "version": "1.0.0",
+                "doc_items": [
+                    {
+                        "self_ref": "#/texts/0",
+                        "parent": {
+                            "$ref": "#/body"
+                        },
+                        "children": [],
+                        "content_layer": "body",
+                        "label": "section_header",
+                        "prov": []
+                    },
+                    {
+                        "self_ref": "#/texts/1",
+                        "parent": {
+                            "$ref": "#/body"
+                        },
+                        "children": [],
+                        "content_layer": "body",
+                        "label": "section_header",
+                        "prov": []
+                    }
+                ],
+                "headings": [
+                    "Section 1",
+                    "Section 1.1"
+                ]
+            }
+        },
+        {
+            "text": "",
+            "meta": {
+                "schema_name": "docling_core.transforms.chunker.DocMeta",
+                "version": "1.0.0",
+                "doc_items": [
+                    {
+                        "self_ref": "#/texts/0",
+                        "parent": {
+                            "$ref": "#/body"
+                        },
+                        "children": [],
+                        "content_layer": "body",
+                        "label": "section_header",
+                        "prov": []
+                    },
+                    {
+                        "self_ref": "#/texts/2",
+                        "parent": {
+                            "$ref": "#/body"
+                        },
+                        "children": [],
+                        "content_layer": "body",
+                        "label": "section_header",
+                        "prov": []
+                    }
+                ],
+                "headings": [
+                    "Section 1",
+                    "Section 1.2"
+                ]
+            }
+        },
+        {
+            "text": "",
+            "meta": {
+                "schema_name": "docling_core.transforms.chunker.DocMeta",
+                "version": "1.0.0",
+                "doc_items": [
+                    {
+                        "self_ref": "#/texts/3",
+                        "parent": {
+                            "$ref": "#/body"
+                        },
+                        "children": [],
+                        "content_layer": "body",
+                        "label": "section_header",
+                        "prov": []
+                    },
+                    {
+                        "self_ref": "#/texts/4",
+                        "parent": {
+                            "$ref": "#/body"
+                        },
+                        "children": [],
+                        "content_layer": "body",
+                        "label": "section_header",
+                        "prov": []
+                    },
+                    {
+                        "self_ref": "#/texts/5",
+                        "parent": {
+                            "$ref": "#/body"
+                        },
+                        "children": [],
+                        "content_layer": "body",
+                        "label": "section_header",
+                        "prov": []
+                    }
+                ],
+                "headings": [
+                    "Section 2",
+                    "Section 2.1",
+                    "Section 2.1.1"
+                ]
+            }
+        },
+        {
+            "text": "Foo",
+            "meta": {
+                "schema_name": "docling_core.transforms.chunker.DocMeta",
+                "version": "1.0.0",
+                "doc_items": [
+                    {
+                        "self_ref": "#/texts/8",
+                        "parent": {
+                            "$ref": "#/body"
+                        },
+                        "children": [],
+                        "content_layer": "body",
+                        "label": "text",
+                        "prov": []
+                    }
+                ],
+                "headings": [
+                    "Section 3",
+                    "Section 3.1"
+                ]
+            }
+        },
+        {
+            "text": "",
+            "meta": {
+                "schema_name": "docling_core.transforms.chunker.DocMeta",
+                "version": "1.0.0",
+                "doc_items": [
+                    {
+                        "self_ref": "#/texts/9",
+                        "parent": {
+                            "$ref": "#/body"
+                        },
+                        "children": [],
+                        "content_layer": "body",
+                        "label": "section_header",
+                        "prov": []
+                    },
+                    {
+                        "self_ref": "#/texts/10",
+                        "parent": {
+                            "$ref": "#/body"
+                        },
+                        "children": [],
+                        "content_layer": "body",
+                        "label": "section_header",
+                        "prov": []
+                    }
+                ],
+                "headings": [
+                    "Section 4",
+                    "Section 4.1"
+                ]
+            }
+        }
+    ]
+}

--- a/test/data/chunker/2h_out_chunks_hybr_emit_false.json
+++ b/test/data/chunker/2h_out_chunks_hybr_emit_false.json
@@ -1,0 +1,27 @@
+{
+    "root": [
+        {
+            "text": "Foo",
+            "meta": {
+                "schema_name": "docling_core.transforms.chunker.DocMeta",
+                "version": "1.0.0",
+                "doc_items": [
+                    {
+                        "self_ref": "#/texts/8",
+                        "parent": {
+                            "$ref": "#/body"
+                        },
+                        "children": [],
+                        "content_layer": "body",
+                        "label": "text",
+                        "prov": []
+                    }
+                ],
+                "headings": [
+                    "Section 3",
+                    "Section 3.1"
+                ]
+            }
+        }
+    ]
+}

--- a/test/data/chunker/2h_out_chunks_hybr_emit_true.json
+++ b/test/data/chunker/2h_out_chunks_hybr_emit_true.json
@@ -1,0 +1,170 @@
+{
+    "root": [
+        {
+            "text": "",
+            "meta": {
+                "schema_name": "docling_core.transforms.chunker.DocMeta",
+                "version": "1.0.0",
+                "doc_items": [
+                    {
+                        "self_ref": "#/texts/0",
+                        "parent": {
+                            "$ref": "#/body"
+                        },
+                        "children": [],
+                        "content_layer": "body",
+                        "label": "section_header",
+                        "prov": []
+                    },
+                    {
+                        "self_ref": "#/texts/1",
+                        "parent": {
+                            "$ref": "#/body"
+                        },
+                        "children": [],
+                        "content_layer": "body",
+                        "label": "section_header",
+                        "prov": []
+                    }
+                ],
+                "headings": [
+                    "Section 1",
+                    "Section 1.1"
+                ]
+            }
+        },
+        {
+            "text": "",
+            "meta": {
+                "schema_name": "docling_core.transforms.chunker.DocMeta",
+                "version": "1.0.0",
+                "doc_items": [
+                    {
+                        "self_ref": "#/texts/0",
+                        "parent": {
+                            "$ref": "#/body"
+                        },
+                        "children": [],
+                        "content_layer": "body",
+                        "label": "section_header",
+                        "prov": []
+                    },
+                    {
+                        "self_ref": "#/texts/2",
+                        "parent": {
+                            "$ref": "#/body"
+                        },
+                        "children": [],
+                        "content_layer": "body",
+                        "label": "section_header",
+                        "prov": []
+                    }
+                ],
+                "headings": [
+                    "Section 1",
+                    "Section 1.2"
+                ]
+            }
+        },
+        {
+            "text": "",
+            "meta": {
+                "schema_name": "docling_core.transforms.chunker.DocMeta",
+                "version": "1.0.0",
+                "doc_items": [
+                    {
+                        "self_ref": "#/texts/3",
+                        "parent": {
+                            "$ref": "#/body"
+                        },
+                        "children": [],
+                        "content_layer": "body",
+                        "label": "section_header",
+                        "prov": []
+                    },
+                    {
+                        "self_ref": "#/texts/4",
+                        "parent": {
+                            "$ref": "#/body"
+                        },
+                        "children": [],
+                        "content_layer": "body",
+                        "label": "section_header",
+                        "prov": []
+                    },
+                    {
+                        "self_ref": "#/texts/5",
+                        "parent": {
+                            "$ref": "#/body"
+                        },
+                        "children": [],
+                        "content_layer": "body",
+                        "label": "section_header",
+                        "prov": []
+                    }
+                ],
+                "headings": [
+                    "Section 2",
+                    "Section 2.1",
+                    "Section 2.1.1"
+                ]
+            }
+        },
+        {
+            "text": "Foo",
+            "meta": {
+                "schema_name": "docling_core.transforms.chunker.DocMeta",
+                "version": "1.0.0",
+                "doc_items": [
+                    {
+                        "self_ref": "#/texts/8",
+                        "parent": {
+                            "$ref": "#/body"
+                        },
+                        "children": [],
+                        "content_layer": "body",
+                        "label": "text",
+                        "prov": []
+                    }
+                ],
+                "headings": [
+                    "Section 3",
+                    "Section 3.1"
+                ]
+            }
+        },
+        {
+            "text": "",
+            "meta": {
+                "schema_name": "docling_core.transforms.chunker.DocMeta",
+                "version": "1.0.0",
+                "doc_items": [
+                    {
+                        "self_ref": "#/texts/9",
+                        "parent": {
+                            "$ref": "#/body"
+                        },
+                        "children": [],
+                        "content_layer": "body",
+                        "label": "section_header",
+                        "prov": []
+                    },
+                    {
+                        "self_ref": "#/texts/10",
+                        "parent": {
+                            "$ref": "#/body"
+                        },
+                        "children": [],
+                        "content_layer": "body",
+                        "label": "section_header",
+                        "prov": []
+                    }
+                ],
+                "headings": [
+                    "Section 4",
+                    "Section 4.1"
+                ]
+            }
+        }
+    ]
+}


### PR DESCRIPTION
Adding an option to address cases (e.g. related to https://github.com/docling-project/docling/issues/287) like:

```console
## Section 1

## Section 1.1

## Section 1.1.1

Foo
```

where currently `Section 1` and `Section 1.1` are not emitted in any chunk, as they are considered "shadowed" by fellow-level2 `Section 1.1.1`.