### PR TITLE
fix: lazy load transformers in HybridChunker

### DIFF
--- a/docling_core/transforms/chunker/hybrid_chunker.py
+++ b/docling_core/transforms/chunker/hybrid_chunker.py
@@ -7,16 +7,6 @@ from typing import Any, Optional, Union, cast
 
 from pydantic import BaseModel, ConfigDict, Field, computed_field, model_validator
 
-try:
-    import semchunk
-except ImportError:
-    raise RuntimeError(
-        "Extra required by module: 'chunking' by default (or 'chunking-openai' if "
-        "specifically using OpenAI tokenization); to install, run: "
-        "`pip install 'docling-core[chunking]'` or "
-        "`pip install 'docling-core[chunking-openai]'`"
-    )
-
 from docling_core.transforms.chunker import (
     BaseChunk,
     BaseChunker,
@@ -30,13 +20,27 @@ from docling_core.transforms.chunker.hierarchical_chunker import (
 )
 from docling_core.transforms.chunker.line_chunker import LineBasedTokenChunker
 from docling_core.transforms.chunker.tokenizer.base import BaseTokenizer
-from docling_core.transforms.chunker.tokenizer.huggingface import get_default_tokenizer
 from docling_core.transforms.serializer.base import (
     BaseDocSerializer,
     BaseSerializerProvider,
 )
 from docling_core.types import DoclingDocument
 from docling_core.types.doc.document import SectionHeaderItem, TableItem, TitleItem
+
+_SEMCHUNK_AVAILABLE: bool = False
+_SEMCHUNK_IMPORT_ERROR: ImportError | None = None
+try:
+    import semchunk
+
+    _SEMCHUNK_AVAILABLE = True
+except ImportError as e:
+    _SEMCHUNK_IMPORT_ERROR = e
+
+_SEMCHUNK_INSTALL_HINT = (
+    "The 'semchunk' package is required by HybridChunker. "
+    "Install it with `pip install 'docling-core[chunking]'` or "
+    "`pip install 'docling-core[chunking-openai]'`."
+)
 
 
 def _get_default_tokenizer():
@@ -64,7 +68,7 @@ class HybridChunker(BaseChunker):
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
-    tokenizer: BaseTokenizer = Field(default_factory=get_default_tokenizer)
+    tokenizer: BaseTokenizer = Field(default_factory=_get_default_tokenizer)
     repeat_table_header: bool = True
     merge_peers: bool = True
     omit_header_on_overflow: bool = False
@@ -236,8 +240,6 @@ class HybridChunker(BaseChunker):
         else:
             # How much room is there for text after subtracting out the headers and
             # captions:
-            import semchunk
-
             available_length = self.max_tokens - lengths.other_len
 
             if available_length <= 0:
@@ -311,6 +313,8 @@ class HybridChunker(BaseChunker):
             if preamble:
                 segments = segments[:1] + [s[len(preamble) :] for s in segments[1:]]
         else:
+            if not _SEMCHUNK_AVAILABLE:
+                raise ImportError(_SEMCHUNK_INSTALL_HINT) from _SEMCHUNK_IMPORT_ERROR
             sem_chunker = semchunk.chunkerify(self.tokenizer.get_tokenizer(), chunk_size=available_length)
             sem_segments = sem_chunker(doc_chunk.text)
             segments = cast(list[str], sem_segments)

--- a/docling_core/transforms/chunker/hybrid_chunker.py
+++ b/docling_core/transforms/chunker/hybrid_chunker.py
@@ -24,8 +24,7 @@ from docling_core.transforms.serializer.base import (
     BaseDocSerializer,
     BaseSerializerProvider,
 )
-from docling_core.types import DoclingDocument
-from docling_core.types.doc.document import SectionHeaderItem, TableItem, TitleItem
+from docling_core.types.doc import DoclingDocument, SectionHeaderItem, TableItem, TitleItem
 
 _SEMCHUNK_AVAILABLE: bool = False
 _SEMCHUNK_IMPORT_ERROR: ImportError | None = None

--- a/docling_core/transforms/chunker/hybrid_chunker.py
+++ b/docling_core/transforms/chunker/hybrid_chunker.py
@@ -7,19 +7,8 @@ from typing import Any, Optional, Union, cast
 
 from pydantic import BaseModel, ConfigDict, Field, computed_field, model_validator
 
-from docling_core.transforms.chunker.hierarchical_chunker import (
-    ChunkingDocSerializer,
-    ChunkingSerializerProvider,
-)
-from docling_core.transforms.chunker.line_chunker import LineBasedTokenChunker
-from docling_core.transforms.chunker.tokenizer.base import BaseTokenizer
-from docling_core.transforms.chunker.tokenizer.huggingface import get_default_tokenizer
-from docling_core.transforms.serializer.base import BaseDocSerializer
-from docling_core.types.doc import SectionHeaderItem, TableItem, TitleItem
-
 try:
     import semchunk
-    from transformers import PreTrainedTokenizerBase
 except ImportError:
     raise RuntimeError(
         "Extra required by module: 'chunking' by default (or 'chunking-openai' if "
@@ -35,10 +24,27 @@ from docling_core.transforms.chunker import (
     DocMeta,
     HierarchicalChunker,
 )
+from docling_core.transforms.chunker.hierarchical_chunker import (
+    ChunkingDocSerializer,
+    ChunkingSerializerProvider,
+)
+from docling_core.transforms.chunker.line_chunker import LineBasedTokenChunker
+from docling_core.transforms.chunker.tokenizer.base import BaseTokenizer
+from docling_core.transforms.chunker.tokenizer.huggingface import get_default_tokenizer
 from docling_core.transforms.serializer.base import (
+    BaseDocSerializer,
     BaseSerializerProvider,
 )
 from docling_core.types import DoclingDocument
+from docling_core.types.doc.document import SectionHeaderItem, TableItem, TitleItem
+
+
+def _get_default_tokenizer():
+    from docling_core.transforms.chunker.tokenizer.huggingface import (
+        HuggingFaceTokenizer,
+    )
+
+    return HuggingFaceTokenizer.from_pretrained(model_name="sentence-transformers/all-MiniLM-L6-v2")
 
 
 class HybridChunker(BaseChunker):
@@ -92,8 +98,15 @@ class HybridChunker(BaseChunker):
                         model_name=tokenizer,
                         max_tokens=max_tokens,
                     )
-                elif tokenizer is None or isinstance(tokenizer, PreTrainedTokenizerBase):
-                    kwargs = {"tokenizer": tokenizer or get_default_tokenizer().tokenizer}
+                elif tokenizer is None or (
+                    hasattr(tokenizer, "__module__")
+                    and (tokenizer.__module__.startswith("transformers.") or tokenizer.__module__ == "transformers")
+                ):
+                    from docling_core.transforms.chunker.tokenizer.huggingface import (
+                        HuggingFaceTokenizer,
+                    )
+
+                    kwargs = {"tokenizer": tokenizer or _get_default_tokenizer().tokenizer}
                     if max_tokens is not None:
                         kwargs["max_tokens"] = max_tokens
                     data["tokenizer"] = HuggingFaceTokenizer(**kwargs)
@@ -223,6 +236,8 @@ class HybridChunker(BaseChunker):
         else:
             # How much room is there for text after subtracting out the headers and
             # captions:
+            import semchunk
+
             available_length = self.max_tokens - lengths.other_len
 
             if available_length <= 0:

--- a/docling_core/transforms/chunker/hybrid_chunker.py
+++ b/docling_core/transforms/chunker/hybrid_chunker.py
@@ -44,11 +44,13 @@ _SEMCHUNK_INSTALL_HINT = (
 
 
 def _get_default_tokenizer():
-    from docling_core.transforms.chunker.tokenizer.huggingface import (
-        HuggingFaceTokenizer,
-    )
+    """Get default tokenizer instance.
 
-    return HuggingFaceTokenizer.from_pretrained(model_name="sentence-transformers/all-MiniLM-L6-v2")
+    Defer import to avoid pulling in transformers at module import time.
+    """
+    from docling_core.transforms.chunker.tokenizer.huggingface import get_default_tokenizer
+
+    return get_default_tokenizer()
 
 
 class HybridChunker(BaseChunker):

--- a/docling_core/transforms/chunker/tokenizer/huggingface.py
+++ b/docling_core/transforms/chunker/tokenizer/huggingface.py
@@ -88,6 +88,6 @@ class HuggingFaceTokenizer(BaseTokenizer):
         return self.tokenizer
 
 
-def get_default_tokenizer():
+def get_default_tokenizer() -> HuggingFaceTokenizer:
     """Get default tokenizer instance."""
     return HuggingFaceTokenizer.from_pretrained(model_name="sentence-transformers/all-MiniLM-L6-v2")

--- a/docling_core/transforms/chunker/tokenizer/huggingface.py
+++ b/docling_core/transforms/chunker/tokenizer/huggingface.py
@@ -10,10 +10,19 @@ from typing_extensions import Self
 
 from docling_core.transforms.chunker.tokenizer.base import BaseTokenizer
 
+_TRANSFORMERS_AVAILABLE: bool = False
+_TRANSFORMERS_IMPORT_ERROR: ImportError | None = None
 try:
     from transformers import AutoTokenizer, PreTrainedTokenizerBase
-except ImportError:
-    raise RuntimeError("Module requires 'chunking' extra; to install, run: `pip install 'docling-core[chunking]'`")
+
+    _TRANSFORMERS_AVAILABLE = True
+except ImportError as e:
+    _TRANSFORMERS_IMPORT_ERROR = e
+
+_INSTALL_HINT = (
+    "The 'transformers' package is required by HuggingFaceTokenizer. "
+    "Install it with `pip install 'docling-core[chunking]'`."
+)
 
 
 class HuggingFaceTokenizer(BaseTokenizer):
@@ -21,8 +30,15 @@ class HuggingFaceTokenizer(BaseTokenizer):
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
-    tokenizer: PreTrainedTokenizerBase
+    tokenizer: "PreTrainedTokenizerBase"
     max_tokens: int = None  # type: ignore[assignment]
+
+    @model_validator(mode="before")
+    @classmethod
+    def _check_deps(cls, data: Any) -> Any:
+        if not _TRANSFORMERS_AVAILABLE:
+            raise ImportError(_INSTALL_HINT) from _TRANSFORMERS_IMPORT_ERROR
+        return data
 
     @model_validator(mode="after")
     def _patch(self) -> Self:
@@ -58,6 +74,8 @@ class HuggingFaceTokenizer(BaseTokenizer):
         **kwargs,
     ) -> Self:
         """Create tokenizer from model name."""
+        if not _TRANSFORMERS_AVAILABLE:
+            raise ImportError(_INSTALL_HINT) from _TRANSFORMERS_IMPORT_ERROR
         my_kwargs: dict[str, Any] = {
             "tokenizer": AutoTokenizer.from_pretrained(pretrained_model_name_or_path=model_name, **kwargs),
         }

--- a/docling_core/transforms/chunker/tokenizer/openai.py
+++ b/docling_core/transforms/chunker/tokenizer/openai.py
@@ -1,15 +1,24 @@
 """OpenAI tokenization."""
 
-from pydantic import ConfigDict
+from typing import Any
+
+from pydantic import ConfigDict, model_validator
 
 from docling_core.transforms.chunker.hybrid_chunker import BaseTokenizer
 
+_TIKTOKEN_AVAILABLE: bool = False
+_TIKTOKEN_IMPORT_ERROR: ImportError | None = None
 try:
     import tiktoken
-except ImportError:
-    raise RuntimeError(
-        "Module requires 'chunking-openai' extra; to install, run: `pip install 'docling-core[chunking-openai]'`"
-    )
+
+    _TIKTOKEN_AVAILABLE = True
+except ImportError as e:
+    _TIKTOKEN_IMPORT_ERROR = e
+
+_INSTALL_HINT = (
+    "The 'tiktoken' package is required by OpenAITokenizer. "
+    "Install it with `pip install 'docling-core[chunking-openai]'`."
+)
 
 
 class OpenAITokenizer(BaseTokenizer):
@@ -17,8 +26,15 @@ class OpenAITokenizer(BaseTokenizer):
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
-    tokenizer: tiktoken.Encoding
+    tokenizer: "tiktoken.Encoding"
     max_tokens: int
+
+    @model_validator(mode="before")
+    @classmethod
+    def _check_deps(cls, data: Any) -> Any:
+        if not _TIKTOKEN_AVAILABLE:
+            raise ImportError(_INSTALL_HINT) from _TIKTOKEN_IMPORT_ERROR
+        return data
 
     def count_tokens(self, text: str) -> int:
         """Get number of tokens for given text."""
@@ -28,6 +44,6 @@ class OpenAITokenizer(BaseTokenizer):
         """Get maximum number of tokens allowed."""
         return self.max_tokens
 
-    def get_tokenizer(self) -> tiktoken.Encoding:
+    def get_tokenizer(self) -> "tiktoken.Encoding":
         """Get underlying tokenizer object."""
         return self.tokenizer

--- a/test/test_hybrid_chunker.py
+++ b/test/test_hybrid_chunker.py
@@ -6,6 +6,7 @@ import pytest
 import tiktoken
 from transformers import AutoTokenizer
 
+import docling_core.transforms.chunker.hybrid_chunker as _hybrid_mod
 from docling_core.transforms.chunker.base import BaseChunker
 from docling_core.transforms.chunker.hierarchical_chunker import (
     ChunkingDocSerializer,
@@ -742,3 +743,45 @@ def test_html_parser_error_handling(dl_doc_0):
     for chunk in chunks:
         assert isinstance(chunk.text, str), "Chunk text should be a string"
         assert chunk.meta is not None, "Chunk should have metadata"
+
+
+@pytest.mark.parametrize(
+    "tokenizer",
+    [
+        pytest.param(
+            lambda: HuggingFaceTokenizer(tokenizer=INNER_TOKENIZER, max_tokens=MAX_TOKENS),
+            id="huggingface",
+        ),
+        pytest.param(
+            lambda: OpenAITokenizer(tokenizer=tiktoken.get_encoding("cl100k_base"), max_tokens=MAX_TOKENS),
+            id="openai",
+        ),
+    ],
+)
+def test_chunk_with_tokenizer_backends(sample_doc, tokenizer):
+    """HybridChunker produces chunks with both supported tokenizer backends."""
+    chunker = HybridChunker(tokenizer=tokenizer())
+    chunks = list(chunker.chunk(dl_doc=sample_doc))
+    assert len(chunks) >= 1
+    assert all(isinstance(c.text, str) for c in chunks)
+
+
+def test_chunk_raises_on_missing_semchunk(monkeypatch):
+    """HybridChunker raises ImportError when semchunk is not installed.
+
+    Regression test for lazy-loading: the error must be raised at chunk time,
+    not at import time, so users of chunking-openai or chunking-hf without the
+    other extra can still import the module safely.
+    """
+    with open(INPUT_FILE, encoding="utf-8") as f:
+        dl_doc = DLDocument.model_validate_json(f.read())
+
+    chunker = HybridChunker(
+        tokenizer=HuggingFaceTokenizer(tokenizer=INNER_TOKENIZER, max_tokens=MAX_TOKENS),
+    )
+
+    monkeypatch.setattr(_hybrid_mod, "_SEMCHUNK_AVAILABLE", False)
+    monkeypatch.setattr(_hybrid_mod, "_SEMCHUNK_IMPORT_ERROR", ImportError("semchunk not installed"))
+
+    with pytest.raises(ImportError, match="semchunk"):
+        list(chunker.chunk(dl_doc=dl_doc))

--- a/test/test_hybrid_chunker.py
+++ b/test/test_hybrid_chunker.py
@@ -20,7 +20,7 @@ from docling_core.transforms.chunker.tokenizer.openai import OpenAITokenizer
 from docling_core.transforms.serializer.html import HTMLTableSerializer
 from docling_core.transforms.serializer.markdown import MarkdownParams, MarkdownTableSerializer
 from docling_core.types.doc import DocItemLabel, DoclingDocument
-from docling_core.types.doc.document import TableCell, TableData
+from docling_core.types.doc.items.table.table_data import TableCell, TableData
 
 from .test_utils import assert_or_generate_json_ground_truth, build_single_cell_rich_table_doc
 
@@ -773,8 +773,8 @@ def test_chunk_raises_on_missing_semchunk(monkeypatch):
     not at import time, so users of chunking-openai or chunking-hf without the
     other extra can still import the module safely.
     """
-    with open(INPUT_FILE, encoding="utf-8") as f:
-        dl_doc = DLDocument.model_validate_json(f.read())
+    with open(INPUT_FILE_2, encoding="utf-8") as f:
+        dl_doc = DoclingDocument.model_validate_json(f.read())
 
     chunker = HybridChunker(
         tokenizer=HuggingFaceTokenizer(tokenizer=INNER_TOKENIZER, max_tokens=MAX_TOKENS),


### PR DESCRIPTION
## Description
Resolves #459.

Implements lazy loading for `transformers` and `semchunk` in `HybridChunker`. This prevents `RuntimeError` when using `docling-core` with only the `chunking-openai` extra (which does not depend on `transformers`).

**Note:** This applies the same lazy-loading pattern accepted in `docling` PR #2826(https://github.com/docling-project/docling/pull/2826) (fix: transformers models lazy-loaded).

## Changes
- Moved `semchunk` import to `_split_using_plain_text` method.
- Replaced explicit `isinstance` check for `PreTrainedTokenizerBase` with a module path string check (`tokenizer.__module__`) to avoid importing `transformers`.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes