### PR TITLE
feat: add _to_referenced_images and _to_embedded_images to DoclingDocument

### DIFF
--- a/docling_core/types/doc/document.py
+++ b/docling_core/types/doc/document.py
@@ -5703,9 +5703,10 @@ class DoclingDocument(BaseModel):
         """Create a copy of this document with images saved as referenced files.
 
         Creates a deep copy of the document where each :class:`PictureItem`'s
-        image is saved as a PNG file inside *image_dir* and the stored URI is
-        updated to ``image_path_prefix + <filename>`` so that the exported
-        markdown (or any other format) emits the desired relative reference.
+        image and each page image is saved as a PNG file inside *image_dir* and
+        the stored URI is updated to ``image_path_prefix + <filename>`` so that
+        the exported markdown (or any other format) emits the desired relative
+        reference.
 
         This is the recommended way to obtain a document ready for
         ``export_to_markdown(image_mode=ImageRefMode.REFERENCED)`` when you
@@ -5729,8 +5730,8 @@ class DoclingDocument(BaseModel):
         :param image_path_prefix: String prepended to each image filename in
             the document's URI field (e.g. ``"images/"``).  Defaults to ``""``.
         :type image_path_prefix: str
-        :returns: A new :class:`DoclingDocument` whose picture URIs point to
-            the saved files.
+        :returns: A new :class:`DoclingDocument` whose picture and page image
+            URIs point to the saved files.
         :rtype: DoclingDocument
         """
         result: DoclingDocument = copy.deepcopy(self)
@@ -5750,6 +5751,15 @@ class DoclingDocument(BaseModel):
                         item.image = ImageRef.from_pil(image=img, dpi=round(72 * scale))
                     item.image.uri = uri_path
                 img_count += 1
+
+        for page_no, page_item in sorted(result.pages.items()):
+            if page_item.image is not None:
+                pil_img = page_item.image.pil_image
+                if pil_img is not None:
+                    filename = f"page_{page_no:03d}.png"
+                    loc_path = image_dir / filename
+                    pil_img.save(loc_path)
+                    page_item.image.uri = Path(image_path_prefix + filename)
 
         return result
 

--- a/docling_core/types/doc/document.py
+++ b/docling_core/types/doc/document.py
@@ -5695,6 +5695,89 @@ class DoclingDocument(BaseModel):
 
         return result
 
+    def _to_referenced_images(
+        self,
+        image_dir: Path,
+        image_path_prefix: str = "",
+    ) -> "DoclingDocument":
+        """Create a copy of this document with images saved as referenced files.
+
+        Creates a deep copy of the document where each :class:`PictureItem`'s
+        image is saved as a PNG file inside *image_dir* and the stored URI is
+        updated to ``image_path_prefix + <filename>`` so that the exported
+        markdown (or any other format) emits the desired relative reference.
+
+        This is the recommended way to obtain a document ready for
+        ``export_to_markdown(image_mode=ImageRefMode.REFERENCED)`` when you
+        need full control over where images land and what prefix appears in the
+        output — without writing the document to a file first.
+
+        Example::
+
+            from pathlib import Path
+            from docling_core.types.doc.base import ImageRefMode
+
+            doc_ref = doc._to_referenced_images(
+                image_dir=Path("output/images"),
+                image_path_prefix="images/",
+            )
+            md = doc_ref.export_to_markdown(image_mode=ImageRefMode.REFERENCED)
+
+        :param image_dir: Directory where image files will be written.
+            Created automatically if it does not exist.
+        :type image_dir: Path
+        :param image_path_prefix: String prepended to each image filename in
+            the document's URI field (e.g. ``"images/"``).  Defaults to ``""``.
+        :type image_path_prefix: str
+        :returns: A new :class:`DoclingDocument` whose picture URIs point to
+            the saved files.
+        :rtype: DoclingDocument
+        """
+        result: DoclingDocument = copy.deepcopy(self)
+        image_dir.mkdir(parents=True, exist_ok=True)
+
+        img_count = 0
+        for item, _ in result.iterate_items(with_groups=False):
+            if isinstance(item, PictureItem):
+                img = item.get_image(doc=self)
+                if img is not None:
+                    filename = f"image_{img_count + 1:03d}.png"
+                    loc_path = image_dir / filename
+                    img.save(loc_path)
+                    uri_path = Path(image_path_prefix + filename)
+                    if item.image is None:
+                        scale = img.size[0] / item.prov[0].bbox.width
+                        item.image = ImageRef.from_pil(image=img, dpi=round(72 * scale))
+                    item.image.uri = uri_path
+                img_count += 1
+
+        return result
+
+    def _to_embedded_images(self) -> "DoclingDocument":
+        """Create a copy of this document with all images embedded as base64.
+
+        Creates a deep copy of the document where every :class:`PictureItem`
+        that currently holds an image referenced through a file URI is
+        converted to an inline base64-encoded form.  Pictures that are already
+        embedded are left unchanged.
+
+        This is the recommended way to obtain a self-contained document ready
+        for ``export_to_markdown(image_mode=ImageRefMode.EMBEDDED)`` or for
+        serialisation to JSON / YAML without external artefacts.
+
+        Example::
+
+            from docling_core.types.doc.base import ImageRefMode
+
+            doc_emb = doc._to_embedded_images()
+            md = doc_emb.export_to_markdown(image_mode=ImageRefMode.EMBEDDED)
+
+        :returns: A new :class:`DoclingDocument` with all picture data
+            embedded inline.
+        :rtype: DoclingDocument
+        """
+        return self._with_embedded_pictures()
+
     def print_element_tree(self):
         """Print_element_tree."""
         for ix, (item, level) in enumerate(

--- a/test/test_docling_doc.py
+++ b/test/test_docling_doc.py
@@ -1070,6 +1070,39 @@ def test_to_referenced_images_markdown_output(sample_doc, tmp_path):
     )
 
 
