### PR TITLE
fix: convert headings to plain text in table cells

### DIFF
--- a/docling_core/transforms/serializer/markdown.py
+++ b/docling_core/transforms/serializer/markdown.py
@@ -196,6 +196,7 @@ class MarkdownTextSerializer(BaseModel, BaseTextSerializer):
         doc_serializer: BaseDocSerializer,
         doc: DoclingDocument,
         is_inline_scope: bool = False,
+        in_table_cell: bool = False,
         visited: Optional[set[str]] = None,  # refs of visited items
         **kwargs: Any,
     ) -> SerializationResult:
@@ -276,7 +277,7 @@ class MarkdownTextSerializer(BaseModel, BaseTextSerializer):
                 pieces.append(text)
                 text_part = " ".join(pieces)
             else:
-                text_part = self._format_heading(text, item)
+                text_part = self._format_heading(text, item, in_table_cell=in_table_cell)
         elif isinstance(item, CodeItem):
             if params.format_code_blocks:
                 # inline items and all hyperlinks: use single backticks
@@ -325,8 +326,13 @@ class MarkdownTextSerializer(BaseModel, BaseTextSerializer):
         self,
         text: str,
         item: Union[TitleItem, SectionHeaderItem],
+        in_table_cell: bool = False,
     ) -> str:
         """Format a heading/title item. Override to customize heading representation."""
+        # According to markdown specs, headings are not allowed inside tables
+        # Convert to plain text when in table cell
+        if in_table_cell:
+            return text
         num_hashes = 1 if isinstance(item, TitleItem) else item.level + 1
         return f"{num_hashes * '#'} {text}"
 
@@ -548,7 +554,7 @@ class MarkdownTableSerializer(BaseTableSerializer):
                 for col in row:
                     if isinstance(col, RichTableCell):
                         ref_item = col.ref.resolve(doc=doc)
-                        inner_kwargs = {**kwargs, "_nested_in_table": True}
+                        inner_kwargs = {**kwargs, "_nested_in_table": True, "in_table_cell": True}
                         cell_text = doc_serializer.serialize(
                             item=ref_item,
                             **inner_kwargs,

--- a/docling_core/transforms/serializer/markdown.py
+++ b/docling_core/transforms/serializer/markdown.py
@@ -229,7 +229,26 @@ class MarkdownTextSerializer(BaseModel, BaseTextSerializer):
         visited: Optional[set[str]] = None,  # refs of visited items
         **kwargs: Any,
     ) -> SerializationResult:
-        """Serializes the passed item."""
+        """Serialize the passed text item to Markdown.
+
+        Args:
+            item: The text item to serialize.
+            doc_serializer: The parent document serializer.
+            doc: The document the item belongs to.
+            is_inline_scope: Whether serialization happens in an inline context
+                (e.g. inside an InlineGroup). Affects delimiter and code/formula
+                wrapping.
+            in_table_cell: Whether the item is being rendered inside a table
+                cell. When ``True``, heading markers are suppressed because the
+                Markdown spec does not allow headings inside tables.
+            visited: Set of already-visited item refs used to prevent duplicate
+                serialization.
+            **kwargs: Additional keyword arguments forwarded to
+                ``MarkdownParams``.
+
+        Returns:
+            The serialization result containing the rendered Markdown text.
+        """
         my_visited = visited if visited is not None else set()
         params = MarkdownParams(**kwargs)
         res_parts: list[SerializationResult] = []
@@ -366,9 +385,21 @@ class MarkdownTextSerializer(BaseModel, BaseTextSerializer):
         item: Union[TitleItem, SectionHeaderItem],
         in_table_cell: bool = False,
     ) -> str:
-        """Format a heading/title item. Override to customize heading representation."""
-        # According to markdown specs, headings are not allowed inside tables
-        # Convert to plain text when in table cell
+        """Format a heading or title item as a Markdown heading string.
+
+        Override this method to customize heading representation in subclasses.
+
+        Args:
+            text: The heading text content, already post-processed.
+            item: The title or section header item being formatted.
+            in_table_cell: When ``True``, returns plain text without ``#``
+                markers because headings are not valid inside Markdown tables
+                per the Markdown spec.
+
+        Returns:
+            The formatted heading string, e.g. ``"## My heading"`` for a
+            level-1 section header, or plain ``text`` when inside a table cell.
+        """
         if in_table_cell:
             return text
         num_hashes = 1 if isinstance(item, TitleItem) else item.level + 1

