### PR TITLE
fix: sync picture classification enums with DocumentFigureClassifier-v2.0 model

### DIFF
--- a/docling_core/types/doc/document.py
+++ b/docling_core/types/doc/document.py
@@ -5400,56 +5400,60 @@ class DoclingDocument(BaseModel):
             """Extract any picture classification label from the chunk."""
             label = None
 
-            # All possible picture classification labels
-            all_labels = [
-                # Charts
-                PictureClassificationLabel.PIE_CHART,
-                PictureClassificationLabel.BAR_CHART,
-                PictureClassificationLabel.STACKED_BAR_CHART,
-                PictureClassificationLabel.LINE_CHART,
-                PictureClassificationLabel.FLOW_CHART,
-                PictureClassificationLabel.SCATTER_CHART,
-                PictureClassificationLabel.SCATTER_PLOT,
-                PictureClassificationLabel.BOX_PLOT,
-                PictureClassificationLabel.HEATMAP,
-                PictureClassificationLabel.TABLE,
-                # Images
-                PictureClassificationLabel.NATURAL_IMAGE,
-                PictureClassificationLabel.PHOTOGRAPH,
-                PictureClassificationLabel.FULL_PAGE_IMAGE,
-                PictureClassificationLabel.PAGE_THUMBNAIL,
-                PictureClassificationLabel.REMOTE_SENSING,
-                # Company/Document elements
-                PictureClassificationLabel.ICON,
+            # Current v2 model labels (DocumentFigureClassifier-v2.0)
+            all_labels: list[PictureClassificationLabel | str] = [
                 PictureClassificationLabel.LOGO,
-                PictureClassificationLabel.SIGNATURE,
-                PictureClassificationLabel.STAMP,
-                PictureClassificationLabel.QR_CODE,
-                PictureClassificationLabel.BAR_CODE,
-                PictureClassificationLabel.SCREENSHOT,
-                PictureClassificationLabel.SCREENSHOT_FROM_COMPUTER,
-                PictureClassificationLabel.SCREENSHOT_FROM_MANUAL,
-                # Chemistry
-                PictureClassificationLabel.MOLECULAR_STRUCTURE,
-                PictureClassificationLabel.MARKUSH_STRUCTURE,
-                PictureClassificationLabel.CHEMISTRY_STRUCTURE,
-                # Geology/Geography
-                PictureClassificationLabel.GEOGRAPHICAL_MAP,
-                PictureClassificationLabel.TOPOGRAPHICAL_MAP,
-                # Engineering
+                PictureClassificationLabel.PHOTOGRAPH,
+                PictureClassificationLabel.ICON,
                 PictureClassificationLabel.ENGINEERING_DRAWING,
-                # Other
+                PictureClassificationLabel.LINE_CHART,
+                PictureClassificationLabel.BAR_CHART,
                 PictureClassificationLabel.OTHER,
-                PictureClassificationLabel.PICTURE_GROUP,
+                PictureClassificationLabel.TABLE,
+                PictureClassificationLabel.FLOW_CHART,
+                PictureClassificationLabel.SCREENSHOT_FROM_COMPUTER,
+                PictureClassificationLabel.SIGNATURE,
+                PictureClassificationLabel.SCREENSHOT_FROM_MANUAL,
+                PictureClassificationLabel.GEOGRAPHICAL_MAP,
+                PictureClassificationLabel.PIE_CHART,
+                PictureClassificationLabel.PAGE_THUMBNAIL,
+                PictureClassificationLabel.STAMP,
                 PictureClassificationLabel.MUSIC,
                 PictureClassificationLabel.CALENDAR,
+                PictureClassificationLabel.QR_CODE,
+                PictureClassificationLabel.BAR_CODE,
+                PictureClassificationLabel.FULL_PAGE_IMAGE,
+                PictureClassificationLabel.SCATTER_PLOT,
+                PictureClassificationLabel.CHEMISTRY_STRUCTURE,
+                PictureClassificationLabel.TOPOGRAPHICAL_MAP,
                 PictureClassificationLabel.CROSSWORD_PUZZLE,
-                # Legacy SmolDocling labels
-                "line",
-                "dot_line",
-                "vbar_categorical",
-                "hbar_categorical",
+                PictureClassificationLabel.BOX_PLOT,
             ]
+
+            # Legacy v1 model labels
+            all_labels.extend(
+                [
+                    PictureClassificationLabel.STACKED_BAR_CHART,
+                    PictureClassificationLabel.SCATTER_CHART,
+                    PictureClassificationLabel.HEATMAP,
+                    PictureClassificationLabel.NATURAL_IMAGE,
+                    PictureClassificationLabel.REMOTE_SENSING,
+                    PictureClassificationLabel.SCREENSHOT,
+                    PictureClassificationLabel.MOLECULAR_STRUCTURE,
+                    PictureClassificationLabel.MARKUSH_STRUCTURE,
+                    PictureClassificationLabel.PICTURE_GROUP,
+                ]
+            )
+
+            # Legacy SmolDocling labels
+            all_labels.extend(
+                [
+                    "line",
+                    "dot_line",
+                    "vbar_categorical",
+                    "hbar_categorical",
+                ]
+            )
 
             # Mapping for legacy labels
             label_mapping = {

--- a/docling_core/types/doc/labels.py
+++ b/docling_core/types/doc/labels.py
@@ -93,61 +93,64 @@ class GroupLabel(str, Enum):
 class PictureClassificationLabel(str, Enum):
     """PictureClassificationLabel."""
 
-    OTHER = "other"
+    # Current v2 model labels (DocumentFigureClassifier-v2.0)
 
-    # If more than one picture is grouped together, it
-    # is generally not possible to assign a label
-    PICTURE_GROUP = "picture_group"
-
-    # General
-    PIE_CHART = "pie_chart"
+    # Charts
     BAR_CHART = "bar_chart"
-    STACKED_BAR_CHART = "stacked_bar_chart"
-    LINE_CHART = "line_chart"
-    FLOW_CHART = "flow_chart"
-    SCATTER_CHART = "scatter_chart"
-    SCATTER_PLOT = "scatter_plot"
     BOX_PLOT = "box_plot"
-    HEATMAP = "heatmap"
-    REMOTE_SENSING = "remote_sensing"
+    FLOW_CHART = "flow_chart"
+    LINE_CHART = "line_chart"
+    PIE_CHART = "pie_chart"
+    SCATTER_PLOT = "scatter_plot"
     TABLE = "table"
 
-    NATURAL_IMAGE = "natural_image"
-    PHOTOGRAPH = "photograph"
+    # Images
     FULL_PAGE_IMAGE = "full_page_image"
     PAGE_THUMBNAIL = "page_thumbnail"
+    PHOTOGRAPH = "photograph"
 
     # Chemistry
-    MOLECULAR_STRUCTURE = "chemistry_molecular_structure"
-    MARKUSH_STRUCTURE = "chemistry_markush_structure"
     CHEMISTRY_STRUCTURE = "chemistry_structure"
 
-    # Company
+    # Company & Document
+    BAR_CODE = "bar_code"
     ICON = "icon"
     LOGO = "logo"
+    QR_CODE = "qr_code"
     SIGNATURE = "signature"
     STAMP = "stamp"
-    QR_CODE = "qr_code"
-    BAR_CODE = "bar_code"
-    SCREENSHOT = "screenshot"
+
+    # Engineering
+    ENGINEERING_DRAWING = "engineering_drawing"
+
+    # Screenshots
     SCREENSHOT_FROM_COMPUTER = "screenshot_from_computer"
     SCREENSHOT_FROM_MANUAL = "screenshot_from_manual"
 
-    # Geology/Geography
-    GEOGRAPHIC_MAP = "map"
+    # Geography
     GEOGRAPHICAL_MAP = "geographical_map"
     TOPOGRAPHICAL_MAP = "topographical_map"
-    STRATIGRAPHIC_CHART = "stratigraphic_chart"
 
-    # Engineering
-    CAD_DRAWING = "cad_drawing"
-    ENGINEERING_DRAWING = "engineering_drawing"
-    ELECTRICAL_DIAGRAM = "electrical_diagram"
-
-    # Other specific
-    MUSIC = "music"
+    # Other
     CALENDAR = "calendar"
     CROSSWORD_PUZZLE = "crossword_puzzle"
+    MUSIC = "music"
+    OTHER = "other"
+
+    # Legacy labels
+    CAD_DRAWING = "cad_drawing"
+    ELECTRICAL_DIAGRAM = "electrical_diagram"
+    GEOGRAPHIC_MAP = "map"
+    HEATMAP = "heatmap"
+    MARKUSH_STRUCTURE = "chemistry_markush_structure"
+    MOLECULAR_STRUCTURE = "chemistry_molecular_structure"
+    NATURAL_IMAGE = "natural_image"
+    PICTURE_GROUP = "picture_group"
+    REMOTE_SENSING = "remote_sensing"
+    SCATTER_CHART = "scatter_chart"
+    SCREENSHOT = "screenshot"
+    STACKED_BAR_CHART = "stacked_bar_chart"
+    STRATIGRAPHIC_CHART = "stratigraphic_chart"
 
     def __str__(self):
         """Get string value."""

--- a/docling_core/types/doc/tokens.py
+++ b/docling_core/types/doc/tokens.py
@@ -42,67 +42,70 @@ _SECTION_HEADER_PREFIX = "section_header_level_"
 class _PictureClassificationToken(str, Enum):
     """PictureClassificationToken."""
 
-    OTHER = "<other>"
+    # Current v2 model tokens (DocumentFigureClassifier-v2.0)
 
-    # If more than one picture is grouped together, it
-    # is generally not possible to assign a label
-    PICTURE_GROUP = "<picture_group>"
-
-    # General
-    CHART = "<chart>"
-    PIE_CHART = "<pie_chart>"
+    # Charts
     BAR_CHART = "<bar_chart>"
-    STACKED_BAR_CHART = "<stacked_bar_chart>"
-    LINE_CHART = "<line_chart>"
-    FLOW_CHART = "<flow_chart>"
-    SCATTER_CHART = "<scatter_chart>"
-    SCATTER_PLOT = "<scatter_plot>"
     BOX_PLOT = "<box_plot>"
-    HEATMAP = "<heatmap>"
-    REMOTE_SENSING = "<remote_sensing>"
-    INFOGRAPHIC = "<infographic>"
-    DECORATION = "<decoration>"
-    ILLUSTRATION = "<illustration>"
+    FLOW_CHART = "<flow_chart>"
+    LINE_CHART = "<line_chart>"
+    PIE_CHART = "<pie_chart>"
+    SCATTER_PLOT = "<scatter_plot>"
     TABLE = "<table>"
 
-    NATURAL_IMAGE = "<natural_image>"
-    PHOTOGRAPH = "<photograph>"
+    # Images
     FULL_PAGE_IMAGE = "<full_page_image>"
     PAGE_THUMBNAIL = "<page_thumbnail>"
-    PERSON = "<person>"
+    PHOTOGRAPH = "<photograph>"
 
     # Chemistry
-    MOLECULAR_STRUCTURE = "<chemistry_molecular_structure>"
-    MARKUSH_STRUCTURE = "<chemistry_markush_structure>"
     CHEMISTRY_STRUCTURE = "<chemistry_structure>"
 
-    # Company
+    # Company & Document
+    BAR_CODE = "<bar_code>"
     ICON = "<icon>"
     LOGO = "<logo>"
+    QR_CODE = "<qr_code>"
     SIGNATURE = "<signature>"
     STAMP = "<stamp>"
-    QR_CODE = "<qr_code>"
-    BAR_CODE = "<bar_code>"
-    SCREENSHOT = "<screenshot>"
-    SCREENSHOT_FROM_COMPUTER = "<screenshot_from_computer>"
-    SCREENSHOT_FROM_MANUAL = "<screenshot_from_manual>"
-    UI_ELEMENT = "<ui_element>"
-
-    # Geology/Geography
-    GEOGRAPHIC_MAP = "<map>"
-    GEOGRAPHICAL_MAP = "<geographical_map>"
-    TOPOGRAPHICAL_MAP = "<topographical_map>"
-    STRATIGRAPHIC_CHART = "<stratigraphic_chart>"
 
     # Engineering
-    CAD_DRAWING = "<cad_drawing>"
     ENGINEERING_DRAWING = "<engineering_drawing>"
-    ELECTRICAL_DIAGRAM = "<electrical_diagram>"
 
-    # Other specific
-    MUSIC = "<music>"
+    # Screenshots
+    SCREENSHOT_FROM_COMPUTER = "<screenshot_from_computer>"
+    SCREENSHOT_FROM_MANUAL = "<screenshot_from_manual>"
+
+    # Geography
+    GEOGRAPHICAL_MAP = "<geographical_map>"
+    TOPOGRAPHICAL_MAP = "<topographical_map>"
+
+    # Other
     CALENDAR = "<calendar>"
     CROSSWORD_PUZZLE = "<crossword_puzzle>"
+    MUSIC = "<music>"
+    OTHER = "<other>"
+
+    # Legacy tokens
+    CAD_DRAWING = "<cad_drawing>"
+    CHART = "<chart>"
+    DECORATION = "<decoration>"
+    ELECTRICAL_DIAGRAM = "<electrical_diagram>"
+    GEOGRAPHIC_MAP = "<map>"
+    HEATMAP = "<heatmap>"
+    ILLUSTRATION = "<illustration>"
+    INFOGRAPHIC = "<infographic>"
+    MARKUSH_STRUCTURE = "<chemistry_markush_structure>"
+    MOLECULAR_STRUCTURE = "<chemistry_molecular_structure>"
+    NATURAL_IMAGE = "<natural_image>"
+    PERSON = "<person>"
+    PICTURE_GROUP = "<picture_group>"
+    REMOTE_SENSING = "<remote_sensing>"
+    SCATTER_CHART = "<scatter_chart>"
+    SCREENSHOT = "<screenshot>"
+    STACKED_BAR_CHART = "<stacked_bar_chart>"
+    STRATIGRAPHIC_CHART = "<stratigraphic_chart>"
+    UI_ELEMENT = "<ui_element>"
 
 
 class _CodeLanguageToken(str, Enum):


### PR DESCRIPTION
## Summary

- `DocumentFigureClassifier-v2.0` model outputs class names (e.g. `photograph`, `geographical_map`, `scatter_plot`) that are not defined in `_PictureClassificationToken` and `PictureClassificationLabel` enums, causing `ValueError` during DocTags serialization
- Added all 15 missing classification entries to both `_PictureClassificationToken` (tokens.py) and `PictureClassificationLabel` (labels.py) to fully align with the v2.0 model's `id2label` config

Resolves #499  #541

### Added tokens

| Category | Token |
|---|---|
| Charts | `scatter_plot`, `box_plot`, `table` |
| Images | `photograph`, `full_page_image`, `page_thumbnail` |
| Chemistry | `chemistry_structure` |
| Screenshots | `screenshot_from_computer`, `screenshot_from_manual` |
| Geography | `geographical_map`, `topographical_map` |
| Engineering | `engineering_drawing` |
| Other | `music`, `calendar`, `crossword_puzzle` |

## Test plan

- [x] Ruff lint and format check passed
- [x] All 288 existing tests pass (chunker tests excluded due to unrelated `tree_sitter` dependency)