+def test_to_referenced_images_saves_page_images(tmp_path):
+    """_to_referenced_images also saves page images and updates their URIs."""
+    from docling_core.types.doc.document import PageItem
+    from docling_core.types.doc.base import Size
+
+    image_dir = tmp_path / "pages"
+    prefix = "pages/"
+
+    # Build a document with one page that has an image
+    doc = DoclingDocument(name="page-image test")
+    page_img = PILImage.new("RGB", (32, 32), "blue")
+    page_image_ref = ImageRef.from_pil(image=page_img, dpi=72)
+    doc.add_page(page_no=1, size=Size(width=100, height=100), image=page_image_ref)
+
+    result = doc._to_referenced_images(
+        image_dir=image_dir,
+        image_path_prefix=prefix,
+    )
+
+    # The page image file should have been saved
+    saved = list(image_dir.glob("*.png"))
+    assert len(saved) == 1, f"expected 1 saved page image, got {len(saved)}"
+    assert saved[0].name == "page_001.png"
+
+    # The result document's page URI must be updated
+    assert str(result.pages[1].image.uri) == prefix + "page_001.png"
+
+    # The source document must not have been mutated
+    assert str(doc.pages[1].image.uri) != prefix + "page_001.png", (
+        "_to_referenced_images must not mutate the source document's page URIs"
+    )
+
+
 def test_to_embedded_images(sample_doc):
     """_to_embedded_images returns a deep copy; the source document is unchanged."""
     result = sample_doc._to_embedded_images()

--- a/test/test_docling_doc.py
+++ b/test/test_docling_doc.py
@@ -1024,6 +1024,72 @@ def test_save_pictures_with_page():
     assert n_images == 1
 
 
+def test_to_referenced_images(sample_doc, tmp_path):
+    """_to_referenced_images saves images and sets URIs with the given prefix."""
+    image_dir = tmp_path / "images"
+    prefix = "images/"
+
+    result = sample_doc._to_referenced_images(
+        image_dir=image_dir,
+        image_path_prefix=prefix,
+    )
+
+    # Directory must have been created and contain exactly one PNG
+    saved = list(image_dir.glob("*.png"))
+    assert len(saved) == 1, f"expected 1 saved image, got {len(saved)}"
+
+    # The filename should follow the sequential naming convention
+    assert saved[0].name == "image_001.png"
+
+    # The original document must not have been mutated
+    for item, _ in sample_doc.iterate_items(with_groups=False):
+        if isinstance(item, PictureItem) and item.image is not None:
+            assert str(item.image.uri) != prefix + "image_001.png", (
+                "_to_referenced_images must not mutate the source document"
+            )
+
+    # The returned document must have the URI set to prefix + filename
+    for item, _ in result.iterate_items(with_groups=False):
+        if isinstance(item, PictureItem) and item.image is not None:
+            assert str(item.image.uri) == prefix + "image_001.png"
+
+
+def test_to_referenced_images_markdown_output(sample_doc, tmp_path):
+    """_to_referenced_images + export_to_markdown emits the correct image refs."""
+    image_dir = tmp_path / "imgs"
+    prefix = "imgs/"
+
+    doc_ref = sample_doc._to_referenced_images(
+        image_dir=image_dir,
+        image_path_prefix=prefix,
+    )
+    md = doc_ref.export_to_markdown(image_mode=ImageRefMode.REFERENCED)
+
+    assert "imgs/image_001.png" in md, (
+        f"expected 'imgs/image_001.png' in markdown output, got:\n{md}"
+    )
+
+
+def test_to_embedded_images(sample_doc):
+    """_to_embedded_images returns a deep copy; the source document is unchanged."""
+    result = sample_doc._to_embedded_images()
+
+    # Must return a DoclingDocument
+    assert isinstance(result, DoclingDocument)
+
+    # Must be a copy, not the same object
+    assert result is not sample_doc
+
+    # Pictures that were already embedded should remain embedded in the copy
+    for item, _ in result.iterate_items(with_groups=False):
+        if isinstance(item, PictureItem) and item.image is not None:
+            # Embedded images have no file-based URI
+            if item.image.uri is not None:
+                assert not (
+                    isinstance(item.image.uri, Path) and item.image.uri.is_absolute()
+                ), "Expected no absolute file URI in embedded document"
+
+
 def _normalise_string_wrt_filepaths(instr: str, paths: list[Path]):
     for p in paths:
         instr = instr.replace(str(p), str(p.name))


### PR DESCRIPTION
## Summary

Closes #3094

Adds two named transformation methods on `DoclingDocument` that follow the same pattern as `_hierarchize()` and `_flatten()` — they operate on a deep copy and leave the source document unchanged, as suggested by @PeterStaar-IBM in docling-project/docling#3288.

### `_to_referenced_images(image_dir, image_path_prefix="")`
Saves each `PictureItem` image as `image_001.png`, `image_002.png`, … into `image_dir` and updates the stored URI to `image_path_prefix + filename`. This makes it easy to call `export_to_markdown(image_mode=ImageRefMode.REFERENCED)` with full control over where images land and what prefix appears in the output — without writing the whole document to disk first.

### `_to_embedded_images()`
Returns a deep copy where every image referenced through a file URI is converted to inline base64 form (delegates to `_with_embedded_pictures()`).

### Usage

```python
from pathlib import Path
from docling_core.types.doc.base import ImageRefMode

# Save images to disk, get markdown with relative references
doc_ref = doc._to_referenced_images(
    image_dir=Path("output/images"),
    image_path_prefix="images/",
)
md = doc_ref.export_to_markdown(image_mode=ImageRefMode.REFERENCED)

# Get a fully self-contained document with embedded images
doc_emb = doc._to_embedded_images()
md = doc_emb.export_to_markdown(image_mode=ImageRefMode.EMBEDDED)
```

## Tests

Three new tests added to `test/test_docling_doc.py`:

- `test_to_referenced_images` — verifies images are written with sequential filenames (`image_001.png`) and URIs are set to `prefix + filename`; checks source document is not mutated
- `test_to_referenced_images_markdown_output` — verifies the full pipeline: transform → `export_to_markdown` emits the correct image reference
- `test_to_embedded_images` — verifies the method returns an independent deep copy

## Design notes

- Both methods follow the `_hierarchize` / `_flatten` pattern (private helper, returns a new `DoclingDocument`)
- `_to_embedded_images` is a thin, named wrapper over `_with_embedded_pictures()` to make the intent explicit at call sites
- No existing behaviour is changed; the two lower-level helpers (`_with_pictures_refs`, `_with_embedded_pictures`) remain in place

Signed-off-by: OfekDanny <ofekdanny@gmail.com>