### PR TITLE
fix(chunker): forward content layers from serializer params to doc traversal

### DIFF
--- a/docling_core/transforms/chunker/hierarchical_chunker.py
+++ b/docling_core/transforms/chunker/hierarchical_chunker.py
@@ -209,9 +209,12 @@ class HierarchicalChunker(BaseChunker):
         ser_res = create_ser_result()
         excluded_refs = my_doc_ser.get_excluded_refs(**kwargs)
         traverse_pictures = my_doc_ser.params.traverse_pictures if isinstance(my_doc_ser, DocSerializer) else False
+        included_content_layers = my_doc_ser.params.layers if isinstance(my_doc_ser, DocSerializer) else None
+
         for item, level in dl_doc.iterate_items(
             with_groups=True,
             traverse_pictures=traverse_pictures,
+            included_content_layers=included_content_layers,
         ):
             if item.self_ref in excluded_refs:
                 continue

--- a/docling_core/transforms/chunker/hybrid_chunker.py
+++ b/docling_core/transforms/chunker/hybrid_chunker.py
@@ -329,7 +329,6 @@ class HybridChunker(BaseChunker):
         res: Iterable[DocChunk]
         res = self._inner_chunker.chunk(
             dl_doc=dl_doc,
-            doc_serializer=my_doc_ser,
             **kwargs,
         )  # type: ignore
         res = [x for c in res for x in self._split_by_doc_items(c, doc_serializer=my_doc_ser)]

--- a/docling_core/transforms/chunker/hybrid_chunker.py
+++ b/docling_core/transforms/chunker/hybrid_chunker.py
@@ -384,7 +384,6 @@ class HybridChunker(BaseChunker):
         res: Iterable[DocChunk]
         res = self._inner_chunker.chunk(
             dl_doc=dl_doc,
-            doc_serializer=my_doc_ser,
             **kwargs,
         )  # type: ignore
         res = [x for c in res for x in self._split_by_doc_items(c, doc_serializer=my_doc_ser)]

