### PR TITLE
fix(serializer): stop duplicating spanning cells in markdown/dataframe output

### DIFF
--- a/docling_core/transforms/serializer/markdown.py
+++ b/docling_core/transforms/serializer/markdown.py
@@ -532,9 +532,20 @@ class MarkdownTableSerializer(BaseTableSerializer):
                     res_parts.append(ann_res)
 
             rows = []
-            for row in item.data.grid:
+            for r, row in enumerate(item.data.grid):
                 rendered_row = []
-                for col in row:
+                for c, col in enumerate(row):
+                    # Spanning cells (col_span > 1 or row_span > 1) appear at
+                    # every grid position they cover. Emit cell text only at
+                    # the cell's origin position; spanned positions render as
+                    # empty so a colspan=4 cell isn't repeated 4 times.
+                    is_origin = (
+                        r == col.start_row_offset_idx
+                        and c == col.start_col_offset_idx
+                    )
+                    if not is_origin:
+                        rendered_row.append("")
+                        continue
                     if isinstance(col, RichTableCell):
                         ref_item = col.ref.resolve(doc=doc)
                         inner_kwargs = {**kwargs, "_nested_in_table": True}

--- a/docling_core/types/doc/document.py
+++ b/docling_core/types/doc/document.py
@@ -2233,19 +2233,39 @@ class TableItem(FloatingItem):
             else:
                 break
 
-        # Create the column names from all col_headers
+        # Create the column names from all col_headers. A spanning header
+        # cell appears at every grid position it covers; emit its text only
+        # at the cell's origin (start_row_offset_idx, start_col_offset_idx)
+        # so a colspan=N header is not concatenated N times into N columns.
         columns: Optional[list[str]] = None
         if num_headers > 0:
             columns = ["" for _ in range(self.data.num_cols)]
             for i in range(num_headers):
                 for j, cell in enumerate(self.data.grid[i]):
+                    if (
+                        i != cell.start_row_offset_idx
+                        or j != cell.start_col_offset_idx
+                    ):
+                        continue
                     col_name = cell._get_text(doc=doc, **kwargs)
                     if columns[j] != "":
                         col_name = f".{col_name}"
                     columns[j] += col_name
 
-        # Create table data
-        table_data = [[cell._get_text(doc=doc, **kwargs) for cell in row] for row in self.data.grid[num_headers:]]
+        # Create table data — emit cell text only at its origin position;
+        # spanned positions render empty so spanning cells are not duplicated.
+        table_data = [
+            [
+                cell._get_text(doc=doc, **kwargs)
+                if (
+                    (num_headers + i) == cell.start_row_offset_idx
+                    and j == cell.start_col_offset_idx
+                )
+                else ""
+                for j, cell in enumerate(row)
+            ]
+            for i, row in enumerate(self.data.grid[num_headers:])
+        ]
 
         # Create DataFrame
         table = pd.DataFrame(table_data, columns=columns)
@@ -2268,9 +2288,18 @@ class TableItem(FloatingItem):
             )
 
             table = []
-            for row in self.data.grid:
+            for r, row in enumerate(self.data.grid):
                 tmp = []
-                for col in row:
+                for c, col in enumerate(row):
+                    # Spanning cells appear at every grid position they
+                    # cover; emit text only at the cell's origin so a
+                    # colspan/rowspan cell isn't duplicated in the output.
+                    if (
+                        r != col.start_row_offset_idx
+                        or c != col.start_col_offset_idx
+                    ):
+                        tmp.append("")
+                        continue
                     # make sure that md tables are not broken
                     # due to newline chars in the text
                     text = col._get_text(doc=doc)

--- a/test/data/doc/2206.01062.yaml.md
+++ b/test/data/doc/2206.01062.yaml.md
@@ -101,21 +101,21 @@ The annotation campaign was carried out in four phases. In phase one, we identif
 
 Table 1: DocLayNet dataset overview. Along with the frequency of each class label, we present the relative occurrence (as % of row 'Total') in the train, test and validation sets. The inter-annotator agreement is computed as the mAP@0.5-0.95 metric between pairwise annotations from the triple-annotated pages, from which we obtain accuracy ranges.
 
