### PR TITLE
feat(serializer): add MsExcelMarkdownDocSerializer for sheet-name headings

### DIFF
--- a/docling_core/transforms/serializer/markdown_excel.py
+++ b/docling_core/transforms/serializer/markdown_excel.py
@@ -1,0 +1,68 @@
+"""Markdown serialization for MS Excel documents."""
+
+from typing import Any
+
+from typing_extensions import override
+
+from docling_core.transforms.serializer.base import (
+    BaseDocSerializer,
+    BaseFallbackSerializer,
+    SerializationResult,
+)
+from docling_core.transforms.serializer.common import create_ser_result
+from docling_core.transforms.serializer.markdown import (
+    MarkdownDocSerializer,
+    MarkdownFallbackSerializer,
+)
+from docling_core.types.doc.document import DoclingDocument, GroupItem, NodeItem
+from docling_core.types.doc.labels import GroupLabel
+
+
+class MsExcelMarkdownFallbackSerializer(MarkdownFallbackSerializer):
+    """Fallback serializer that renders ``GroupLabel.SHEET`` groups as headings.
+
+    When a ``GroupItem`` with ``label=GroupLabel.SHEET`` is encountered the
+    group's ``name`` is emitted as a level-2 Markdown heading (``##``) before
+    the group's children, matching the visual structure of the original
+    workbook where each worksheet has a name.
+    """
+
+    @override
+    def serialize(
+        self,
+        *,
+        item: NodeItem,
+        doc_serializer: BaseDocSerializer,
+        doc: DoclingDocument,
+        **kwargs: Any,
+    ) -> SerializationResult:
+        if isinstance(item, GroupItem) and item.label == GroupLabel.SHEET:
+            parts = doc_serializer.get_parts(item=item, **kwargs)
+            content = "\n\n".join(p.text for p in parts if p.text)
+            heading = f"## {item.name}"
+            text = f"{heading}\n\n{content}" if content else heading
+            return create_ser_result(text=text, span_source=parts)
+        return super().serialize(
+            item=item, doc_serializer=doc_serializer, doc=doc, **kwargs
+        )
+
+
+class MsExcelMarkdownDocSerializer(MarkdownDocSerializer):
+    """``MarkdownDocSerializer`` variant for Excel-sourced ``DoclingDocument``\\s.
+
+    Swap in :class:`MsExcelMarkdownFallbackSerializer` so that worksheet
+    groups (``GroupLabel.SHEET``) are rendered with their name as a Markdown
+    heading without requiring heading nodes to be injected into the document
+    model by the backend.
+
+    Usage::
+
+        from docling_core.transforms.serializer.markdown_excel import (
+            MsExcelMarkdownDocSerializer,
+        )
+
+        serializer = MsExcelMarkdownDocSerializer(doc=result.document)
+        md = serializer.serialize().text
+    """
+
+    fallback_serializer: BaseFallbackSerializer = MsExcelMarkdownFallbackSerializer()

--- a/docling_core/transforms/serializer/markdown_excel.py
+++ b/docling_core/transforms/serializer/markdown_excel.py
@@ -42,9 +42,7 @@ class MsExcelMarkdownFallbackSerializer(MarkdownFallbackSerializer):
             heading = f"## {item.name}"
             text = f"{heading}\n\n{content}" if content else heading
             return create_ser_result(text=text, span_source=parts)
-        return super().serialize(
-            item=item, doc_serializer=doc_serializer, doc=doc, **kwargs
-        )
+        return super().serialize(item=item, doc_serializer=doc_serializer, doc=doc, **kwargs)
 
 
 class MsExcelMarkdownDocSerializer(MarkdownDocSerializer):


### PR DESCRIPTION
## Summary

- Adds `MsExcelMarkdownFallbackSerializer` and `MsExcelMarkdownDocSerializer` to `docling_core/transforms/serializer/markdown_excel.py`
- These classes enable rendering `GroupLabel.SHEET` groups as level-2 Markdown headings (`## <sheet_name>`) when exporting Excel-sourced `DoclingDocument`s
- Requested in docling-project/docling#3255 — the serializer was originally placed in the `docling` repo but belongs here per reviewer feedback

## Test plan

- [ ] Verify `MsExcelMarkdownDocSerializer` renders sheet names as `## <name>` headings
- [ ] Verify non-SHEET groups are handled by the standard fallback logic
- [ ] Verify the import path `from docling_core.transforms.serializer.markdown_excel import MsExcelMarkdownDocSerializer` works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)