--- a/test/data/chunker/0f_out_chunks_multilayer.json
+++ b/test/data/chunker/0f_out_chunks_multilayer.json
@@ -1,0 +1,106 @@
+{
+    "root": [
+        {
+            "text": "Page Header",
+            "meta": {
+                "schema_name": "docling_core.transforms.chunker.DocMeta",
+                "version": "1.0.0",
+                "doc_items": [
+                    {
+                        "self_ref": "#/texts/0",
+                        "parent": {
+                            "$ref": "#/body"
+                        },
+                        "children": [],
+                        "content_layer": "furniture",
+                        "label": "page_header",
+                        "prov": [
+                            {
+                                "page_no": 1,
+                                "bbox": {
+                                    "l": 1.0,
+                                    "t": 4.0,
+                                    "r": 3.0,
+                                    "b": 2.0,
+                                    "coord_origin": "BOTTOMLEFT"
+                                },
+                                "charspan": [
+                                    0,
+                                    11
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        },
+        {
+            "text": "Main body content",
+            "meta": {
+                "schema_name": "docling_core.transforms.chunker.DocMeta",
+                "version": "1.0.0",
+                "doc_items": [
+                    {
+                        "self_ref": "#/texts/1",
+                        "parent": {
+                            "$ref": "#/body"
+                        },
+                        "children": [],
+                        "content_layer": "body",
+                        "label": "text",
+                        "prov": [
+                            {
+                                "page_no": 1,
+                                "bbox": {
+                                    "l": 5.0,
+                                    "t": 8.0,
+                                    "r": 7.0,
+                                    "b": 6.0,
+                                    "coord_origin": "BOTTOMLEFT"
+                                },
+                                "charspan": [
+                                    0,
+                                    17
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        },
+        {
+            "text": "Page Footer",
+            "meta": {
+                "schema_name": "docling_core.transforms.chunker.DocMeta",
+                "version": "1.0.0",
+                "doc_items": [
+                    {
+                        "self_ref": "#/texts/2",
+                        "parent": {
+                            "$ref": "#/body"
+                        },
+                        "children": [],
+                        "content_layer": "furniture",
+                        "label": "page_footer",
+                        "prov": [
+                            {
+                                "page_no": 1,
+                                "bbox": {
+                                    "l": 9.0,
+                                    "t": 12.0,
+                                    "r": 11.0,
+                                    "b": 10.0,
+                                    "coord_origin": "BOTTOMLEFT"
+                                },
+                                "charspan": [
+                                    0,
+                                    11
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/test/data/chunker/2i_out_chunks_multilayer.json
+++ b/test/data/chunker/2i_out_chunks_multilayer.json
@@ -1,0 +1,88 @@
+{
+    "root": [
+        {
+            "text": "Page Header\nMain body content\nPage Footer",
+            "meta": {
+                "schema_name": "docling_core.transforms.chunker.DocMeta",
+                "version": "1.0.0",
+                "doc_items": [
+                    {
+                        "self_ref": "#/texts/0",
+                        "parent": {
+                            "$ref": "#/body"
+                        },
+                        "children": [],
+                        "content_layer": "furniture",
+                        "label": "page_header",
+                        "prov": [
+                            {
+                                "page_no": 1,
+                                "bbox": {
+                                    "l": 1.0,
+                                    "t": 4.0,
+                                    "r": 3.0,
+                                    "b": 2.0,
+                                    "coord_origin": "BOTTOMLEFT"
+                                },
+                                "charspan": [
+                                    0,
+                                    11
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "self_ref": "#/texts/1",
+                        "parent": {
+                            "$ref": "#/body"
+                        },
+                        "children": [],
+                        "content_layer": "body",
+                        "label": "text",
+                        "prov": [
+                            {
+                                "page_no": 1,
+                                "bbox": {
+                                    "l": 5.0,
+                                    "t": 8.0,
+                                    "r": 7.0,
+                                    "b": 6.0,
+                                    "coord_origin": "BOTTOMLEFT"
+                                },
+                                "charspan": [
+                                    0,
+                                    17
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "self_ref": "#/texts/2",
+                        "parent": {
+                            "$ref": "#/body"
+                        },
+                        "children": [],
+                        "content_layer": "furniture",
+                        "label": "page_footer",
+                        "prov": [
+                            {
+                                "page_no": 1,
+                                "bbox": {
+                                    "l": 9.0,
+                                    "t": 12.0,
+                                    "r": 11.0,
+                                    "b": 10.0,
+                                    "coord_origin": "BOTTOMLEFT"
+                                },
+                                "charspan": [
+                                    0,
+                                    11
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/test/test_hierarchical_chunker.py
+++ b/test/test_hierarchical_chunker.py
@@ -9,7 +9,7 @@ from docling_core.transforms.chunker.hierarchical_chunker import (
 )
 from docling_core.transforms.serializer.html import HTMLDocSerializer
 from docling_core.transforms.serializer.markdown import MarkdownParams, MarkdownTableSerializer
-from docling_core.types.doc import DocItemLabel, DoclingDocument, PictureItem, TableData, TextItem
+from docling_core.types.doc import ContentLayer, DocItemLabel, DoclingDocument, PictureItem, TableData, TextItem
 
 from .test_utils import assert_or_generate_json_ground_truth, build_single_cell_rich_table_doc
 
@@ -48,7 +48,6 @@ def test_chunk_custom_serializer():
     assert_or_generate_json_ground_truth(act_data, "test/data/chunker/0b_out_chunks.json")
 
 
-
 def test_traverse_pictures():
     """Test that traverse_pictures parameter works correctly with HierarchicalChunker."""
 
@@ -65,9 +64,7 @@ def test_traverse_pictures():
                 has_non_caption_text_in_picture = True
                 break
 
-    assert has_non_caption_text_in_picture, (
-        "Test document should have non-caption TextItem children of PictureItem"
-    )
+    assert has_non_caption_text_in_picture, "Test document should have non-caption TextItem children of PictureItem"
 
     # Test 1: Default behavior (traverse_pictures=False)
     # Only caption TextItems should be included
@@ -115,9 +112,7 @@ def test_traverse_pictures():
         f"children of PictureItems should NOT be included. Found {non_caption_count_default}"
     )
 
-    assert caption_count_default > 0, (
-        "Caption TextItems should be included even with traverse_pictures=False"
-    )
+    assert caption_count_default > 0, "Caption TextItems should be included even with traverse_pictures=False"
 
     assert non_caption_count_traverse > 0, (
         f"With traverse_pictures=True, non-caption TextItems that are children of "
@@ -134,6 +129,38 @@ def test_traverse_pictures():
     assert total_items_traverse > total_items_default, (
         f"With traverse_pictures=True, more doc_items should be included in chunks. "
         f"Got {total_items_traverse} vs {total_items_default}"
+    )
+
+
+def test_chunk_multiple_content_layers(doc_with_layers: DoclingDocument):
+    """Test that chunking can include multiple content layers in the output."""
+
+    default_chunker = HierarchicalChunker()
+    default_text = "\n".join(chunk.text for chunk in default_chunker.chunk(dl_doc=doc_with_layers))
+
+    assert "Main body content" in default_text
+    assert "Page Header" not in default_text
+    assert "Page Footer" not in default_text
+
+    class MultiLayerSerializerProvider(ChunkingSerializerProvider):
+        def get_serializer(self, doc: DoclingDocument):
+            params = MarkdownParams(layers={ContentLayer.BODY, ContentLayer.FURNITURE})
+            return ChunkingDocSerializer(doc=doc, params=params)
+
+    multilayer_chunker = HierarchicalChunker(
+        serializer_provider=MultiLayerSerializerProvider(),
+    )
+    multilayer_chunks = list(multilayer_chunker.chunk(dl_doc=doc_with_layers))
+    multilayer_text = "\n".join(chunk.text for chunk in multilayer_chunks)
+
+    assert "Main body content" in multilayer_text
+    assert "Page Header" in multilayer_text
+    assert "Page Footer" in multilayer_text
+
+    act_data = dict(root=[DocChunk.model_validate(chunk).export_json_dict() for chunk in multilayer_chunks])
+    assert_or_generate_json_ground_truth(
+        act_data,
+        "test/data/chunker/0f_out_chunks_multilayer.json",
     )
 
 
@@ -269,8 +296,6 @@ def test_chunk_rich_table_custom_serializer(rich_table_doc: DoclingDocument):
     )
 
     chunks = chunker.chunk(dl_doc=doc)
-    act_data = dict(
-        root=[DocChunk.model_validate(n).export_json_dict() for n in chunks]
-    )
+    act_data = dict(root=[DocChunk.model_validate(n).export_json_dict() for n in chunks])
 
     assert_or_generate_json_ground_truth(act_data, "test/data/chunker/0c_out_chunks.json")

--- a/test/test_hierarchical_chunker.py
+++ b/test/test_hierarchical_chunker.py
@@ -9,7 +9,7 @@ from docling_core.transforms.chunker.hierarchical_chunker import (
 )
 from docling_core.transforms.serializer.html import HTMLDocSerializer
 from docling_core.transforms.serializer.markdown import MarkdownParams, MarkdownTableSerializer
-from docling_core.types.doc import DocItemLabel, DoclingDocument, PictureItem, TableData, TextItem
+from docling_core.types.doc import ContentLayer, DocItemLabel, DoclingDocument, PictureItem, TableData, TextItem
 
 from .test_utils import assert_or_generate_json_ground_truth, build_single_cell_rich_table_doc
 
@@ -128,6 +128,38 @@ def test_traverse_pictures():
     assert total_items_traverse > total_items_default, (
         f"With traverse_pictures=True, more doc_items should be included in chunks. "
         f"Got {total_items_traverse} vs {total_items_default}"
+    )
+
+
+def test_chunk_multiple_content_layers(doc_with_layers: DoclingDocument):
+    """Test that chunking can include multiple content layers in the output."""
+
+    default_chunker = HierarchicalChunker()
+    default_text = "\n".join(chunk.text for chunk in default_chunker.chunk(dl_doc=doc_with_layers))
+
+    assert "Main body content" in default_text
+    assert "Page Header" not in default_text
+    assert "Page Footer" not in default_text
+
+    class MultiLayerSerializerProvider(ChunkingSerializerProvider):
+        def get_serializer(self, doc: DoclingDocument):
+            params = MarkdownParams(layers={ContentLayer.BODY, ContentLayer.FURNITURE})
+            return ChunkingDocSerializer(doc=doc, params=params)
+
+    multilayer_chunker = HierarchicalChunker(
+        serializer_provider=MultiLayerSerializerProvider(),
+    )
+    multilayer_chunks = list(multilayer_chunker.chunk(dl_doc=doc_with_layers))
+    multilayer_text = "\n".join(chunk.text for chunk in multilayer_chunks)
+
+    assert "Main body content" in multilayer_text
+    assert "Page Header" in multilayer_text
+    assert "Page Footer" in multilayer_text
+
+    act_data = dict(root=[DocChunk.model_validate(chunk).export_json_dict() for chunk in multilayer_chunks])
+    assert_or_generate_json_ground_truth(
+        act_data,
+        "test/data/chunker/0f_out_chunks_multilayer.json",
     )
 
 

--- a/test/test_hybrid_chunker.py
+++ b/test/test_hybrid_chunker.py
@@ -17,7 +17,7 @@ from docling_core.transforms.chunker.tokenizer.openai import OpenAITokenizer
 from docling_core.transforms.serializer.html import HTMLTableSerializer
 from docling_core.transforms.serializer.markdown import MarkdownParams, MarkdownTableSerializer
 from docling_core.types.doc import DoclingDocument as DLDocument
-from docling_core.types.doc.document import DoclingDocument
+from docling_core.types.doc.document import ContentLayer, DoclingDocument
 from docling_core.types.doc.labels import DocItemLabel
 
 from .test_utils import assert_or_generate_json_ground_truth, build_single_cell_rich_table_doc
@@ -254,6 +254,47 @@ def test_contextualize_altered_delim():
     )
 
 
+def test_chunk_multiple_content_layers(doc_with_layers: DoclingDocument):
+    """Test that hybrid chunking can include multiple content layers in the output."""
+
+    default_chunker = HybridChunker(
+        tokenizer=HuggingFaceTokenizer(
+            tokenizer=INNER_TOKENIZER,
+            max_tokens=MAX_TOKENS,
+        ),
+    )
+    default_text = "\n".join(chunk.text for chunk in default_chunker.chunk(dl_doc=doc_with_layers))
+
+    assert "Main body content" in default_text
+    assert "Page Header" not in default_text
+    assert "Page Footer" not in default_text
+
+    class MultiLayerSerializerProvider(ChunkingSerializerProvider):
+        def get_serializer(self, doc: DoclingDocument):
+            params = MarkdownParams(layers={ContentLayer.BODY, ContentLayer.FURNITURE})
+            return ChunkingDocSerializer(doc=doc, params=params)
+
+    multilayer_chunker = HybridChunker(
+        tokenizer=HuggingFaceTokenizer(
+            tokenizer=INNER_TOKENIZER,
+            max_tokens=MAX_TOKENS,
+        ),
+        serializer_provider=MultiLayerSerializerProvider(),
+    )
+    multilayer_chunks = list(multilayer_chunker.chunk(dl_doc=doc_with_layers))
+    multilayer_text = "\n".join(chunk.text for chunk in multilayer_chunks)
+
+    assert "Main body content" in multilayer_text
+    assert "Page Header" in multilayer_text
+    assert "Page Footer" in multilayer_text
+
+    act_data = dict(root=[DocChunk.model_validate(chunk).export_json_dict() for chunk in multilayer_chunks])
+    assert_or_generate_json_ground_truth(
+        act_data,
+        "test/data/chunker/2i_out_chunks_multilayer.json",
+    )
+
+
 def test_chunk_custom_serializer():
     EXPECTED_OUT_FILE = "test/data/chunker/2e_out_chunks.json"
 
@@ -412,13 +453,12 @@ def test_shadowed_headings_wout_content():
         chunker = setup.chunker
         chunk_iter = chunker.chunk(dl_doc=doc)
         chunks = list(chunk_iter)
-        act_data = dict(
-            root=[DocChunk.model_validate(n).export_json_dict() for n in chunks]
-        )
+        act_data = dict(root=[DocChunk.model_validate(n).export_json_dict() for n in chunks])
         assert_or_generate_json_ground_truth(
             act_data,
             setup.exp,
         )
+
 
 def test_chunk_with_repeat_table_header():
     """Test that table headers are repeated when a table is split across chunks."""
@@ -437,7 +477,7 @@ def test_chunk_with_repeat_table_header():
             return ChunkingDocSerializer(
                 doc=doc,
                 table_serializer=MarkdownTableSerializer(),
-                params = MarkdownParams(compact_tables=True),  # Use compact table format to reduce token count
+                params=MarkdownParams(compact_tables=True),  # Use compact table format to reduce token count
             )
 
     chunker = HybridChunker(
@@ -458,7 +498,7 @@ def test_chunk_with_repeat_table_header():
         # Serialize the table
         ser_result = serializer.serialize(
             item=table_item,
-            )
+        )
         table_contents[table_item.self_ref] = ser_result.text
 
     chunks = list(chunker.chunk(dl_doc=dl_doc))
@@ -470,9 +510,7 @@ def test_chunk_with_repeat_table_header():
     for table_ref, table_text in table_contents.items():
         # Get header and body lines from the serialized table
         if table_text:
-            header_lines, body_lines = serializer.table_serializer.get_header_and_body_lines(
-                table_text=table_text
-            )
+            header_lines, body_lines = serializer.table_serializer.get_header_and_body_lines(table_text=table_text)
 
             # Find all chunks that contain content from this table
             chunks_with_table = [chunk for chunk in chunks if table_ref in [i.self_ref for i in chunk.meta.doc_items]]
@@ -485,10 +523,7 @@ def test_chunk_with_repeat_table_header():
                 # Each chunk with table content should have the header
                 for chunk in chunks_with_table:
                     # Check if header lines are present
-                    has_header = all(
-                        header_line.strip() in chunk.text
-                        for header_line in header_lines
-                    )
+                    has_header = all(header_line.strip() in chunk.text for header_line in header_lines)
                     assert has_header, (
                         f"Table {table_ref} split across chunks should have header repeated in each chunk. "
                         f"Missing header in chunk: {chunk.text[:200]}..."
@@ -507,7 +542,7 @@ def test_chunk_with_repeat_table_header():
             "meta": {
                 "doc_items": [item.self_ref for item in chunk.meta.doc_items] if chunk.meta.doc_items else [],
                 "headings": chunk.meta.headings,
-            }
+            },
         }
         for chunk in chunks
     ]
@@ -519,13 +554,13 @@ def test_chunk_html_table_serializer():
     """Test chunking with HTML table serializer."""
     INPUT_FILE = "test/data/chunker/0_inp_dl_doc.json"
     EXPECTED_OUT_FILE = "test/data/chunker/0e_out_chunks.json"
-    MAX_TOKENS= 250
+    MAX_TOKENS = 250
 
     with open(INPUT_FILE, encoding="utf-8") as f:
         data_json = f.read()
     dl_doc = DLDocument.model_validate_json(data_json)
 
-# Verify the document has tables
+    # Verify the document has tables
     assert len(dl_doc.tables) > 0, "Input file should contain at least one table"
 
     class HTMLSerializerProvider(ChunkingSerializerProvider):
@@ -538,23 +573,22 @@ def test_chunk_html_table_serializer():
     chunker = HybridChunker(
         tokenizer=HuggingFaceTokenizer(
             tokenizer=INNER_TOKENIZER,
-            max_tokens=MAX_TOKENS*2,
+            max_tokens=MAX_TOKENS * 2,
         ),
         merge_peers=True,
         repeat_table_header=True,
         serializer_provider=HTMLSerializerProvider(),
     )
 
-
     serializer = chunker.serializer_provider.get_serializer(dl_doc)
 
-# Serialize each table item individually to get expected content
+    # Serialize each table item individually to get expected content
     table_contents = {}
     for table_item in dl_doc.tables:
         # Serialize the table
         ser_result = serializer.serialize(
             item=table_item,
-            )
+        )
         table_contents[table_item.self_ref] = ser_result.text
 
     chunks = list(chunker.chunk(dl_doc=dl_doc))
@@ -566,9 +600,7 @@ def test_chunk_html_table_serializer():
     for table_ref, table_text in table_contents.items():
         # Get header and body lines from the serialized table
         if table_text:
-            header_lines, body_lines = serializer.table_serializer.get_header_and_body_lines(
-                table_text=table_text
-            )
+            header_lines, body_lines = serializer.table_serializer.get_header_and_body_lines(table_text=table_text)
 
             # Find all chunks that contain content from this table
             chunks_with_table = [chunk for chunk in chunks if table_ref in [i.self_ref for i in chunk.meta.doc_items]]
@@ -581,10 +613,7 @@ def test_chunk_html_table_serializer():
                 # Each chunk with table content should have the header
                 for chunk in chunks_with_table:
                     # Check if header lines are present
-                    has_header = all(
-                        header_line.strip() in chunk.text
-                        for header_line in header_lines
-                    )
+                    has_header = all(header_line.strip() in chunk.text for header_line in header_lines)
                     assert has_header, (
                         f"Table {table_ref} split across chunks should have header repeated in each chunk. "
                         f"Missing header in chunk: {chunk.text[:200]}..."
@@ -602,7 +631,6 @@ def test_chunk_html_table_serializer():
         act_data,
         EXPECTED_OUT_FILE,
     )
-
 
 
 def test_html_parser_error_handling():

--- a/test/test_hybrid_chunker.py
+++ b/test/test_hybrid_chunker.py
@@ -20,6 +20,7 @@ from docling_core.transforms.chunker.tokenizer.openai import OpenAITokenizer
 from docling_core.transforms.serializer.html import HTMLTableSerializer
 from docling_core.transforms.serializer.markdown import MarkdownParams, MarkdownTableSerializer
 from docling_core.types.doc import DocItemLabel, DoclingDocument
+from docling_core.types.doc.common.content_layer import ContentLayer
 from docling_core.types.doc.items.table.table_data import TableCell, TableData
 
 from .test_utils import assert_or_generate_json_ground_truth, build_single_cell_rich_table_doc
@@ -304,6 +305,41 @@ def test_contextualize_altered_delim():
     assert_or_generate_json_ground_truth(
         act_data,
         EXPECTED_OUT_FILE,
+    )
+
+
+def test_chunk_multiple_content_layers(doc_with_layers, markdown_chunker_250):
+    """Test that hybrid chunking can include multiple content layers in the output."""
+
+    default_text = "\n".join(chunk.text for chunk in markdown_chunker_250.chunk(dl_doc=doc_with_layers))
+
+    assert "Main body content" in default_text
+    assert "Page Header" not in default_text
+    assert "Page Footer" not in default_text
+
+    class MultiLayerSerializerProvider(ChunkingSerializerProvider):
+        def get_serializer(self, doc: DoclingDocument):
+            params = MarkdownParams(layers={ContentLayer.BODY, ContentLayer.FURNITURE})
+            return ChunkingDocSerializer(doc=doc, params=params)
+
+    multilayer_chunker = HybridChunker(
+        tokenizer=HuggingFaceTokenizer(
+            tokenizer=INNER_TOKENIZER,
+            max_tokens=MAX_TOKENS,
+        ),
+        serializer_provider=MultiLayerSerializerProvider(),
+    )
+    multilayer_chunks = list(multilayer_chunker.chunk(dl_doc=doc_with_layers))
+    multilayer_text = "\n".join(chunk.text for chunk in multilayer_chunks)
+
+    assert "Main body content" in multilayer_text
+    assert "Page Header" in multilayer_text
+    assert "Page Footer" in multilayer_text
+
+    act_data = dict(root=[DocChunk.model_validate(chunk).export_json_dict() for chunk in multilayer_chunks])
+    assert_or_generate_json_ground_truth(
+        act_data,
+        "test/data/chunker/2i_out_chunks_multilayer.json",
     )
 
 


### PR DESCRIPTION
## Summary

`HybridChunker` (and its underlying `HierarchicalChunker`) ignored the `layers`
parameter configured in serializer params. Items on non-default content layers
(e.g. `ContentLayer.FURNITURE`) were never included in chunks, even when the user
explicitly configured `MarkdownParams(layers={ContentLayer.BODY, ContentLayer.FURNITURE})`.

## Root cause

`HierarchicalChunker.chunk` already extracted `traverse_pictures` from the
serializer params and forwarded it to `dl_doc.iterate_items`, but did not do the
same for `params.layers`. As a result, `iterate_items` always used the default
content layers regardless of what was configured on the serializer, making the
`layers` parameter effectively a no-op for both chunkers.

## Changes

- **`hierarchical_chunker.py`**: extract `params.layers` from the serializer (when
  it is a `DocSerializer`) and pass it as `included_content_layers` to
  `dl_doc.iterate_items`, following the same pattern already used for
  `traverse_pictures`.
- **`hybrid_chunker.py`**: remove the redundant `doc_serializer=my_doc_ser` kwarg
  that was being passed to `_inner_chunker.chunk`. This kwarg was silently ignored
  by `HierarchicalChunker.chunk` — the inner chunker already builds its own
  serializer from the shared `serializer_provider`.

## Tests

Added `test_chunk_multiple_content_layers` to both `test_hierarchical_chunker.py`
and `test_hybrid_chunker.py`. Each test:

1. Asserts that the default chunker excludes furniture-layer items (`PAGE_HEADER`,
   `PAGE_FOOTER`).
2. Asserts that a chunker configured with `layers={BODY, FURNITURE}` correctly
   includes those items in the output.
3. Validates the full chunk structure against a JSON ground-truth snapshot.

Resolves #592
