### PR TITLE
fix(serialization): escape pipe symbol in single cell md serialization

### DIFF
--- a/docling_core/transforms/serializer/markdown.py
+++ b/docling_core/transforms/serializer/markdown.py
@@ -376,13 +376,13 @@ class MarkdownTableSerializer(BaseTableSerializer):
 
             rows = [
                 [
-                    # make sure that md tables are not broken
-                    # due to newline chars in the text
+                    # make sure that md tables are not broken due to newline or pipe chars in the text
+                    # TODO: escape pipe characters also in RichTableCell once nested tables are properly handled
                     (
-                        doc_serializer.serialize(item=col.ref.resolve(doc=doc), **kwargs).text
+                        doc_serializer.serialize(item=col.ref.resolve(doc=doc), **kwargs).text.replace("\n", " ")
                         if isinstance(col, RichTableCell)
-                        else col.text
-                    ).replace("\n", " ")
+                        else col.text.replace("\n", " ").replace("|", "&#124;")
+                    )
                     for col in row
                 ]
                 for row in item.data.grid

--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -331,6 +331,22 @@ def test_md_single_row_table():
     actual = ser.serialize().text
     verify(exp_file=exp_file, actual=actual)
 
+def test_md_pipe_in_table():
+    doc = DoclingDocument(name="Pipe in Table")
+    table = doc.add_table(data=TableData(num_rows=1, num_cols=1))
+    # TODO: properly handle nested tables, for now just escape the pipe
+    doc.add_table_cell(
+        table,
+        TableCell(
+            start_row_offset_idx=0,
+            end_row_offset_idx=1,
+            start_col_offset_idx=0,
+            end_col_offset_idx=1,
+            text="Fruits | Veggies",
+        )
+    )
+    ser = doc.export_to_markdown()
+    assert ser == "| Fruits &#124; Veggies   |\n|-------------------------|"
 
 # ===============================
 # HTML tests


### PR DESCRIPTION
This PR fixes the markdown serialization of pipe characters (|) in a table single cell.
In markdown, pipe characters appearing in table cells need to be replaced by the HTML character code `&#124;`.

This PR is intended to support PR docling-project/docling#2904  , which addresses the issue docling-project/docling#2880 

Known limitation: in case of `RichTableCell` objects, the markdown serializer needs a prior refactoring to properly serialize nested tables (currently not supported).