### PR TITLE
fix: prevent numeric precision loss in Markdown table serialization

### DIFF
--- a/docling_core/transforms/serializer/markdown.py
+++ b/docling_core/transforms/serializer/markdown.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from typing import Annotated, Any, Optional, Union
 
 from pydantic import AnyUrl, BaseModel, Field, PositiveInt
-from tabulate import tabulate
+from tabulate import _column_type, tabulate
 from typing_extensions import override
 
 from docling_core.transforms.serializer.base import (
@@ -549,15 +549,22 @@ class MarkdownTableSerializer(BaseTableSerializer):
                     rendered_row.append(cell_text.replace("\n", " ").replace("|", "&#124;"))
                 rows.append(rendered_row)
             if len(rows) > 0:
-                try:
-                    table_text = tabulate(rows[1:], headers=rows[0], tablefmt="github")
-                except ValueError:
-                    table_text = tabulate(
-                        rows[1:],
-                        headers=rows[0],
-                        tablefmt="github",
-                        disable_numparse=True,
-                    )
+                # Always disable numparse to prevent silent precision loss in numeric values
+                # Use tabulate's _column_type to detect numeric columns for right-alignment
+                colalign = []
+                if len(rows) > 1:  # Need at least header + 1 data row
+                    num_cols = len(rows[0])
+                    for col_idx in range(num_cols):
+                        col_values = [row[col_idx] if col_idx < len(row) else "" for row in rows[1:]]
+                        col_type = _column_type(col_values)
+                        colalign.append("right" if col_type in (int, float) else "left")
+                table_text = tabulate(
+                    rows[1:],
+                    headers=rows[0],
+                    tablefmt="github",
+                    disable_numparse=True,
+                    colalign=tuple(colalign) if colalign else None,
+                )
 
                 if params.compact_tables:
                     table_text = self._compact_table(table_text)

--- a/docling_core/types/doc/document.py
+++ b/docling_core/types/doc/document.py
@@ -44,7 +44,7 @@ from pydantic import (
     model_validator,
     validate_call,
 )
-from tabulate import tabulate
+from tabulate import _column_type, tabulate
 from typing_extensions import Self, deprecated, override
 
 from docling_core.search.package import VERSION_PATTERN
@@ -2274,15 +2274,22 @@ class TableItem(FloatingItem):
 
             res = ""
             if len(table) > 1 and len(table[0]) > 0:
-                try:
-                    res = tabulate(table[1:], headers=table[0], tablefmt="github")
-                except ValueError:
-                    res = tabulate(
-                        table[1:],
-                        headers=table[0],
-                        tablefmt="github",
-                        disable_numparse=True,
-                    )
+                # Always disable numparse to prevent silent precision loss in numeric values
+                # Use tabulate's _column_type to detect numeric columns for right-alignment
+                colalign = []
+                num_cols = len(table[0])
+                for col_idx in range(num_cols):
+                    col_values = [row[col_idx] if col_idx < len(row) else "" for row in table[1:]]
+                    col_type = _column_type(col_values)
+                    colalign.append("right" if col_type in (int, float) else "left")
+
+                res = tabulate(
+                    table[1:],
+                    headers=table[0],
+                    tablefmt="github",
+                    disable_numparse=True,
+                    colalign=tuple(colalign) if colalign else None,
+                )
 
         return res
 

--- a/test/data/chunker/2e_out_chunks.json
+++ b/test/data/chunker/2e_out_chunks.json
@@ -1278,7 +1278,7 @@
             }
         },
         {
-            "text": "-\n-----|\n|   2014 |                92.7 |                   12   |     379,592 |\n|   2015 |                81.7 |                   13.1 |     377,757 |\nA last paragraph is down here, after the results table.",
+            "text": "-\n-----|\n|   2014 |                92.7 |                   12.0 |     379,592 |\n|   2015 |                81.7 |                   13.1 |     377,757 |\nA last paragraph is down here, after the results table.",
             "meta": {
                 "schema_name": "docling_core.transforms.chunker.DocMeta",
                 "version": "1.0.0",

--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -2,6 +2,7 @@
 
 import threading
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -10,6 +11,7 @@ from docling_core.transforms.serializer.html import (
     HTMLDocSerializer,
     HTMLOutputStyle,
     HTMLParams,
+    HTMLTableSerializer,
 )
 from docling_core.transforms.serializer.markdown import (
     MarkdownDocSerializer,
@@ -607,46 +609,44 @@ def test_md_traverse_pictures():
 
 def test_html_table_serializer_get_header_and_body_lines():
     """Test HTMLTableSerializer.get_header_and_body_lines() method."""
-    from docling_core.transforms.serializer.html import HTMLTableSerializer
-    from unittest.mock import patch, MagicMock
-    
+
     serializer = HTMLTableSerializer()
-    
+
     # Test 1: Valid HTML with headers and data
     valid_html = "<table><tr><th>Header1</th><th>Header2</th></tr><tr><td>Data1</td><td>Data2</td></tr></table>"
     headers, body = serializer.get_header_and_body_lines(table_text=valid_html)
     assert len(headers) > 0, "Should have headers"
     assert len(body) > 0, "Should have body rows"
-    
+
     # Test 2: Row without closing </tr> tag
     # Parser will find the row, but when we search for </tr> it won't be found
     no_close_tr = "<tr><th>Header</th></tr><tr><td>Data1"
     headers, body = serializer.get_header_and_body_lines(table_text=no_close_tr)
     assert isinstance(headers, list)
     assert isinstance(body, list)
-    
+
     # Test 3: Data rows with incomplete closing tags
     # When collecting remaining rows, some </tr> tags are missing
     incomplete_data = "<tr><th>H1</th></tr><tr><td>D1</td></tr><tr><td>D2"
     headers, body = serializer.get_header_and_body_lines(table_text=incomplete_data)
     assert isinstance(headers, list)
     assert isinstance(body, list)
-    
+
     # Test 4: Force exception in parser
-    with patch('docling_core.transforms.serializer.html._SimpleHTMLTableParser') as mock_parser_class:
+    with patch("docling_core.transforms.serializer.html._SimpleHTMLTableParser") as mock_parser_class:
         mock_parser = MagicMock()
         mock_parser.feed.side_effect = Exception("Parser error")
         mock_parser_class.return_value = mock_parser
-        
+
         broken_html = "<tr><th>Header</th></tr><tr><td>Data</td></tr>"
         headers, body = serializer.get_header_and_body_lines(table_text=broken_html)
         # Should use fallback logic
         assert isinstance(headers, list)
         assert isinstance(body, list)
-    
+
     # Test 5: Parser returns more rows than exist in HTML
     # Mock parser to return extra rows that don't exist in the HTML
-    with patch('docling_core.transforms.serializer.html._SimpleHTMLTableParser') as mock_parser_class:
+    with patch("docling_core.transforms.serializer.html._SimpleHTMLTableParser") as mock_parser_class:
         mock_parser = MagicMock()
         # Create fake row data - more rows than actually exist in HTML
         mock_parser.rows = [
@@ -656,32 +656,32 @@ def test_html_table_serializer_get_header_and_body_lines():
             {"th_cells": [], "td_cells": ["D1"]},
         ]
         mock_parser_class.return_value = mock_parser
-        
+
         # HTML with only 2 rows, but parser claims 4
         limited_html = "<tr><th>H1</th></tr><tr><th>H2</th></tr>"
         headers, body = serializer.get_header_and_body_lines(table_text=limited_html)
         assert isinstance(headers, list)
         assert isinstance(body, list)
-    
+
     # Test 6: Specific case for line 485 - row_start found but row_end not found
     # Create HTML where parser finds a row, but the actual HTML has <tr without </tr>
-    with patch('docling_core.transforms.serializer.html._SimpleHTMLTableParser') as mock_parser_class:
+    with patch("docling_core.transforms.serializer.html._SimpleHTMLTableParser") as mock_parser_class:
         mock_parser = MagicMock()
         # Parser reports a header row exists
         mock_parser.rows = [
             {"th_cells": ["Header"], "td_cells": []},
         ]
         mock_parser_class.return_value = mock_parser
-        
+
         # But the HTML has <tr without matching </tr>
         html_no_close = "<tr><th>Header"
         headers, body = serializer.get_header_and_body_lines(table_text=html_no_close)
         assert isinstance(headers, list)
         assert isinstance(body, list)
-    
+
     # Test 7: Specific case for line 504 - data collection finds <tr but no </tr>
     # Create HTML where we start collecting data rows but encounter incomplete row
-    with patch('docling_core.transforms.serializer.html._SimpleHTMLTableParser') as mock_parser_class:
+    with patch("docling_core.transforms.serializer.html._SimpleHTMLTableParser") as mock_parser_class:
         mock_parser = MagicMock()
         # Parser reports header then data rows
         mock_parser.rows = [
@@ -689,13 +689,13 @@ def test_html_table_serializer_get_header_and_body_lines():
             {"th_cells": [], "td_cells": ["D1"]},  # This triggers data collection
         ]
         mock_parser_class.return_value = mock_parser
-        
+
         # HTML has complete header but incomplete data row
         html_incomplete_data = "<tr><th>H</th></tr><tr><td>D1</td></tr><tr><td>D2"
         headers, body = serializer.get_header_and_body_lines(table_text=html_incomplete_data)
         assert isinstance(headers, list)
         assert isinstance(body, list)
-    
+
     # Test 8: Table with footer content
     with_footer = "<tr><th>H</th></tr><tr><td>D</td></tr>Footer content"
     headers, body = serializer.get_header_and_body_lines(table_text=with_footer)

--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -478,6 +478,75 @@ def test_md_compact_table():
     assert len(compact_result) < len(padded_table)
 
 
+def test_md_numeric_precision_preserved():
+    """Test that numeric values in tables preserve their full precision.
+
+    Regression test for issue where tabulate's numparse would silently
+    truncate numeric strings to ~6 significant figures.
+    """
+    doc = DoclingDocument(name="Numeric Precision Test")
+    precise_values = [
+        "225.8183",
+        "24797.34",
+        "20896.7184",
+        "17358.138",
+        "123.456789",
+    ]
+    table = doc.add_table(data=TableData(num_rows=len(precise_values) + 1, num_cols=2))
+
+    # Add header row
+    doc.add_table_cell(
+        table_item=table,
+        cell=TableCell(
+            start_row_offset_idx=0,
+            end_row_offset_idx=1,
+            start_col_offset_idx=0,
+            end_col_offset_idx=1,
+            text="Description",
+        ),
+    )
+    doc.add_table_cell(
+        table_item=table,
+        cell=TableCell(
+            start_row_offset_idx=0,
+            end_row_offset_idx=1,
+            start_col_offset_idx=1,
+            end_col_offset_idx=2,
+            text="Value",
+        ),
+    )
+
+    # Add data rows with precise numeric values
+    for row_idx, value in enumerate(precise_values, start=1):
+        doc.add_table_cell(
+            table_item=table,
+            cell=TableCell(
+                start_row_offset_idx=row_idx,
+                end_row_offset_idx=row_idx + 1,
+                start_col_offset_idx=0,
+                end_col_offset_idx=1,
+                text=f"Item {row_idx}",
+            ),
+        )
+        doc.add_table_cell(
+            table_item=table,
+            cell=TableCell(
+                start_row_offset_idx=row_idx,
+                end_row_offset_idx=row_idx + 1,
+                start_col_offset_idx=1,
+                end_col_offset_idx=2,
+                text=value,
+            ),
+        )
+
+    markdown_output = doc.export_to_markdown()
+    for value in precise_values:
+        assert value in markdown_output, (
+            f"Numeric value '{value}' was not preserved in markdown output. "
+            "This indicates precision loss during table serialization."
+        )
+
+
 def test_md_traverse_pictures():
     """Test traverse_pictures parameter to include text inside PictureItems."""
 


### PR DESCRIPTION
## Summary
Fixes a bug where numeric values in tables were losing precision when exported to markdown format. The issue was caused by `tabulate` parsing and reformatting numeric strings, reducing precision to approximately 6 significant figures.

Resolves #583 

## Problem
When exporting documents with tables to markdown, numeric values were being truncated:
- `225.8183` became `225.818`
- `20896.7184` became `20896.7`
- `12.0` became `12`

This occurred because `tabulate` was parsing numeric strings as floats and reformatting them with reduced precision.

## Solution
Modified the markdown serialization to:
1. **Preserve precision**: Pass `disable_numparse=True` to `tabulate` to prevent automatic numeric parsing and reformatting
2. **Maintain alignment**: Use tabulate's internal `_column_type()` function to detect column types and apply proper alignment:
   - Numeric columns (int/float): right-aligned
   - Text columns (str/bool/None): left-aligned

## Changes
### Core Fix (commit `0c061a4`)
- **`docling_core/transforms/serializer/markdown.py`**: Updated table serialization logic
- **`docling_core/types/doc/document.py`**: Applied same fix to legacy export path
- **`test/test_serialization.py`**: Added `test_md_numeric_precision_preserved()` regression test
- **`test/data/chunker/2e_out_chunks.json`**: Updated golden test file to reflect correct precision

### Code Style (commit `d91c1ba`)
- **`test/test_serialization.py`**: Applied style conventions to test module

## Example
**Before:**
```markdown
| Value 1  | Value 2   |
|----------|-----------|
| 225.818  | 20896.7   |
```

**After:**
```markdown
|  Value 1 |   Value 2 |
|----------|-----------|
| 225.8183 | 20896.7184|
```