### PR TITLE
fix(doclang): default DoclangDeserializer to page 1 

### DIFF
--- a/docling_core/experimental/doclang.py
+++ b/docling_core/experimental/doclang.py
@@ -2372,18 +2372,20 @@ class DoclangDeserializer(BaseModel):
     """Doclang deserializer."""
 
     # Internal state used while walking the tree (private instance attributes)
-    _page_no: int = PrivateAttr(default=0)
+    _page_no: int = PrivateAttr(default=1)
     _default_resolution: int = PrivateAttr(default=DOCLANG_DFLT_RESOLUTION)
 
     def deserialize(
         self,
         *,
         text: str,
+        page_no: int = 1,
     ) -> DoclingDocument:
         """Deserialize Doclang XML into a DoclingDocument.
 
         Args:
             text: Doclang XML string to parse.
+            page_no: Starting page number (default 1).
 
         Returns:
             A populated `DoclingDocument` parsed from the input.
@@ -2402,9 +2404,7 @@ class DoclangDeserializer(BaseModel):
                 root = cast(Element, candidates[0])
 
         doc = DoclingDocument(name="Document")
-        # TODO revise need for default page & resolution
-        # Initialize with a default page so location tokens can be re-emitted
-        self._page_no = 0
+        self._page_no = page_no
         self._default_resolution = DOCLANG_DFLT_RESOLUTION
         self._ensure_page_exists(doc=doc, page_no=self._page_no, resolution=self._default_resolution)
         self._parse_document_root(doc=doc, root=root)

--- a/test/data/doc/roundtrip_list_item_with_inline_deserialized.yaml
+++ b/test/data/doc/roundtrip_list_item_with_inline_deserialized.yaml
@@ -90,8 +90,8 @@ groups:
 key_value_items: []
 name: Document
 pages:
-  '0':
-    page_no: 0
+  '1':
+    page_no: 1
     size:
       height: 512.0
       width: 512.0


### PR DESCRIPTION
Doclang VLM output was assigning provenance to page 0 while DoclingDocument and ground truth use 1-based page numbers, which broke page-aligned matching.

- Default internal _page_no to 1 and add deserialize(..., page_no=1).
- Replace hardcoded self._page_no = 0 with the page_no argument.
- Update roundtrip_list_item_with_inline deserialized fixture for page 1.