-|                |         | % of Total   | % of Total   | % of Total   | % of Total   | triple inter-annotator mAP @ 0.5-0.95 (%)   | triple inter-annotator mAP @ 0.5-0.95 (%)   | triple inter-annotator mAP @ 0.5-0.95 (%)   | triple inter-annotator mAP @ 0.5-0.95 (%)   | triple inter-annotator mAP @ 0.5-0.95 (%)   | triple inter-annotator mAP @ 0.5-0.95 (%)   |
-|----------------|---------|--------------|--------------|--------------|--------------|---------------------------------------------|---------------------------------------------|---------------------------------------------|---------------------------------------------|---------------------------------------------|---------------------------------------------|
-| class label    | Count   | Train        | Test         | Val          | All          | Fin                                         | Man                                         | Sci                                         | Law                                         | Pat                                         | Ten                                         |
-| Caption        | 22524   | 2.04         | 1.77         | 2.32         | 84-89        | 40-61                                       | 86-92                                       | 94-99                                       | 95-99                                       | 69-78                                       | n/a                                         |
-| Footnote       | 6318    | 0.60         | 0.31         | 0.58         | 83-91        | n/a                                         | 100                                         | 62-88                                       | 85-94                                       | n/a                                         | 82-97                                       |
-| Formula        | 25027   | 2.25         | 1.90         | 2.96         | 83-85        | n/a                                         | n/a                                         | 84-87                                       | 86-96                                       | n/a                                         | n/a                                         |
-| List-item      | 185660  | 17.19        | 13.34        | 15.82        | 87-88        | 74-83                                       | 90-92                                       | 97-97                                       | 81-85                                       | 75-88                                       | 93-95                                       |
-| Page-footer    | 70878   | 6.51         | 5.58         | 6.00         | 93-94        | 88-90                                       | 95-96                                       | 100                                         | 92-97                                       | 100                                         | 96-98                                       |
-| Page-header    | 58022   | 5.10         | 6.70         | 5.06         | 85-89        | 66-76                                       | 90-94                                       | 98-100                                      | 91-92                                       | 97-99                                       | 81-86                                       |
-| Picture        | 45976   | 4.21         | 2.78         | 5.31         | 69-71        | 56-59                                       | 82-86                                       | 69-82                                       | 80-95                                       | 66-71                                       | 59-76                                       |
-| Section-header | 142884  | 12.60        | 15.77        | 12.85        | 83-84        | 76-81                                       | 90-92                                       | 94-95                                       | 87-94                                       | 69-73                                       | 78-86                                       |
-| Table          | 34733   | 3.20         | 2.27         | 3.60         | 77-81        | 75-80                                       | 83-86                                       | 98-99                                       | 58-80                                       | 79-84                                       | 70-85                                       |
-| Text           | 510377  | 45.82        | 49.28        | 45.00        | 84-86        | 81-86                                       | 88-93                                       | 89-93                                       | 87-92                                       | 71-79                                       | 87-95                                       |
-| Title          | 5071    | 0.47         | 0.30         | 0.50         | 60-72        | 24-63                                       | 50-63                                       | 94-100                                      | 82-96                                       | 68-79                                       | 24-56                                       |
-| Total          | 1107470 | 941123       | 99816        | 66531        | 82-83        | 71-74                                       | 79-81                                       | 89-94                                       | 86-91                                       | 71-76                                       | 68-85                                       |
+|                |         | % of Total   |       |       |       | triple inter-annotator mAP @ 0.5-0.95 (%)   |       |        |       |       |       |
+|----------------|---------|--------------|-------|-------|-------|---------------------------------------------|-------|--------|-------|-------|-------|
+| class label    | Count   | Train        | Test  | Val   | All   | Fin                                         | Man   | Sci    | Law   | Pat   | Ten   |
+| Caption        | 22524   | 2.04         | 1.77  | 2.32  | 84-89 | 40-61                                       | 86-92 | 94-99  | 95-99 | 69-78 | n/a   |
+| Footnote       | 6318    | 0.60         | 0.31  | 0.58  | 83-91 | n/a                                         | 100   | 62-88  | 85-94 | n/a   | 82-97 |
+| Formula        | 25027   | 2.25         | 1.90  | 2.96  | 83-85 | n/a                                         | n/a   | 84-87  | 86-96 | n/a   | n/a   |
+| List-item      | 185660  | 17.19        | 13.34 | 15.82 | 87-88 | 74-83                                       | 90-92 | 97-97  | 81-85 | 75-88 | 93-95 |
+| Page-footer    | 70878   | 6.51         | 5.58  | 6.00  | 93-94 | 88-90                                       | 95-96 | 100    | 92-97 | 100   | 96-98 |
+| Page-header    | 58022   | 5.10         | 6.70  | 5.06  | 85-89 | 66-76                                       | 90-94 | 98-100 | 91-92 | 97-99 | 81-86 |
+| Picture        | 45976   | 4.21         | 2.78  | 5.31  | 69-71 | 56-59                                       | 82-86 | 69-82  | 80-95 | 66-71 | 59-76 |
+| Section-header | 142884  | 12.60        | 15.77 | 12.85 | 83-84 | 76-81                                       | 90-92 | 94-95  | 87-94 | 69-73 | 78-86 |
+| Table          | 34733   | 3.20         | 2.27  | 3.60  | 77-81 | 75-80                                       | 83-86 | 98-99  | 58-80 | 79-84 | 70-85 |
+| Text           | 510377  | 45.82        | 49.28 | 45.00 | 84-86 | 81-86                                       | 88-93 | 89-93  | 87-92 | 71-79 | 87-95 |
+| Title          | 5071    | 0.47         | 0.30  | 0.50  | 60-72 | 24-63                                       | 50-63 | 94-100 | 82-96 | 68-79 | 24-56 |
+| Total          | 1107470 | 941123       | 99816 | 66531 | 82-83 | 71-74                                       | 79-81 | 89-94  | 86-91 | 71-76 | 68-85 |
 
 Figure 3: Corpus Conversion Service annotation user interface. The PDF page is shown in the background, with overlaid text-cells (in darker shades). The annotation boxes can be drawn by dragging a rectangle over each segment with the respective label from the palette on the right.
 
