### PR TITLE
fix: shift KV/Form graph cell page numbers during DoclingDocument.concatenate

### DIFF
--- a/docling_core/types/doc/document.py
+++ b/docling_core/types/doc/document.py
@@ -6214,9 +6214,12 @@ class DoclingDocument(BaseModel):
 
                     if isinstance(new_item, DocItem):
                         # update page numbers
-                        # NOTE other prov sources (e.g. GraphCell) currently not covered
                         for prov in new_item.prov:
                             prov.page_no += page_delta
+                        if isinstance(new_item, KeyValueItem | FormItem):
+                            for graph_cell in new_item.graph.cells:
+                                if graph_cell.prov is not None:
+                                    graph_cell.prov.page_no += page_delta
 
                     if item.parent:
                         # set item's parent
@@ -6248,9 +6251,9 @@ class DoclingDocument(BaseModel):
 
                             # update rich table cells references:
                             if isinstance(parent_item, TableItem):
-                                for cell in parent_item.data.table_cells:
-                                    if isinstance(cell, RichTableCell) and cell.ref.cref == item.self_ref:
-                                        cell.ref.cref = new_cref
+                                for table_cell in parent_item.data.table_cells:
+                                    if isinstance(table_cell, RichTableCell) and table_cell.ref.cref == item.self_ref:
+                                        table_cell.ref.cref = new_cref
                                         break
 
                         elif num_components == 2 and path_components[1] == "body":


### PR DESCRIPTION
`DoclingDocument.concatenate` was updating `DocItem.prov.page_no` with `page_delta`, but it did not update `GraphCell.prov.page_no` inside `KeyValueItem`/`FormItem` graphs.  
As a result, after concatenation, key-value/form graph cells from later documents could still point to page 1, causing incorrect visualization/page placement.

### What changed
- In `_DocIndex.index` (`docling_core/types/doc/document.py`), when copying a `KeyValueItem` or `FormItem`, we now also shift `cell.prov.page_no` for every graph cell by `page_delta`.
- Added regression test `test_concatenate_shifts_graph_cell_pages_for_keyvalue_and_form` in `test/test_docling_doc.py` to verify concatenating two 1-page docs yields:
  - first KV/Form graph cells on page 1
  - second KV/Form graph cells on page 2

### Why
This ensures graph-cell provenance remains consistent with concatenated page numbering, fixing KV/Form items appearing on the wrong page after merge.