### PR TITLE
fix: consider rich table cell refs in tree operations

### DIFF
--- a/docling_core/types/doc/document.py
+++ b/docling_core/types/doc/document.py
@@ -3453,6 +3453,9 @@ class DoclingDocument(BaseModel):
             node = child_ref.resolve(self)
             self._update_breadth_first_with_lookup(node=node, refs_to_be_deleted=refs_to_be_deleted, lookup=lookup)
 
+    def _find_referencing_table_cells(self, table: TableItem, ref: str) -> list[RichTableCell]:
+        return [cell for cell in table.data.table_cells if isinstance(cell, RichTableCell) and cell.ref.cref == ref]
+
     def _shift_up(self, *, old_subroot: NodeItem) -> None:
         """Move a subtree up in the document tree, removing the old subroot.
 
@@ -3465,6 +3468,7 @@ class DoclingDocument(BaseModel):
         # use old subroot's parent as new subroot
         new_subroot: NodeItem = old_subroot.parent.resolve(doc=self)
 
+        old_subr_cref = old_subroot.self_ref
         old_subr_idx = new_subroot.children.index(old_subroot.get_ref())
         for i, child_ref in enumerate(old_subroot.children):
             # link new subroot => children (right after the old subroot)
@@ -3474,7 +3478,18 @@ class DoclingDocument(BaseModel):
             child: NodeItem = child_ref.resolve(doc=self)
             child.parent = new_subroot.get_ref()
 
-        # unlink old subroot its parent
+        if isinstance(new_subroot, TableItem):
+            if referencing_cells := self._find_referencing_table_cells(table=new_subroot, ref=old_subr_cref):
+                if len(old_subroot.children) == 1:
+                    # cell references
+                    for cell in referencing_cells:
+                        cell.ref.cref = old_subroot.children[0].cref
+                else:
+                    raise ValueError(
+                        "Can not shift up a subtree that is referenced by a table cell if it has multiple or no children"
+                    )
+
+        # unlink old subroot from its parent
         new_subroot.children.remove(old_subroot.get_ref())
 
     def _shift_down(self, *, old_subroot: NodeItem, new_subroot: NodeItem) -> None:
@@ -3487,7 +3502,14 @@ class DoclingDocument(BaseModel):
         if old_subroot.parent is None:
             raise ValueError("Can not shift down the root")
 
+        # If the parent of old_subroot is a TableItem, we'll need to update references in table cells.
+        table_parent = prnt_node if isinstance(prnt_node := old_subroot.parent.resolve(doc=self), TableItem) else None
+
         self.insert_item_before_sibling(new_item=new_subroot, sibling=old_subroot)
+
+        if table_parent:
+            for cell in self._find_referencing_table_cells(table=table_parent, ref=old_subroot.get_ref().cref):
+                cell.ref.cref = new_subroot.self_ref
 
         self._move_subtree(old_subroot=old_subroot, new_subroot=new_subroot)
 
@@ -3496,8 +3518,13 @@ class DoclingDocument(BaseModel):
         if old_subroot.parent is None:
             raise ValueError("Can not move the root")
 
-        # unlink old subroot from its previous parent
         previous_parent: NodeItem = old_subroot.parent.resolve(doc=self)
+        if isinstance(previous_parent, TableItem) and self._find_referencing_table_cells(
+            table=previous_parent, ref=old_subroot.self_ref
+        ):
+            raise ValueError("Can not move a subtree that is referenced by a table cell")
+
+        # unlink old subroot from its previous parent
         previous_parent.children.remove(old_subroot.get_ref())
 
         # link new subroot => old subroot
@@ -7251,27 +7278,19 @@ class DoclingDocument(BaseModel):
         for curr_list_items in reversed(misplaced_list_items):
             # add group
             new_group = ListGroup(self_ref="#")
-            self.insert_item_before_sibling(
-                new_item=new_group,
-                sibling=curr_list_items[0],
-            )
-
-            # delete list items from document (should not be affected by group addition)
-            self.delete_items(node_items=list(curr_list_items))
 
             # add list items to new group
-            for li in curr_list_items:
-                self.add_list_item(
-                    text=li.text,
-                    enumerated=li.enumerated,
-                    marker=li.marker,
-                    orig=li.orig,
-                    prov=li.prov[0] if li.prov else None,
-                    parent=new_group,
-                    content_layer=li.content_layer,
-                    formatting=li.formatting,
-                    hyperlink=li.hyperlink,
-                )
+            for i, li in enumerate(curr_list_items):
+                if i == 0:
+                    self._shift_down(
+                        old_subroot=li,
+                        new_subroot=new_group,
+                    )
+                else:
+                    self._move_subtree(
+                        old_subroot=li,
+                        new_subroot=new_group,
+                    )
         return self
 
     class _DocIndex(BaseModel):

--- a/test/data/doc/misplaced_list_items.out.yaml
+++ b/test/data/doc/misplaced_list_items.out.yaml
@@ -1,7 +1,7 @@
 body:
   children:
   - $ref: '#/groups/1'
-  - $ref: '#/texts/0'
+  - $ref: '#/texts/1'
   - $ref: '#/groups/0'
   content_layer: body
   label: unspecified
@@ -16,8 +16,8 @@ furniture:
   self_ref: '#/furniture'
 groups:
 - children:
-  - $ref: '#/texts/1'
   - $ref: '#/texts/2'
+  - $ref: '#/texts/3'
   content_layer: body
   label: list
   name: group
@@ -25,7 +25,7 @@ groups:
     $ref: '#/body'
   self_ref: '#/groups/0'
 - children:
-  - $ref: '#/texts/3'
+  - $ref: '#/texts/0'
   content_layer: body
   label: list
   name: group
@@ -41,12 +41,23 @@ tables: []
 texts:
 - children: []
   content_layer: body
+  enumerated: true
+  label: list_item
+  marker: '1.'
+  orig: foo
+  parent:
+    $ref: '#/groups/1'
+  prov: []
+  self_ref: '#/texts/0'
+  text: foo
+- children: []
+  content_layer: body
   label: text
   orig: bar
   parent:
     $ref: '#/body'
   prov: []
-  self_ref: '#/texts/0'
+  self_ref: '#/texts/1'
   text: bar
 - children: []
   content_layer: body
@@ -57,7 +68,7 @@ texts:
   parent:
     $ref: '#/groups/0'
   prov: []
-  self_ref: '#/texts/1'
+  self_ref: '#/texts/2'
   text: here
 - children: []
   content_layer: body
@@ -68,17 +79,6 @@ texts:
   parent:
     $ref: '#/groups/0'
   prov: []
-  self_ref: '#/texts/2'
-  text: there
-- children: []
-  content_layer: body
-  enumerated: true
-  label: list_item
-  marker: '1.'
-  orig: foo
-  parent:
-    $ref: '#/groups/1'
-  prov: []
   self_ref: '#/texts/3'
-  text: foo
+  text: there
 version: 1.10.0

--- a/test/test_docling_doc.py
+++ b/test/test_docling_doc.py
@@ -1565,7 +1565,6 @@ def test_move_subtree_raises_when_node_referenced_by_rich_table_cell():
     table = doc.add_table(data=TableData(num_rows=1, num_cols=1))
     target_group = doc.add_list_group(parent=doc.body)
     txt_item = doc.add_text(label=DocItemLabel.TEXT, text="foo", formatting=Formatting(bold=True), parent=table)
-    table.children.append(RefItem(cref=txt_item.self_ref))
     doc.add_table_cell(
         table_item=table,
         cell=RichTableCell(
@@ -1584,7 +1583,6 @@ def test_shift_up_raises_when_node_referenced_by_rich_table_cell():
     doc = DoclingDocument(name="")
     table = doc.add_table(data=TableData(num_rows=1, num_cols=1))
     txt_item = doc.add_text(label=DocItemLabel.TEXT, text="foo", formatting=Formatting(bold=True), parent=table)
-    table.children.append(RefItem(cref=txt_item.self_ref))
     doc.add_table_cell(
         table_item=table,
         cell=RichTableCell(

--- a/test/test_docling_doc.py
+++ b/test/test_docling_doc.py
@@ -34,6 +34,7 @@ from docling_core.types.doc import (
     ImageRef,
     ImageRefMode,
     KeyValueItem,
+    ListGroup,
     ListItem,
     NodeItem,
     PictureItem,
@@ -48,7 +49,7 @@ from docling_core.types.doc import (
     TextItem,
     TitleItem,
 )
-from docling_core.types.doc.document import FieldHeadingItem, FieldItem, FieldRegionItem, FieldValueItem
+from docling_core.types.doc.document import FieldHeadingItem, FieldItem, FieldRegionItem, FieldValueItem, GroupItem
 from docling_core.types.doc.document import CURRENT_VERSION, PageItem
 from docling_core.types.doc.webvtt import WebVTTFile
 
@@ -1558,6 +1559,91 @@ def test_moving_within_same_parent():
     doc._move_subtree(old_subroot=foo, new_subroot=foo.parent.resolve(doc), pos=0)
     assert [it.text for it, _ in doc.iterate_items() if isinstance(it, TextItem)] == ["foo", "bar"]
 
+
+def test_move_subtree_raises_when_node_referenced_by_rich_table_cell():
+    doc = DoclingDocument(name="")
+    table = doc.add_table(data=TableData(num_rows=1, num_cols=1))
+    target_group = doc.add_list_group(parent=doc.body)
+    txt_item = doc.add_text(label=DocItemLabel.TEXT, text="foo", formatting=Formatting(bold=True), parent=table)
+    table.children.append(RefItem(cref=txt_item.self_ref))
+    doc.add_table_cell(
+        table_item=table,
+        cell=RichTableCell(
+            start_row_offset_idx=0,
+            end_row_offset_idx=1,
+            start_col_offset_idx=0,
+            end_col_offset_idx=1,
+            text="",
+            ref=txt_item.get_ref(),
+        ),
+    )
+    with pytest.raises(ValueError, match="referenced by a table cell"):
+        doc._move_subtree(old_subroot=txt_item, new_subroot=target_group)
+
+def test_shift_up_raises_when_node_referenced_by_rich_table_cell():
+    doc = DoclingDocument(name="")
+    table = doc.add_table(data=TableData(num_rows=1, num_cols=1))
+    txt_item = doc.add_text(label=DocItemLabel.TEXT, text="foo", formatting=Formatting(bold=True), parent=table)
+    table.children.append(RefItem(cref=txt_item.self_ref))
+    doc.add_table_cell(
+        table_item=table,
+        cell=RichTableCell(
+            start_row_offset_idx=0,
+            end_row_offset_idx=1,
+            start_col_offset_idx=0,
+            end_col_offset_idx=1,
+            text="",
+            ref=txt_item.get_ref(),
+        ),
+    )
+    with pytest.raises(ValueError, match="referenced by a table cell"):
+        doc._shift_up(old_subroot=txt_item)
+
+
+def test_shift_down_heals_rich_table_cell_ref_when_wrapping_in_group():
+    """_shift_down retargets RichTableCell refs to the new GroupItem before _move_subtree."""
+    doc = DoclingDocument(name="")
+    table = doc.add_table(data=TableData(num_rows=1, num_cols=1))
+    text_item = doc.add_text(label=DocItemLabel.TEXT, text="row", parent=table)
+    cell = RichTableCell(
+        start_row_offset_idx=0,
+        end_row_offset_idx=1,
+        start_col_offset_idx=0,
+        end_col_offset_idx=1,
+        text="",
+        ref=text_item.get_ref(),
+    )
+    doc.add_table_cell(table_item=table, cell=cell)
+    new_group = GroupItem(self_ref="#")
+    doc._shift_down(old_subroot=text_item, new_subroot=new_group)
+
+    assert cell.ref.cref == new_group.self_ref
+    assert text_item.parent.cref == new_group.self_ref
+    assert new_group.parent is not None and new_group.parent.cref == table.self_ref
+    assert [c.cref for c in table.children] == [new_group.self_ref]
+    assert [c.cref for c in new_group.children] == [text_item.self_ref]
+    doc.validate_tree(doc.body, raise_on_error=True)
+
+
+def test_misplaced_list_items_under_table_roundtrip_without_rich_cells():
+    """Table-hosted ListItems (no ListGroup parent) are repaired without delete_items ref rewriting."""
+    doc = DoclingDocument(name="")
+    table = doc.add_table(data=TableData(num_rows=2, num_cols=1))
+    for text in ("a", "b"):
+        idx = len(doc.texts)
+        li = ListItem(
+            text=text,
+            orig=text,
+            self_ref=f"#/texts/{idx}",
+            parent=table.get_ref(),
+            enumerated=False,
+            marker="-",
+        )
+        doc.texts.append(li)
+        table.children.append(RefItem(cref=li.self_ref))
+
+    roundtrip = DoclingDocument.model_validate(doc.model_dump(mode="json"))
+    roundtrip.validate_tree(roundtrip.body, raise_on_error=True)
 
 def test_export_with_precision():
     doc = DoclingDocument.load_from_yaml(filename="test/data/doc/dummy_doc_2.yaml")


### PR DESCRIPTION
## Fix: Consider rich table cell refs during tree operations

This commit fixes an issue where tree operations weren't handling references from `RichTableCell` objects, causing broken document hierarchies.

### Changes:

1. **Updated `_shift_up`**: When removing a node, updates any table cell references to point to the node's child instead (errors if the node has multiple or no children).
1. **Updated `_shift_down`**: Updates table cell references to point to the new wrapper node before moving the subtree.
1. **Updated `_move_subtree`**: Prevents moving nodes that are referenced by table cells.
1. **Improved `fix_misplaced_list_items`** auto-healing: Uses updated `_shift_down` and `_move_subtree` instead of deleting and recreating items, which preserves references correctly.

### Tests:
- Added 3 test cases for rich table cell reference handling
- Updated expected output for misplaced list items test