@@ -160,21 +160,21 @@ Phase 4: Production annotation. The previously selected 80K pages were annotated
 
 Table 2: Prediction performance (mAP@0.5-0.95) of object detection networks on DocLayNet test set. The MRCNN (Mask R-CNN) and FRCNN (Faster R-CNN) models with ResNet-50 or ResNet-101 backbone were trained based on the network architectures from the detectron2 model zoo (Mask R-CNN R50, R101-FPN 3x, Faster R-CNN R101-FPN 3x), with default configurations. The YOLO implementation utilized was YOLOv5x6 [13]. All models were initialised using pre-trained weights from the COCO 2017 dataset.
 
-|                | human   | MRCNN   | MRCNN   | FRCNN   | YOLO   |
-|----------------|---------|---------|---------|---------|--------|
-|                | human   | R50     | R101    | R101    | v5x6   |
-| Caption        | 84-89   | 68.4    | 71.5    | 70.1    | 77.7   |
-| Footnote       | 83-91   | 70.9    | 71.8    | 73.7    | 77.2   |
-| Formula        | 83-85   | 60.1    | 63.4    | 63.5    | 66.2   |
-| List-item      | 87-88   | 81.2    | 80.8    | 81.0    | 86.2   |
-| Page-footer    | 93-94   | 61.6    | 59.3    | 58.9    | 61.1   |
-| Page-header    | 85-89   | 71.9    | 70.0    | 72.0    | 67.9   |
-| Picture        | 69-71   | 71.7    | 72.7    | 72.0    | 77.1   |
-| Section-header | 83-84   | 67.6    | 69.3    | 68.4    | 74.6   |
-| Table          | 77-81   | 82.2    | 82.9    | 82.2    | 86.3   |
-| Text           | 84-86   | 84.6    | 85.8    | 85.4    | 88.1   |
-| Title          | 60-72   | 76.7    | 80.4    | 79.9    | 82.7   |
-| All            | 82-83   | 72.4    | 73.5    | 73.4    | 76.8   |
+|                | human   | MRCNN   |      | FRCNN   | YOLO   |
+|----------------|---------|---------|------|---------|--------|
+|                |         | R50     | R101 | R101    | v5x6   |
+| Caption        | 84-89   | 68.4    | 71.5 | 70.1    | 77.7   |
+| Footnote       | 83-91   | 70.9    | 71.8 | 73.7    | 77.2   |
+| Formula        | 83-85   | 60.1    | 63.4 | 63.5    | 66.2   |
+| List-item      | 87-88   | 81.2    | 80.8 | 81.0    | 86.2   |
+| Page-footer    | 93-94   | 61.6    | 59.3 | 58.9    | 61.1   |
+| Page-header    | 85-89   | 71.9    | 70.0 | 72.0    | 67.9   |
+| Picture        | 69-71   | 71.7    | 72.7 | 72.0    | 77.1   |
+| Section-header | 83-84   | 67.6    | 69.3 | 68.4    | 74.6   |
+| Table          | 77-81   | 82.2    | 82.9 | 82.2    | 86.3   |
+| Text           | 84-86   | 84.6    | 85.8 | 85.4    | 88.1   |
+| Title          | 60-72   | 76.7    | 80.4 | 79.9    | 82.7   |
+| All            | 82-83   | 72.4    | 73.5 | 73.4    | 76.8   |
 
 to avoid this at any cost in order to have clear, unbiased baseline numbers for human document-layout annotation. Third, we introduced the feature of snapping boxes around text segments to obtain a pixel-accurate annotation and again reduce time and effort. The CCS annotation tool automatically shrinks every user-drawn box to the minimum bounding-box around the enclosed text-cells for all purely text-based segments, which excludes only Table and Picture . For the latter, we instructed annotation staff to minimise inclusion of surrounding whitespace while including all graphical lines. A downside of snapping boxes to enclosed text cells is that some wrongly parsed PDF pages cannot be annotated correctly and need to be skipped. Fourth, we established a way to flag pages as rejected for cases where no valid annotation according to the label guidelines could be achieved. Example cases for this would be PDF pages that render incorrectly or contain layouts that are impossible to capture with non-overlapping rectangles. Such rejected pages are not contained in the final dataset. With all these measures in place, experienced annotation staff managed to annotate a single page in a typical timeframe of 20s to 60s, depending on its complexity.
 
