### PR TITLE
feat: add page_no to TableCell

### DIFF
--- a/docs/DoclingDocument.json
+++ b/docs/DoclingDocument.json
@@ -2250,6 +2250,18 @@
           "title": "Fillable",
           "type": "boolean"
         },
+        "page_no": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Page No"
+        },
         "ref": {
           "$ref": "#/$defs/RefItem"
         }
@@ -2523,6 +2535,18 @@
           "default": false,
           "title": "Fillable",
           "type": "boolean"
+        },
+        "page_no": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Page No"
         }
       },
       "required": [

--- a/test/data/docling_document/unit/TableItem.yaml
+++ b/test/data/docling_document/unit/TableItem.yaml
@@ -1,5 +1,7 @@
+annotations: []
 captions: []
 children: []
+content_layer: body
 data:
   grid:
   - - bbox: null
@@ -8,6 +10,7 @@ data:
       end_col_offset_idx: 1
       end_row_offset_idx: 1
       fillable: false
+      page_no: null
       row_header: false
       row_section: false
       row_span: 1
@@ -20,6 +23,7 @@ data:
       end_col_offset_idx: 2
       end_row_offset_idx: 1
       fillable: false
+      page_no: null
       row_header: false
       row_section: false
       row_span: 1
@@ -32,6 +36,7 @@ data:
       end_col_offset_idx: 3
       end_row_offset_idx: 1
       fillable: false
+      page_no: null
       row_header: false
       row_section: false
       row_span: 1
@@ -44,6 +49,7 @@ data:
       end_col_offset_idx: 4
       end_row_offset_idx: 1
       fillable: false
+      page_no: null
       row_header: false
       row_section: false
       row_span: 1
@@ -56,6 +62,7 @@ data:
       end_col_offset_idx: 5
       end_row_offset_idx: 1
       fillable: false
+      page_no: null
       row_header: false
       row_section: false
       row_span: 1
@@ -68,6 +75,7 @@ data:
       end_col_offset_idx: 1
       end_row_offset_idx: 2
       fillable: false
+      page_no: null
       row_header: false
       row_section: false
       row_span: 1
@@ -80,6 +88,7 @@ data:
       end_col_offset_idx: 2
       end_row_offset_idx: 2
       fillable: false
+      page_no: null
       row_header: false
       row_section: false
       row_span: 1
@@ -92,6 +101,7 @@ data:
       end_col_offset_idx: 3
       end_row_offset_idx: 2
       fillable: false
+      page_no: null
       row_header: false
       row_section: false
       row_span: 1
@@ -104,6 +114,7 @@ data:
       end_col_offset_idx: 4
       end_row_offset_idx: 2
       fillable: false
+      page_no: null
       row_header: false
       row_section: false
       row_span: 1
@@ -116,6 +127,7 @@ data:
       end_col_offset_idx: 5
       end_row_offset_idx: 2
       fillable: false
+      page_no: null
       row_header: false
       row_section: false
       row_span: 1
@@ -128,6 +140,7 @@ data:
       end_col_offset_idx: 1
       end_row_offset_idx: 3
       fillable: false
+      page_no: null
       row_header: false
       row_section: false
       row_span: 1
@@ -140,6 +153,7 @@ data:
       end_col_offset_idx: 2
       end_row_offset_idx: 3
       fillable: false
+      page_no: null
       row_header: false
       row_section: false
       row_span: 1
@@ -152,6 +166,7 @@ data:
       end_col_offset_idx: 3
       end_row_offset_idx: 3
       fillable: false
+      page_no: null
       row_header: false
       row_section: false
       row_span: 1
@@ -164,6 +179,7 @@ data:
       end_col_offset_idx: 4
       end_row_offset_idx: 3
       fillable: false
+      page_no: null
       row_header: false
       row_section: false
       row_span: 1
@@ -176,6 +192,7 @@ data:
       end_col_offset_idx: 5
       end_row_offset_idx: 3
       fillable: false
+      page_no: null
       row_header: false
       row_section: false
       row_span: 1
@@ -188,10 +205,8 @@ data:
 footnotes: []
 image: null
 label: table
+meta: null
 parent: null
 prov: []
 references: []
 self_ref: '#'
-content_layer: body
-annotations: []
-meta: null


### PR DESCRIPTION
## Description
Resolves #410.

Adds `page_no` attribute to the [TableCell](cci:2://file:///Users/danishkhan/Downloads/codes/contributions/docling-core/docling_core/types/legacy_doc/base.py:100:0-106:39) class to support cross-page table data as requested. This allows upstream parsers to store page location information for individual cells in multi-page tables.

## Changes
- Modified [TableCell](cci:2://file:///Users/danishkhan/Downloads/codes/contributions/docling-core/docling_core/types/legacy_doc/base.py:100:0-106:39) in [docling_core/types/doc/document.py](cci:7://file:///Users/danishkhan/Downloads/codes/contributions/docling-core/docling_core/types/doc/document.py:0:0-0:0) to include optional `page_no`.
- Updated regression test gold file [test/data/docling_document/unit/TableItem.yaml](cci:7://file:///Users/danishkhan/Downloads/codes/contributions/docling-core/test/data/docling_document/unit/TableItem.yaml/Users/danishkhan/Downloads/codes/contributions/docling-core/test/data/docling_document/unit/TableItem.yaml:0:0-0:0).

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes