### PR TITLE
feat(document): add artifacts_dir param to export_to_markdown

### DIFF
--- a/docling_core/types/doc/document.py
+++ b/docling_core/types/doc/document.py
@@ -5903,6 +5903,7 @@ class DoclingDocument(BaseModel):
         image_placeholder: str = "<!-- image -->",
         enable_chart_tables: bool = True,
         image_mode: ImageRefMode = ImageRefMode.PLACEHOLDER,
+        artifacts_dir: Optional[Path] = None,
         indent: int = 4,
         text_width: int = -1,
         page_no: Optional[int] = None,
@@ -5947,6 +5948,12 @@ class DoclingDocument(BaseModel):
         :param image_mode: The mode to use for including images in the
             markdown. (Default value = ImageRefMode.PLACEHOLDER).
         :type image_mode: ImageRefMode = ImageRefMode.PLACEHOLDER
+        :param artifacts_dir: Directory where images are saved when
+            image_mode is ImageRefMode.REFERENCED. The markdown output will
+            contain relative paths pointing into this directory. Ignored when
+            image_mode is not ImageRefMode.REFERENCED.
+            (Default value = None).
+        :type artifacts_dir: Optional[Path] = None
         :param indent: The indent in spaces of the nested lists.
             (Default value = 4).
         :type indent: int = 4
@@ -5994,8 +6001,16 @@ class DoclingDocument(BaseModel):
                 DeprecationWarning,
             )
 
+        if image_mode == ImageRefMode.REFERENCED and artifacts_dir is not None:
+            os.makedirs(artifacts_dir, exist_ok=True)
+            doc: DoclingDocument = self._with_pictures_refs(
+                image_dir=artifacts_dir, page_no=page_no
+            )
+        else:
+            doc = self
+
         serializer = MarkdownDocSerializer(
-            doc=self,
+            doc=doc,
             params=MarkdownParams(
                 labels=my_labels,
                 layers=my_layers,

--- a/docling_core/types/doc/document.py
+++ b/docling_core/types/doc/document.py
@@ -6003,9 +6003,7 @@ class DoclingDocument(BaseModel):
 
         if image_mode == ImageRefMode.REFERENCED and artifacts_dir is not None:
             os.makedirs(artifacts_dir, exist_ok=True)
-            doc: DoclingDocument = self._with_pictures_refs(
-                image_dir=artifacts_dir, page_no=page_no
-            )
+            doc: DoclingDocument = self._with_pictures_refs(image_dir=artifacts_dir, page_no=page_no)
         else:
             doc = self
 

--- a/docling_core/types/doc/document.py
+++ b/docling_core/types/doc/document.py
@@ -6177,6 +6177,7 @@ class DoclingDocument(BaseModel):
         image_placeholder: str = "<!-- image -->",
         enable_chart_tables: bool = True,
         image_mode: ImageRefMode = ImageRefMode.PLACEHOLDER,
+        artifacts_dir: Optional[Path] = None,
         indent: int = 4,
         text_width: int = -1,
         page_no: Optional[int] = None,
@@ -6221,6 +6222,12 @@ class DoclingDocument(BaseModel):
         :param image_mode: The mode to use for including images in the
             markdown. (Default value = ImageRefMode.PLACEHOLDER).
         :type image_mode: ImageRefMode = ImageRefMode.PLACEHOLDER
+        :param artifacts_dir: Directory where images are saved when
+            image_mode is ImageRefMode.REFERENCED. The markdown output will
+            contain relative paths pointing into this directory. Ignored when
+            image_mode is not ImageRefMode.REFERENCED.
+            (Default value = None).
+        :type artifacts_dir: Optional[Path] = None
         :param indent: The indent in spaces of the nested lists.
             (Default value = 4).
         :type indent: int = 4
@@ -6268,8 +6275,14 @@ class DoclingDocument(BaseModel):
                 DeprecationWarning,
             )
 
+        if image_mode == ImageRefMode.REFERENCED and artifacts_dir is not None:
+            os.makedirs(artifacts_dir, exist_ok=True)
+            doc: DoclingDocument = self._with_pictures_refs(image_dir=artifacts_dir, page_no=page_no)
+        else:
+            doc = self
+
         serializer = MarkdownDocSerializer(
-            doc=self,
+            doc=doc,
             params=MarkdownParams(
                 labels=my_labels,
                 layers=my_layers,

--- a/test/test_docling_doc.py
+++ b/test/test_docling_doc.py
@@ -2231,3 +2231,51 @@ def test_docitem_comments_delete_updates_refs():
     # The resolved comment should still work
     resolved = updated_para.comments[0].resolve(doc)
     assert resolved.text == "Comment on second paragraph."
+
+
+def test_export_to_markdown_with_artifacts_dir(sample_doc, tmp_path):
+    """export_to_markdown saves images and returns referenced markdown when artifacts_dir is given."""
+    artifacts_dir = tmp_path / "images"
+
+    md = sample_doc.export_to_markdown(
+        image_mode=ImageRefMode.REFERENCED,
+        artifacts_dir=artifacts_dir,
+    )
+
+    # The directory must be created and contain the saved image(s)
+    assert artifacts_dir.is_dir(), "artifacts_dir was not created"
+    saved_images = list(artifacts_dir.glob("*.png"))
+    assert len(saved_images) > 0, "No images were saved to artifacts_dir"
+
+    # The markdown must contain a reference to at least one saved image
+    assert "![" in md, "Markdown contains no image references"
+    for img_path in saved_images:
+        assert img_path.name in md, f"Image {img_path.name} not referenced in markdown"
+
+
+def test_export_to_markdown_referenced_without_artifacts_dir(sample_doc):
+    """export_to_markdown with REFERENCED mode but no artifacts_dir uses placeholder behaviour."""
+    md = sample_doc.export_to_markdown(image_mode=ImageRefMode.REFERENCED)
+
+    # Without artifacts_dir no images can be written; falls back to placeholder output
+    assert isinstance(md, str)
+    assert len(md) > 0
+
+
+def test_export_to_markdown_artifacts_dir_ignored_for_non_referenced(sample_doc, tmp_path):
+    """artifacts_dir is silently ignored when image_mode is not REFERENCED."""
+    artifacts_dir = tmp_path / "images"
+
+    md_placeholder = sample_doc.export_to_markdown(
+        image_mode=ImageRefMode.PLACEHOLDER,
+        artifacts_dir=artifacts_dir,
+    )
+    md_embedded = sample_doc.export_to_markdown(
+        image_mode=ImageRefMode.EMBEDDED,
+        artifacts_dir=artifacts_dir,
+    )
+
+    # artifacts_dir must NOT have been created for non-REFERENCED modes
+    assert not artifacts_dir.exists(), "artifacts_dir should not be created for non-REFERENCED modes"
+    assert isinstance(md_placeholder, str)
+    assert isinstance(md_embedded, str)

--- a/test/test_docling_doc.py
+++ b/test/test_docling_doc.py
@@ -2620,3 +2620,51 @@ def test_table_data_horizontal_bounding_boxes_with_spans_no_overlap():
             assert a.intersection_area_with(b) == 0, f"row overlap (minimal={minimal})"
         for a, b in itertools.combinations(cols.values(), 2):
             assert a.intersection_area_with(b) == 0, f"col overlap (minimal={minimal})"
+
+
+def test_export_to_markdown_with_artifacts_dir(sample_doc, tmp_path):
+    """export_to_markdown saves images and returns referenced markdown when artifacts_dir is given."""
+    artifacts_dir = tmp_path / "images"
+
+    md = sample_doc.export_to_markdown(
+        image_mode=ImageRefMode.REFERENCED,
+        artifacts_dir=artifacts_dir,
+    )
+
+    # The directory must be created and contain the saved image(s)
+    assert artifacts_dir.is_dir(), "artifacts_dir was not created"
+    saved_images = list(artifacts_dir.glob("*.png"))
+    assert len(saved_images) > 0, "No images were saved to artifacts_dir"
+
+    # The markdown must contain a reference to at least one saved image
+    assert "![" in md, "Markdown contains no image references"
+    for img_path in saved_images:
+        assert img_path.name in md, f"Image {img_path.name} not referenced in markdown"
+
+
+def test_export_to_markdown_referenced_without_artifacts_dir(sample_doc):
+    """export_to_markdown with REFERENCED mode but no artifacts_dir uses placeholder behaviour."""
+    md = sample_doc.export_to_markdown(image_mode=ImageRefMode.REFERENCED)
+
+    # Without artifacts_dir no images can be written; falls back to placeholder output
+    assert isinstance(md, str)
+    assert len(md) > 0
+
+
+def test_export_to_markdown_artifacts_dir_ignored_for_non_referenced(sample_doc, tmp_path):
+    """artifacts_dir is silently ignored when image_mode is not REFERENCED."""
+    artifacts_dir = tmp_path / "images"
+
+    md_placeholder = sample_doc.export_to_markdown(
+        image_mode=ImageRefMode.PLACEHOLDER,
+        artifacts_dir=artifacts_dir,
+    )
+    md_embedded = sample_doc.export_to_markdown(
+        image_mode=ImageRefMode.EMBEDDED,
+        artifacts_dir=artifacts_dir,
+    )
+
+    # artifacts_dir must NOT have been created for non-REFERENCED modes
+    assert not artifacts_dir.exists(), "artifacts_dir should not be created for non-REFERENCED modes"
+    assert isinstance(md_placeholder, str)
+    assert isinstance(md_embedded, str)


### PR DESCRIPTION
## Summary

- Adds an optional `artifacts_dir: Optional[Path]` parameter to `DoclingDocument.export_to_markdown()`
- When `image_mode=ImageRefMode.REFERENCED` and `artifacts_dir` is provided, images are automatically saved to that directory and the returned markdown contains relative paths referencing them
- When `artifacts_dir` is `None` (default) or `image_mode` is not `REFERENCED`, behaviour is unchanged — fully backwards-compatible

**Before:**
```python
# Manual image saving required before calling export_to_markdown
for item, _ in doc.iterate_items():
    if isinstance(item, PictureItem):
        img = item.get_image(doc=doc)
        img.save(f"./images/image_{i}.png")
        item.image.uri = Path(f"./images/image_{i}.png")

md = doc.export_to_markdown(image_mode=ImageRefMode.REFERENCED)
```

**After:**
```python
md = doc.export_to_markdown(
    image_mode=ImageRefMode.REFERENCED,
    artifacts_dir=Path("./images"),
)
```

## Relation to upstream issue

Resolves docling-project/docling#3094

## Test plan

- [x] `test_export_to_markdown_with_artifacts_dir` — verifies images are saved and referenced in markdown
- [x] `test_export_to_markdown_referenced_without_artifacts_dir` — verifies fallback when `artifacts_dir` is omitted
- [x] `test_export_to_markdown_artifacts_dir_ignored_for_non_referenced` — verifies no side-effects for `PLACEHOLDER`/`EMBEDDED` modes
- [x] Existing `test_save_to_disk`, `test_construct_doc`, `test_save_pictures` all still pass