@@ -221,7 +221,7 @@ The choice and number of labels can have a significant effect on the overall mod
 
 Table 4: Performance of a Mask R-CNN R50 network with document-wise and page-wise split for different label sets. Naive page-wise split will result in /tildelow 10% point improvement.
 
-| Class-count    | 11   | 11   | 5   | 5    |
+| Class-count    | 11   |      | 5   |      |
 |----------------|------|------|-----|------|
 | Split          | Doc  | Page | Doc | Page |
 | Caption        | 68   | 83   |     |      |
@@ -249,22 +249,22 @@ Throughout this paper, we claim that DocLayNet's wider variety of document layou
 
 Table 5: Prediction Performance (mAP@0.5-0.95) of a Mask R-CNN R50 network across the PubLayNet, DocBank &amp; DocLayNet data-sets. By evaluating on common label classes of each dataset, we observe that the DocLayNet-trained model has much less pronounced variations in performance across all datasets.
 
-|                 |            | Testing on   | Testing on   | Testing on   |
-|-----------------|------------|--------------|--------------|--------------|
-| Training on     | labels     | PLN          | DB           | DLN          |
-| PubLayNet (PLN) | Figure     | 96           | 43           | 23           |
-| PubLayNet (PLN) | Sec-header | 87           | -            | 32           |
-| PubLayNet (PLN) | Table      | 95           | 24           | 49           |
-| PubLayNet (PLN) | Text       | 96           | -            | 42           |
-| PubLayNet (PLN) | total      | 93           | 34           | 30           |
-| DocBank (DB)    | Figure     | 77           | 71           | 31           |
-| DocBank (DB)    | Table      | 19           | 65           | 22           |
-| DocBank (DB)    | total      | 48           | 68           | 27           |
-| DocLayNet (DLN) | Figure     | 67           | 51           | 72           |
-| DocLayNet (DLN) | Sec-header | 53           | -            | 68           |
-| DocLayNet (DLN) | Table      | 87           | 43           | 82           |
-| DocLayNet (DLN) | Text       | 77           | -            | 84           |
-| DocLayNet (DLN) | total      | 59           | 47           | 78           |
+|                 |            | Testing on   |    |     |
+|-----------------|------------|--------------|----|-----|
+| Training on     | labels     | PLN          | DB | DLN |
+| PubLayNet (PLN) | Figure     | 96           | 43 | 23  |
+|                 | Sec-header | 87           | -  | 32  |
+|                 | Table      | 95           | 24 | 49  |
+|                 | Text       | 96           | -  | 42  |
+|                 | total      | 93           | 34 | 30  |
+| DocBank (DB)    | Figure     | 77           | 71 | 31  |
+|                 | Table      | 19           | 65 | 22  |
+|                 | total      | 48           | 68 | 27  |
+| DocLayNet (DLN) | Figure     | 67           | 51 | 72  |
+|                 | Sec-header | 53           | -  | 68  |
+|                 | Table      | 87           | 43 | 82  |
+|                 | Text       | 77           | -  | 84  |
+|                 | total      | 59           | 47 | 78  |
 
 Section-header , Table and Text . Before training, we either mapped or excluded DocLayNet's other labels as specified in table 3, and also PubLayNet's List to Text . Note that the different clustering of lists (by list-element vs. whole list objects) naturally decreases the mAP score for Text .
 

--- a/test/data/doc/2206.01062.yaml.paged.md
+++ b/test/data/doc/2206.01062.yaml.paged.md
@@ -107,21 +107,21 @@ The annotation campaign was carried out in four phases. In phase one, we identif
 
 Table 1: DocLayNet dataset overview. Along with the frequency of each class label, we present the relative occurrence (as % of row 'Total') in the train, test and validation sets. The inter-annotator agreement is computed as the mAP@0.5-0.95 metric between pairwise annotations from the triple-annotated pages, from which we obtain accuracy ranges.
 
-|                |         | % of Total   | % of Total   | % of Total   | % of Total   | triple inter-annotator mAP @ 0.5-0.95 (%)   | triple inter-annotator mAP @ 0.5-0.95 (%)   | triple inter-annotator mAP @ 0.5-0.95 (%)   | triple inter-annotator mAP @ 0.5-0.95 (%)   | triple inter-annotator mAP @ 0.5-0.95 (%)   | triple inter-annotator mAP @ 0.5-0.95 (%)   |
-|----------------|---------|--------------|--------------|--------------|--------------|---------------------------------------------|---------------------------------------------|---------------------------------------------|---------------------------------------------|---------------------------------------------|---------------------------------------------|
-| class label    | Count   | Train        | Test         | Val          | All          | Fin                                         | Man                                         | Sci                                         | Law                                         | Pat                                         | Ten                                         |
-| Caption        | 22524   | 2.04         | 1.77         | 2.32         | 84-89        | 40-61                                       | 86-92                                       | 94-99                                       | 95-99                                       | 69-78                                       | n/a                                         |
-| Footnote       | 6318    | 0.60         | 0.31         | 0.58         | 83-91        | n/a                                         | 100                                         | 62-88                                       | 85-94                                       | n/a                                         | 82-97                                       |
-| Formula        | 25027   | 2.25         | 1.90         | 2.96         | 83-85        | n/a                                         | n/a                                         | 84-87                                       | 86-96                                       | n/a                                         | n/a                                         |
-| List-item      | 185660  | 17.19        | 13.34        | 15.82        | 87-88        | 74-83                                       | 90-92                                       | 97-97                                       | 81-85                                       | 75-88                                       | 93-95                                       |
-| Page-footer    | 70878   | 6.51         | 5.58         | 6.00         | 93-94        | 88-90                                       | 95-96                                       | 100                                         | 92-97                                       | 100                                         | 96-98                                       |
-| Page-header    | 58022   | 5.10         | 6.70         | 5.06         | 85-89        | 66-76                                       | 90-94                                       | 98-100                                      | 91-92                                       | 97-99                                       | 81-86                                       |
-| Picture        | 45976   | 4.21         | 2.78         | 5.31         | 69-71        | 56-59                                       | 82-86                                       | 69-82                                       | 80-95                                       | 66-71                                       | 59-76                                       |
-| Section-header | 142884  | 12.60        | 15.77        | 12.85        | 83-84        | 76-81                                       | 90-92                                       | 94-95                                       | 87-94                                       | 69-73                                       | 78-86                                       |
-| Table          | 34733   | 3.20         | 2.27         | 3.60         | 77-81        | 75-80                                       | 83-86                                       | 98-99                                       | 58-80                                       | 79-84                                       | 70-85                                       |
-| Text           | 510377  | 45.82        | 49.28        | 45.00        | 84-86        | 81-86                                       | 88-93                                       | 89-93                                       | 87-92                                       | 71-79                                       | 87-95                                       |
-| Title          | 5071    | 0.47         | 0.30         | 0.50         | 60-72        | 24-63                                       | 50-63                                       | 94-100                                      | 82-96                                       | 68-79                                       | 24-56                                       |
-| Total          | 1107470 | 941123       | 99816        | 66531        | 82-83        | 71-74                                       | 79-81                                       | 89-94                                       | 86-91                                       | 71-76                                       | 68-85                                       |
+|                |         | % of Total   |       |       |       | triple inter-annotator mAP @ 0.5-0.95 (%)   |       |        |       |       |       |
+|----------------|---------|--------------|-------|-------|-------|---------------------------------------------|-------|--------|-------|-------|-------|
+| class label    | Count   | Train        | Test  | Val   | All   | Fin                                         | Man   | Sci    | Law   | Pat   | Ten   |
+| Caption        | 22524   | 2.04         | 1.77  | 2.32  | 84-89 | 40-61                                       | 86-92 | 94-99  | 95-99 | 69-78 | n/a   |
+| Footnote       | 6318    | 0.60         | 0.31  | 0.58  | 83-91 | n/a                                         | 100   | 62-88  | 85-94 | n/a   | 82-97 |
+| Formula        | 25027   | 2.25         | 1.90  | 2.96  | 83-85 | n/a                                         | n/a   | 84-87  | 86-96 | n/a   | n/a   |
+| List-item      | 185660  | 17.19        | 13.34 | 15.82 | 87-88 | 74-83                                       | 90-92 | 97-97  | 81-85 | 75-88 | 93-95 |
+| Page-footer    | 70878   | 6.51         | 5.58  | 6.00  | 93-94 | 88-90                                       | 95-96 | 100    | 92-97 | 100   | 96-98 |
+| Page-header    | 58022   | 5.10         | 6.70  | 5.06  | 85-89 | 66-76                                       | 90-94 | 98-100 | 91-92 | 97-99 | 81-86 |
+| Picture        | 45976   | 4.21         | 2.78  | 5.31  | 69-71 | 56-59                                       | 82-86 | 69-82  | 80-95 | 66-71 | 59-76 |
+| Section-header | 142884  | 12.60        | 15.77 | 12.85 | 83-84 | 76-81                                       | 90-92 | 94-95  | 87-94 | 69-73 | 78-86 |
+| Table          | 34733   | 3.20         | 2.27  | 3.60  | 77-81 | 75-80                                       | 83-86 | 98-99  | 58-80 | 79-84 | 70-85 |
+| Text           | 510377  | 45.82        | 49.28 | 45.00 | 84-86 | 81-86                                       | 88-93 | 89-93  | 87-92 | 71-79 | 87-95 |
+| Title          | 5071    | 0.47         | 0.30  | 0.50  | 60-72 | 24-63                                       | 50-63 | 94-100 | 82-96 | 68-79 | 24-56 |
+| Total          | 1107470 | 941123       | 99816 | 66531 | 82-83 | 71-74                                       | 79-81 | 89-94  | 86-91 | 71-76 | 68-85 |
 
 Figure 3: Corpus Conversion Service annotation user interface. The PDF page is shown in the background, with overlaid text-cells (in darker shades). The annotation boxes can be drawn by dragging a rectangle over each segment with the respective label from the palette on the right.
 