--- a/docling_core/transforms/serializer/markdown.py
+++ b/docling_core/transforms/serializer/markdown.py
@@ -225,6 +225,7 @@ class MarkdownTextSerializer(BaseModel, BaseTextSerializer):
         doc_serializer: BaseDocSerializer,
         doc: DoclingDocument,
         is_inline_scope: bool = False,
+        in_table_cell: bool = False,
         visited: Optional[set[str]] = None,  # refs of visited items
         **kwargs: Any,
     ) -> SerializationResult:
@@ -313,7 +314,7 @@ class MarkdownTextSerializer(BaseModel, BaseTextSerializer):
                 pieces.append(text)
                 text_part = " ".join(pieces)
             else:
-                text_part = self._format_heading(text, item)
+                text_part = self._format_heading(text, item, in_table_cell=in_table_cell)
         elif isinstance(item, CodeItem):
             if params.format_code_blocks:
                 # inline items and all hyperlinks: use single backticks
@@ -363,8 +364,13 @@ class MarkdownTextSerializer(BaseModel, BaseTextSerializer):
         self,
         text: str,
         item: Union[TitleItem, SectionHeaderItem],
+        in_table_cell: bool = False,
     ) -> str:
         """Format a heading/title item. Override to customize heading representation."""
+        # According to markdown specs, headings are not allowed inside tables
+        # Convert to plain text when in table cell
+        if in_table_cell:
+            return text
         num_hashes = 1 if isinstance(item, TitleItem) else item.level + 1
         return f"{num_hashes * '#'} {text}"
 
@@ -605,7 +611,7 @@ class MarkdownTableSerializer(BaseTableSerializer):
                 for col in row:
                     if isinstance(col, RichTableCell):
                         ref_item = col.ref.resolve(doc=doc)
-                        inner_kwargs = {**kwargs, "_nested_in_table": True}
+                        inner_kwargs = {**kwargs, "_nested_in_table": True, "in_table_cell": True}
                         cell_text = doc_serializer.serialize(
                             item=ref_item,
                             **inner_kwargs,

--- a/docling_core/transforms/serializer/markdown.py
+++ b/docling_core/transforms/serializer/markdown.py
@@ -200,7 +200,26 @@ class MarkdownTextSerializer(BaseModel, BaseTextSerializer):
         visited: Optional[set[str]] = None,  # refs of visited items
         **kwargs: Any,
     ) -> SerializationResult:
-        """Serializes the passed item."""
+        """Serialize the passed text item to Markdown.
+
+        Args:
+            item: The text item to serialize.
+            doc_serializer: The parent document serializer.
+            doc: The document the item belongs to.
+            is_inline_scope: Whether serialization happens in an inline context
+                (e.g. inside an InlineGroup). Affects delimiter and code/formula
+                wrapping.
+            in_table_cell: Whether the item is being rendered inside a table
+                cell. When ``True``, heading markers are suppressed because the
+                Markdown spec does not allow headings inside tables.
+            visited: Set of already-visited item refs used to prevent duplicate
+                serialization.
+            **kwargs: Additional keyword arguments forwarded to
+                ``MarkdownParams``.
+
+        Returns:
+            The serialization result containing the rendered Markdown text.
+        """
         my_visited = visited if visited is not None else set()
         params = MarkdownParams(**kwargs)
         res_parts: list[SerializationResult] = []
@@ -328,9 +347,21 @@ class MarkdownTextSerializer(BaseModel, BaseTextSerializer):
         item: Union[TitleItem, SectionHeaderItem],
         in_table_cell: bool = False,
     ) -> str:
