### PR TITLE
fix: restore visited set when TripletTableSerializer produces empty output

### DIFF
--- a/docling_core/transforms/chunker/hierarchical_chunker.py
+++ b/docling_core/transforms/chunker/hierarchical_chunker.py
@@ -56,6 +56,8 @@ class TripletTableSerializer(BaseTableSerializer):
     ) -> SerializationResult:
         """Serializes the passed item."""
         parts: list[SerializationResult] = []
+        visited: Optional[set[str]] = kwargs.get("visited") if isinstance(kwargs.get("visited"), set) else None
+        visited_before: set[str] = set(visited) if visited is not None else set()
 
         cap_res = doc_serializer.serialize_captions(
             item=item,
@@ -101,6 +103,14 @@ class TripletTableSerializer(BaseTableSerializer):
                     parts.append(create_ser_result(text=table_text, span_source=item))
 
         text_res = "\n\n".join([r.text for r in parts])
+
+        # If the table produced no output, restore visited to its pre-call state so
+        # that child items referenced via RichTableCell remain available for chunking.
+        # This prevents layout tables (which serialize to empty text) from silently
+        # consuming all their referenced items and producing zero chunks.
+        if not text_res and visited is not None:
+            visited.clear()
+            visited.update(visited_before)
 
         return create_ser_result(text=text_res, span_source=parts)
 

--- a/test/test_hierarchical_chunker.py
+++ b/test/test_hierarchical_chunker.py
@@ -10,6 +10,7 @@ from docling_core.transforms.chunker.hierarchical_chunker import (
 from docling_core.transforms.serializer.html import HTMLDocSerializer
 from docling_core.transforms.serializer.markdown import MarkdownParams, MarkdownTableSerializer
 from docling_core.types.doc import DocItemLabel, DoclingDocument, PictureItem, TableData, TextItem
+from docling_core.types.doc.document import RichTableCell
 
 from .test_utils import assert_or_generate_json_ground_truth
 
@@ -183,3 +184,55 @@ def test_chunk_rich_table_custom_serializer(rich_table_doc: DoclingDocument):
     )
 
     assert_or_generate_json_ground_truth(act_data, "test/data/chunker/0c_out_chunks.json")
+
+
+def test_layout_table_produces_chunks():
+    """Regression test for layout tables (all-header RichTableCell tables) that
+    serialize to empty text but previously consumed all referenced items via the
+    shared `visited` set, resulting in zero chunks for the entire document.
+    """
+    doc = DoclingDocument(name="layout_table_regression")
+
+    # Add a layout table: 2 rows, 1 column, both rows are column headers.
+    # TripletTableSerializer will produce empty text because there are no data
+    # rows, but it must NOT permanently mark the referenced TextItems as visited.
+    table_item = doc.add_table(data=TableData(num_rows=2, num_cols=1))
+    text1 = doc.add_text(
+        parent=table_item,
+        label=DocItemLabel.TEXT,
+        text="Paragraph one from layout table",
+    )
+    text2 = doc.add_text(
+        parent=table_item,
+        label=DocItemLabel.TEXT,
+        text="Paragraph two from layout table",
+    )
+    doc.add_table_cell(
+        table_item=table_item,
+        cell=RichTableCell(
+            start_row_offset_idx=0,
+            end_row_offset_idx=1,
+            start_col_offset_idx=0,
+            end_col_offset_idx=1,
+            column_header=True,
+            ref=text1.get_ref(),
+        ),
+    )
+    doc.add_table_cell(
+        table_item=table_item,
+        cell=RichTableCell(
+            start_row_offset_idx=1,
+            end_row_offset_idx=2,
+            start_col_offset_idx=0,
+            end_col_offset_idx=1,
+            column_header=True,
+            ref=text2.get_ref(),
+        ),
+    )
+
+    chunks = list(HierarchicalChunker().chunk(doc))
+    chunk_texts = [c.text for c in chunks]
+
+    assert len(chunks) > 0, "Expected chunks from layout-table document, got zero"
+    assert text1.text in chunk_texts
+    assert text2.text in chunk_texts


### PR DESCRIPTION
## Problem

Closes #3335 (reported against `docling`, root cause is in `docling-core`).

DOCX files that use layout tables for formatting produce **zero chunks** from both `HierarchicalChunker` and `HybridChunker`, even though `doc.export_to_text()` returns substantial content.

### Root cause

Layout tables are represented as `TableItem` objects whose cells are `RichTableCell` entries pointing to `TextItem` children of the table. During chunking:

1. `HierarchicalChunker` calls `doc_serializer.serialize(item=table, visited=visited)`.
2. `DocSerializer.serialize()` marks the `TableItem` itself in `visited`, then calls `TripletTableSerializer.serialize()`.
3. `TripletTableSerializer` calls `_export_to_dataframe_with_options()`, which internally calls `doc_serializer.serialize()` for every `RichTableCell` reference, **marking all child items in the shared `visited` set**.
4. If the layout table serializes to **empty text** (e.g. all rows are column headers so there are no data rows for the triplet format), every child `TextItem` is permanently visited.
5. The chunker's main loop skips all visited items → **0 chunks**.

The workaround in the issue (`labels.discard(DocItemLabel.TABLE)`) bypasses the table entirely, avoiding visited-set poisoning, but is not a correct general fix.

## Fix

In `TripletTableSerializer.serialize()`, snapshot `visited` before calling `_export_to_dataframe_with_options`. If the table produces no output text, restore `visited` to the snapshot so child items remain available for chunking.

```python
visited_before: set[str] = set(visited) if visited is not None else set()

# ... export & render the table ...

if not text_res and visited is not None:
    visited.clear()
    visited.update(visited_before)
```

This is safe: tables that produce text continue to work exactly as before. Only tables that produce no output have their visited side-effects undone.

## Test

Added `test_layout_table_produces_chunks` to `test/test_hierarchical_chunker.py`. It builds a minimal two-row, one-column table where both rows are column headers (so `TripletTableSerializer` produces empty text), and asserts that `HierarchicalChunker` still yields one chunk per `TextItem` child.

All existing chunker tests continue to pass.