@@ -170,21 +170,21 @@ Phase 4: Production annotation. The previously selected 80K pages were annotated
 
 Table 2: Prediction performance (mAP@0.5-0.95) of object detection networks on DocLayNet test set. The MRCNN (Mask R-CNN) and FRCNN (Faster R-CNN) models with ResNet-50 or ResNet-101 backbone were trained based on the network architectures from the detectron2 model zoo (Mask R-CNN R50, R101-FPN 3x, Faster R-CNN R101-FPN 3x), with default configurations. The YOLO implementation utilized was YOLOv5x6 [13]. All models were initialised using pre-trained weights from the COCO 2017 dataset.
 
-|                | human   | MRCNN   | MRCNN   | FRCNN   | YOLO   |
-|----------------|---------|---------|---------|---------|--------|
-|                | human   | R50     | R101    | R101    | v5x6   |
-| Caption        | 84-89   | 68.4    | 71.5    | 70.1    | 77.7   |
-| Footnote       | 83-91   | 70.9    | 71.8    | 73.7    | 77.2   |
-| Formula        | 83-85   | 60.1    | 63.4    | 63.5    | 66.2   |
-| List-item      | 87-88   | 81.2    | 80.8    | 81.0    | 86.2   |
-| Page-footer    | 93-94   | 61.6    | 59.3    | 58.9    | 61.1   |
-| Page-header    | 85-89   | 71.9    | 70.0    | 72.0    | 67.9   |
-| Picture        | 69-71   | 71.7    | 72.7    | 72.0    | 77.1   |
-| Section-header | 83-84   | 67.6    | 69.3    | 68.4    | 74.6   |
-| Table          | 77-81   | 82.2    | 82.9    | 82.2    | 86.3   |
-| Text           | 84-86   | 84.6    | 85.8    | 85.4    | 88.1   |
-| Title          | 60-72   | 76.7    | 80.4    | 79.9    | 82.7   |
-| All            | 82-83   | 72.4    | 73.5    | 73.4    | 76.8   |
+|                | human   | MRCNN   |      | FRCNN   | YOLO   |
+|----------------|---------|---------|------|---------|--------|
+|                |         | R50     | R101 | R101    | v5x6   |
+| Caption        | 84-89   | 68.4    | 71.5 | 70.1    | 77.7   |
+| Footnote       | 83-91   | 70.9    | 71.8 | 73.7    | 77.2   |
+| Formula        | 83-85   | 60.1    | 63.4 | 63.5    | 66.2   |
+| List-item      | 87-88   | 81.2    | 80.8 | 81.0    | 86.2   |
+| Page-footer    | 93-94   | 61.6    | 59.3 | 58.9    | 61.1   |
+| Page-header    | 85-89   | 71.9    | 70.0 | 72.0    | 67.9   |
+| Picture        | 69-71   | 71.7    | 72.7 | 72.0    | 77.1   |
+| Section-header | 83-84   | 67.6    | 69.3 | 68.4    | 74.6   |
+| Table          | 77-81   | 82.2    | 82.9 | 82.2    | 86.3   |
+| Text           | 84-86   | 84.6    | 85.8 | 85.4    | 88.1   |
+| Title          | 60-72   | 76.7    | 80.4 | 79.9    | 82.7   |
+| All            | 82-83   | 72.4    | 73.5 | 73.4    | 76.8   |
 
 to avoid this at any cost in order to have clear, unbiased baseline numbers for human document-layout annotation. Third, we introduced the feature of snapping boxes around text segments to obtain a pixel-accurate annotation and again reduce time and effort. The CCS annotation tool automatically shrinks every user-drawn box to the minimum bounding-box around the enclosed text-cells for all purely text-based segments, which excludes only Table and Picture . For the latter, we instructed annotation staff to minimise inclusion of surrounding whitespace while including all graphical lines. A downside of snapping boxes to enclosed text cells is that some wrongly parsed PDF pages cannot be annotated correctly and need to be skipped. Fourth, we established a way to flag pages as rejected for cases where no valid annotation according to the label guidelines could be achieved. Example cases for this would be PDF pages that render incorrectly or contain layouts that are impossible to capture with non-overlapping rectangles. Such rejected pages are not contained in the final dataset. With all these measures in place, experienced annotation staff managed to annotate a single page in a typical timeframe of 20s to 60s, depending on its complexity.
 