-        """Format a heading/title item. Override to customize heading representation."""
-        # According to markdown specs, headings are not allowed inside tables
-        # Convert to plain text when in table cell
+        """Format a heading or title item as a Markdown heading string.
+
+        Override this method to customize heading representation in subclasses.
+
+        Args:
+            text: The heading text content, already post-processed.
+            item: The title or section header item being formatted.
+            in_table_cell: When ``True``, returns plain text without ``#``
+                markers because headings are not valid inside Markdown tables
+                per the Markdown spec.
+
+        Returns:
+            The formatted heading string, e.g. ``"## My heading"`` for a
+            level-1 section header, or plain ``text`` when inside a table cell.
+        """
         if in_table_cell:
             return text
         num_hashes = 1 if isinstance(item, TitleItem) else item.level + 1

--- a/docling_core/transforms/serializer/plain_text.py
+++ b/docling_core/transforms/serializer/plain_text.py
@@ -45,6 +45,17 @@ class PlainTextTextSerializer(MarkdownTextSerializer):
         item: Union[TitleItem, SectionHeaderItem],
         in_table_cell: bool = False,
     ) -> str:
+        """Return the heading text without any ``#`` markers.
+
+        Args:
+            text: The heading text content, already post-processed.
+            item: The title or section header item being formatted.
+            in_table_cell: Accepted for interface compatibility; has no effect
+                because this serializer always returns plain text.
+
+        Returns:
+            The undecorated heading text.
+        """
         return text
 
 

--- a/docling_core/transforms/serializer/plain_text.py
+++ b/docling_core/transforms/serializer/plain_text.py
@@ -43,6 +43,7 @@ class PlainTextTextSerializer(MarkdownTextSerializer):
         self,
         text: str,
         item: Union[TitleItem, SectionHeaderItem],
+        in_table_cell: bool = False,
     ) -> str:
         return text
 

--- a/docling_core/transforms/serializer/plain_text.py
+++ b/docling_core/transforms/serializer/plain_text.py
@@ -37,6 +37,17 @@ class PlainTextTextSerializer(MarkdownTextSerializer):
         item: Union[TitleItem, SectionHeaderItem],
         in_table_cell: bool = False,
     ) -> str:
+        """Return the heading text without any ``#`` markers.
+
+        Args:
+            text: The heading text content, already post-processed.
+            item: The title or section header item being formatted.
+            in_table_cell: Accepted for interface compatibility; has no effect
+                because this serializer always returns plain text.
+
+        Returns:
+            The undecorated heading text.
+        """
         return text
 
 

--- a/docling_core/transforms/serializer/plain_text.py
+++ b/docling_core/transforms/serializer/plain_text.py
@@ -35,6 +35,7 @@ class PlainTextTextSerializer(MarkdownTextSerializer):
         self,
         text: str,
         item: Union[TitleItem, SectionHeaderItem],
+        in_table_cell: bool = False,
     ) -> str:
         return text
 

--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -518,6 +518,76 @@ def test_md_pipe_in_table():
     assert ser == "| Fruits &#124; Veggies   |\n|-------------------------|"
 
 
