### PR TITLE
fix: make tree-sitter-java-orchard optional

### DIFF
--- a/docling_core/transforms/chunker/code_chunking/_utils.py
+++ b/docling_core/transforms/chunker/code_chunking/_utils.py
@@ -1,5 +1,6 @@
 """Utility functions and classes for code language detection and processing."""
 
+import logging
 import sys
 from typing import List, Optional
 
@@ -8,6 +9,8 @@ from tree_sitter import Node, Tree
 
 from docling_core.transforms.chunker.tokenizer.base import BaseTokenizer
 from docling_core.types.doc.labels import CodeLanguageLabel
+
+_logger = logging.getLogger(__name__)
 
 
 def _get_file_extensions(language: CodeLanguageLabel) -> List[str]:
@@ -36,9 +39,15 @@ def _get_tree_sitter_language(language: CodeLanguageLabel):
         CodeLanguageLabel.C: lambda: Lang(ts_c.language()),
     }
     if sys.version_info >= (3, 10):
-        import tree_sitter_java_orchard as ts_java
+        try:
+            import tree_sitter_java_orchard as ts_java
 
-        language_map[CodeLanguageLabel.JAVA] = lambda: Lang(ts_java.language())
+            language_map[CodeLanguageLabel.JAVA] = lambda: Lang(ts_java.language())
+        except ImportError:
+            _logger.warning(
+                "Code chunking for Java cannot be enabled because tree-sitter-java-orchard is missing. "
+                "Please installed it via `pip install tree-sitter-java-orchard`."
+            )
 
     factory = language_map.get(language)
     return factory() if factory else None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,6 @@ chunking = [
     'tree-sitter (>=0.23.2,<1.0.0)',
     'tree-sitter-python (>=0.23.6,<1.0.0)',
     'tree-sitter-c (>=0.23.4,<1.0.0)',
-    'tree-sitter-java-orchard (>=0.3.0,<1.0.0); python_version >= "3.10"',
     'tree-sitter-javascript (>=0.23.1,<1.0.0)',
     'tree-sitter-typescript (>=0.23.2,<1.0.0)',
 
@@ -84,7 +83,6 @@ chunking-openai = [
     'tree-sitter (>=0.23.2,<1.0.0)',
     'tree-sitter-python (>=0.23.6,<1.0.0)',
     'tree-sitter-c (>=0.23.4,<1.0.0)',
-    'tree-sitter-java-orchard (>=0.3.0,<1.0.0); python_version >= "3.10"',
     'tree-sitter-javascript (>=0.23.1,<1.0.0)',
     'tree-sitter-typescript (>=0.23.2,<1.0.0)',
 
@@ -117,6 +115,7 @@ dev = [
     "pytest~=8.3",
     "pytest-cov>=6.1.1",
     "python-semantic-release~=7.32",
+    'tree-sitter-java-orchard (>=0.3.0,<1.0.0); python_version >= "3.10"',
 ]
 
 [tool.uv]

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.9, <4.0"
 resolution-markers = [
     "python_full_version >= '3.12'",
@@ -1201,7 +1201,6 @@ chunking = [
     { name = "transformers" },
     { name = "tree-sitter" },
     { name = "tree-sitter-c" },
-    { name = "tree-sitter-java-orchard", marker = "python_full_version >= '3.10'" },
     { name = "tree-sitter-javascript" },
     { name = "tree-sitter-python" },
     { name = "tree-sitter-typescript" },
@@ -1211,7 +1210,6 @@ chunking-openai = [
     { name = "tiktoken" },
     { name = "tree-sitter" },
     { name = "tree-sitter-c" },
-    { name = "tree-sitter-java-orchard", marker = "python_full_version >= '3.10'" },
     { name = "tree-sitter-javascript" },
     { name = "tree-sitter-python" },
     { name = "tree-sitter-typescript" },
@@ -1244,6 +1242,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "python-semantic-release" },
+    { name = "tree-sitter-java-orchard", marker = "python_full_version >= '3.10'" },
     { name = "types-setuptools" },
 ]
 
@@ -1269,8 +1268,6 @@ requires-dist = [
     { name = "tree-sitter", marker = "extra == 'chunking-openai'", specifier = ">=0.23.2,<1.0.0" },
     { name = "tree-sitter-c", marker = "extra == 'chunking'", specifier = ">=0.23.4,<1.0.0" },
     { name = "tree-sitter-c", marker = "extra == 'chunking-openai'", specifier = ">=0.23.4,<1.0.0" },
-    { name = "tree-sitter-java-orchard", marker = "python_full_version >= '3.10' and extra == 'chunking'", specifier = ">=0.3.0,<1.0.0" },
-    { name = "tree-sitter-java-orchard", marker = "python_full_version >= '3.10' and extra == 'chunking-openai'", specifier = ">=0.3.0,<1.0.0" },
     { name = "tree-sitter-javascript", marker = "extra == 'chunking'", specifier = ">=0.23.1,<1.0.0" },
     { name = "tree-sitter-javascript", marker = "extra == 'chunking-openai'", specifier = ">=0.23.1,<1.0.0" },
     { name = "tree-sitter-python", marker = "extra == 'chunking'", specifier = ">=0.23.6,<1.0.0" },
@@ -1300,6 +1297,7 @@ dev = [
     { name = "pytest", specifier = "~=8.3" },
     { name = "pytest-cov", specifier = ">=6.1.1" },
     { name = "python-semantic-release", specifier = "~=7.32" },
+    { name = "tree-sitter-java-orchard", marker = "python_full_version >= '3.10'", specifier = ">=0.3.0,<1.0.0" },
     { name = "types-setuptools", specifier = "~=70.3" },
 ]
 


### PR DESCRIPTION
Since tree-sitter-java-orchard requires compilation from source, we need to make it optional.