@@ -233,7 +233,7 @@ The choice and number of labels can have a significant effect on the overall mod
 
 Table 4: Performance of a Mask R-CNN R50 network with document-wise and page-wise split for different label sets. Naive page-wise split will result in /tildelow 10% point improvement.
 
-| Class-count    | 11   | 11   | 5   | 5    |
+| Class-count    | 11   |      | 5   |      |
 |----------------|------|------|-----|------|
 | Split          | Doc  | Page | Doc | Page |
 | Caption        | 68   | 83   |     |      |
@@ -263,22 +263,22 @@ Throughout this paper, we claim that DocLayNet's wider variety of document layou
 
 Table 5: Prediction Performance (mAP@0.5-0.95) of a Mask R-CNN R50 network across the PubLayNet, DocBank &amp; DocLayNet data-sets. By evaluating on common label classes of each dataset, we observe that the DocLayNet-trained model has much less pronounced variations in performance across all datasets.
 
-|                 |            | Testing on   | Testing on   | Testing on   |
-|-----------------|------------|--------------|--------------|--------------|
-| Training on     | labels     | PLN          | DB           | DLN          |
-| PubLayNet (PLN) | Figure     | 96           | 43           | 23           |
-| PubLayNet (PLN) | Sec-header | 87           | -            | 32           |
-| PubLayNet (PLN) | Table      | 95           | 24           | 49           |
-| PubLayNet (PLN) | Text       | 96           | -            | 42           |
-| PubLayNet (PLN) | total      | 93           | 34           | 30           |
-| DocBank (DB)    | Figure     | 77           | 71           | 31           |
-| DocBank (DB)    | Table      | 19           | 65           | 22           |
-| DocBank (DB)    | total      | 48           | 68           | 27           |
-| DocLayNet (DLN) | Figure     | 67           | 51           | 72           |
-| DocLayNet (DLN) | Sec-header | 53           | -            | 68           |
-| DocLayNet (DLN) | Table      | 87           | 43           | 82           |
-| DocLayNet (DLN) | Text       | 77           | -            | 84           |
-| DocLayNet (DLN) | total      | 59           | 47           | 78           |
+|                 |            | Testing on   |    |     |
+|-----------------|------------|--------------|----|-----|
+| Training on     | labels     | PLN          | DB | DLN |
+| PubLayNet (PLN) | Figure     | 96           | 43 | 23  |
+|                 | Sec-header | 87           | -  | 32  |
+|                 | Table      | 95           | 24 | 49  |
+|                 | Text       | 96           | -  | 42  |
+|                 | total      | 93           | 34 | 30  |
+| DocBank (DB)    | Figure     | 77           | 71 | 31  |
+|                 | Table      | 19           | 65 | 22  |
+|                 | total      | 48           | 68 | 27  |
+| DocLayNet (DLN) | Figure     | 67           | 51 | 72  |
+|                 | Sec-header | 53           | -  | 68  |
+|                 | Table      | 87           | 43 | 82  |
+|                 | Text       | 77           | -  | 84  |
+|                 | total      | 59           | 47 | 78  |
 
 Section-header , Table and Text . Before training, we either mapped or excluded DocLayNet's other labels as specified in table 3, and also PubLayNet's List to Text . Note that the different clustering of lists (by list-element vs. whole list objects) naturally decreases the mAP score for Text .
 

--- a/test/data/doc/constructed_doc.embedded.md.gt
+++ b/test/data/doc/constructed_doc.embedded.md.gt
@@ -23,10 +23,10 @@ This paper introduces the biggest invention ever made. ...
 
 This is the caption of table 1.
 