+def test_md_heading_in_rich_table_cell_renders_as_plain_text():
+    """Regression #2722: headings inside RichTableCell must not emit ``#`` markers.
+
+    According to the Markdown spec, heading syntax is invalid inside tables.
+    A SectionHeaderItem or TitleItem referenced by a RichTableCell must be
+    serialised as plain text, not as ``## Heading``.
+    """
+    doc = DoclingDocument(name="heading_in_table")
+    table = doc.add_table(data=TableData(num_rows=2, num_cols=2))
+
+    # Row 0: header row — cells reference a SectionHeaderItem and a TitleItem.
+    section_header = doc.add_heading(text="Section Heading", level=1, parent=table)
+    title = doc.add_title(text="Document Title", parent=table)
+
+    doc.add_table_cell(
+        table,
+        RichTableCell(
+            start_row_offset_idx=0,
+            end_row_offset_idx=1,
+            start_col_offset_idx=0,
+            end_col_offset_idx=1,
+            ref=section_header.get_ref(),
+        ),
+    )
+    doc.add_table_cell(
+        table,
+        RichTableCell(
+            start_row_offset_idx=0,
+            end_row_offset_idx=1,
+            start_col_offset_idx=1,
+            end_col_offset_idx=2,
+            ref=title.get_ref(),
+        ),
+    )
+
+    # Row 1: plain data row.
+    doc.add_table_cell(
+        table,
+        TableCell(
+            start_row_offset_idx=1,
+            end_row_offset_idx=2,
+            start_col_offset_idx=0,
+            end_col_offset_idx=1,
+            text="value A",
+        ),
+    )
+    doc.add_table_cell(
+        table,
+        TableCell(
+            start_row_offset_idx=1,
+            end_row_offset_idx=2,
+            start_col_offset_idx=1,
+            end_col_offset_idx=2,
+            text="value B",
+        ),
+    )
+
+    md = doc.export_to_markdown()
+
+    # The heading text must appear as plain text inside the table.
+    assert "Section Heading" in md
+    assert "Document Title" in md
+
+    # No ``#`` markers must appear anywhere — the whole document contains only
+    # this table, so any hash marker would be a heading leaking into a cell.
+    table_lines = [line for line in md.splitlines() if line.startswith("|")]
+    for line in table_lines:
+        assert "#" not in line, f"Heading marker leaked into table cell: {line!r}\nFull output:\n{md}"
+
+
 def test_cell_content_has_table_detects_descendant_table():
     """Ensure nested tables are detected through non-table parent nodes."""
     doc = DoclingDocument(name="descendant_table")

--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -519,16 +519,15 @@ def test_md_pipe_in_table():
 
 
 def test_md_heading_in_rich_table_cell_renders_as_plain_text():
-    """Regression #2722: headings inside RichTableCell must not emit ``#`` markers.
+    """Test headings inside RichTableCell must not emit `#` markers.
 
     According to the Markdown spec, heading syntax is invalid inside tables.
     A SectionHeaderItem or TitleItem referenced by a RichTableCell must be
-    serialised as plain text, not as ``## Heading``.
+    serialized as plain text, not as `## Heading`.
     """
     doc = DoclingDocument(name="heading_in_table")
     table = doc.add_table(data=TableData(num_rows=2, num_cols=2))
 
-    # Row 0: header row — cells reference a SectionHeaderItem and a TitleItem.
     section_header = doc.add_heading(text="Section Heading", level=1, parent=table)
     title = doc.add_title(text="Document Title", parent=table)
 
@@ -552,8 +551,6 @@ def test_md_heading_in_rich_table_cell_renders_as_plain_text():
             ref=title.get_ref(),
         ),
     )
-
-    # Row 1: plain data row.
     doc.add_table_cell(
         table,
         TableCell(
@@ -576,13 +573,8 @@ def test_md_heading_in_rich_table_cell_renders_as_plain_text():
     )
 
     md = doc.export_to_markdown()
-
-    # The heading text must appear as plain text inside the table.
     assert "Section Heading" in md
     assert "Document Title" in md
-
-    # No ``#`` markers must appear anywhere — the whole document contains only
-    # this table, so any hash marker would be a heading leaking into a cell.
     table_lines = [line for line in md.splitlines() if line.startswith("|")]
     for line in table_lines:
         assert "#" not in line, f"Heading marker leaked into table cell: {line!r}\nFull output:\n{md}"

--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -371,16 +371,15 @@ def test_md_pipe_in_table():
 
 
 def test_md_heading_in_rich_table_cell_renders_as_plain_text():
-    """Regression #2722: headings inside RichTableCell must not emit ``#`` markers.
+    """Test headings inside RichTableCell must not emit `#` markers.
 
     According to the Markdown spec, heading syntax is invalid inside tables.
     A SectionHeaderItem or TitleItem referenced by a RichTableCell must be
-    serialised as plain text, not as ``## Heading``.
+    serialized as plain text, not as `## Heading`.
     """
     doc = DoclingDocument(name="heading_in_table")
     table = doc.add_table(data=TableData(num_rows=2, num_cols=2))
 
-    # Row 0: header row — cells reference a SectionHeaderItem and a TitleItem.
     section_header = doc.add_heading(text="Section Heading", level=1, parent=table)
     title = doc.add_title(text="Document Title", parent=table)
 