-| Product   |   Years |   Years |
-|-----------|---------|---------|
-| Product   |    2016 |    2017 |
-| Apple     |   49823 |  695944 |
+| Product   |   Years |        |
+|-----------|---------|--------|
+|           |    2016 |   2017 |
+| Apple     |   49823 | 695944 |
 
 This is the caption of figure 1.
 

--- a/test/data/doc/constructed_doc.placeholder.md.gt
+++ b/test/data/doc/constructed_doc.placeholder.md.gt
@@ -23,10 +23,10 @@ This paper introduces the biggest invention ever made. ...
 
 This is the caption of table 1.
 
-| Product   |   Years |   Years |
-|-----------|---------|---------|
-| Product   |    2016 |    2017 |
-| Apple     |   49823 |  695944 |
+| Product   |   Years |        |
+|-----------|---------|--------|
+|           |    2016 |   2017 |
+| Apple     |   49823 | 695944 |
 
 This is the caption of figure 1.
 

--- a/test/data/doc/constructed_doc.referenced.md.gt
+++ b/test/data/doc/constructed_doc.referenced.md.gt
@@ -23,10 +23,10 @@ This paper introduces the biggest invention ever made. ...
 
 This is the caption of table 1.
 
-| Product   |   Years |   Years |
-|-----------|---------|---------|
-| Product   |    2016 |    2017 |
-| Apple     |   49823 |  695944 |
+| Product   |   Years |        |
+|-----------|---------|--------|
+|           |    2016 |   2017 |
+| Apple     |   49823 | 695944 |
 
 This is the caption of figure 1.
 

--- a/test/data/doc/constructed_document.yaml.md
+++ b/test/data/doc/constructed_document.yaml.md
@@ -23,10 +23,10 @@ This paper introduces the biggest invention ever made. ...
 
 This is the caption of table 1.
 
-| Product   |   Years |   Years |
-|-----------|---------|---------|
-| Product   |    2016 |    2017 |
-| Apple     |   49823 |  695944 |
+| Product   |   Years |        |
+|-----------|---------|--------|
+|           |    2016 |   2017 |
+| Apple     |   49823 | 695944 |
 
 This is the caption of figure 1.
 


### PR DESCRIPTION
## Summary

The markdown table serializer and the legacy markdown / dataframe export paths iterate `data.grid` and emit each grid cell's text. When a `TableCell` has `col_span > 1` or `row_span > 1`, the same cell reference occupies every grid position it covers, so iterating produces N copies of the cell's text in the output instead of one.

The underlying `TableCell` data is correct (TableFormer emits one cell per merged region with `col_span` / `row_span` set). Only the serialized presentation duplicates.

## Visible symptoms

- A `col_span=4` header like \`KRYTERIA FORMALNE\` rendered as four repeated cells instead of one cell + three empties.
- A `row_span=2` cell like \`Energy reduction\` rendered twice in consecutive rows of the markdown table.
- `export_to_dataframe()` concatenated the parent header text with each child header (e.g. \`KRYTERIA FORMALNE.Lp.\`, \`KRYTERIA FORMALNE.TAK\`).

## Fix

In all three code paths:

- `MarkdownTableSerializer.serialize` (modern path)
- `TableItem.export_to_markdown` (legacy path)
- `TableItem.export_to_dataframe`

emit cell text only at the cell's origin position (`start_row_offset_idx`, `start_col_offset_idx`). Spanned positions render as empty string. Cells with `col_span=1` and `row_span=1` are unaffected because their single grid position equals their origin.

## Test plan

- [x] \`pytest test/test_docling_doc.py\` — 67 pass after fixture regen
- [x] Full non-chunker test suite — 376 pass, 2 xfailed, no regressions
- [x] Manual run via \`docling\` on three PDFs that exercise spans:
  - CVS Group 2025 annual report (TCFD table, page 35) — \`Energy reduction\` rowspan now renders once
  - Polish gov "Czyste Powietrze" — \`KRYTERIA FORMALNE\` colspan=4 now renders once
  - iShares dividend statement — \`Net Cash for Reinvestment#\` colspan=2 now renders once
- [x] Regenerated 6 affected groundtruth fixtures (\`*.yaml.md\`, \`*.paged.md\`, \`constructed_doc*.md.gt\`). Diffs are precisely the removed cell-content duplication, nothing else.

## Issues addressed

Closes docling-project/docling#2862 — \`export_to_dataframe\` produces duplicated cells when tables contain spanning cells. The dataframe path is fixed by this change.

## Notes

- \`data.grid\` semantics are unchanged — the same \`TableCell\` reference still occupies multiple grid positions for spans. Only the serializers' use of it changes.
- HTML serializer wasn't modified; HTML supports native \`colspan\` / \`rowspan\` so the duplication issue may not apply there. Please flag if it does.