@@ -404,8 +403,6 @@ def test_md_heading_in_rich_table_cell_renders_as_plain_text():
             ref=title.get_ref(),
         ),
     )
-
-    # Row 1: plain data row.
     doc.add_table_cell(
         table,
         TableCell(
@@ -428,13 +425,8 @@ def test_md_heading_in_rich_table_cell_renders_as_plain_text():
     )
 
     md = doc.export_to_markdown()
-
-    # The heading text must appear as plain text inside the table.
     assert "Section Heading" in md
     assert "Document Title" in md
-
-    # No ``#`` markers must appear anywhere — the whole document contains only
-    # this table, so any hash marker would be a heading leaking into a cell.
     table_lines = [line for line in md.splitlines() if line.startswith("|")]
     for line in table_lines:
         assert "#" not in line, f"Heading marker leaked into table cell: {line!r}\nFull output:\n{md}"

--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -370,6 +370,76 @@ def test_md_pipe_in_table():
     assert ser == "| Fruits &#124; Veggies   |\n|-------------------------|"
 
 
+def test_md_heading_in_rich_table_cell_renders_as_plain_text():
+    """Regression #2722: headings inside RichTableCell must not emit ``#`` markers.
+
+    According to the Markdown spec, heading syntax is invalid inside tables.
+    A SectionHeaderItem or TitleItem referenced by a RichTableCell must be
+    serialised as plain text, not as ``## Heading``.
+    """
+    doc = DoclingDocument(name="heading_in_table")
+    table = doc.add_table(data=TableData(num_rows=2, num_cols=2))
+
+    # Row 0: header row — cells reference a SectionHeaderItem and a TitleItem.
+    section_header = doc.add_heading(text="Section Heading", level=1, parent=table)
+    title = doc.add_title(text="Document Title", parent=table)
+
+    doc.add_table_cell(
+        table,
+        RichTableCell(
+            start_row_offset_idx=0,
+            end_row_offset_idx=1,
+            start_col_offset_idx=0,
+            end_col_offset_idx=1,
+            ref=section_header.get_ref(),
+        ),
+    )
+    doc.add_table_cell(
+        table,
+        RichTableCell(
+            start_row_offset_idx=0,
+            end_row_offset_idx=1,
+            start_col_offset_idx=1,
+            end_col_offset_idx=2,
+            ref=title.get_ref(),
+        ),
+    )
+
+    # Row 1: plain data row.
+    doc.add_table_cell(
+        table,
+        TableCell(
+            start_row_offset_idx=1,
+            end_row_offset_idx=2,
+            start_col_offset_idx=0,
+            end_col_offset_idx=1,
+            text="value A",
+        ),
+    )
+    doc.add_table_cell(
+        table,
+        TableCell(
+            start_row_offset_idx=1,
+            end_row_offset_idx=2,
+            start_col_offset_idx=1,
+            end_col_offset_idx=2,
+            text="value B",
+        ),
+    )
+
+    md = doc.export_to_markdown()
+
+    # The heading text must appear as plain text inside the table.
+    assert "Section Heading" in md
+    assert "Document Title" in md
+
+    # No ``#`` markers must appear anywhere — the whole document contains only
+    # this table, so any hash marker would be a heading leaking into a cell.
+    table_lines = [line for line in md.splitlines() if line.startswith("|")]
+    for line in table_lines:
+        assert "#" not in line, f"Heading marker leaked into table cell: {line!r}\nFull output:\n{md}"
+
+
 def test_cell_content_has_table_detects_descendant_table():
     """Ensure nested tables are detected through non-table parent nodes."""
     doc = DoclingDocument(name="descendant_table")


### PR DESCRIPTION
## Description

According to markdown specs, headings are not allowed inside tables. This fix converts markdown headings to plain text when rendering content inside table cells.

## Fix

In MarkdownTextSerializer.serialize(), added in_table_cell parameter. The _format_heading() method now checks this flag and returns plain text instead of markdown headings when rendering inside table cells.

## Issue

Fixes docling-project/docling#2722