### PR TITLE
feat: add DOCLINGCORE_ALLOWED_PRIVATE_IPS setting to allow private IPs

### DIFF
--- a/docling_core/utils/file.py
+++ b/docling_core/utils/file.py
@@ -1,6 +1,7 @@
 """File-related utilities."""
 
 import ipaddress
+import logging
 import re
 import tempfile
 from io import BytesIO
@@ -14,6 +15,9 @@ from typing_extensions import deprecated
 
 from docling_core.types.doc.utils import relative_path
 from docling_core.types.io import DocumentStream
+from docling_core.utils.settings import settings
+
+_logger = logging.getLogger(__name__)
 
 _MAX_REDIRECTS = 5
 
@@ -31,6 +35,20 @@ class FileSizeLimitExceededError(ValueError):
         self.size = size
         self.limit = limit
         super().__init__(f"Remote file exceeds the maximum allowed size ({size} > {limit} bytes).")
+
+
+def _ip_in_allowlist(ip: ipaddress.IPv4Address, allowlist: list[str]) -> bool:
+    for entry in allowlist:
+        entry = entry.strip()
+        if not entry:
+            continue
+        try:
+            network = ipaddress.ip_network(entry)
+            if ip in network:
+                return True
+        except ValueError:
+            _logger.warning(f"Skipping malformed entry in DOCLINGCORE_ALLOWED_PRIVATE_IPS: {entry!r}")
+    return False
 
 
 def _is_safe_url(url: str) -> bool:
@@ -52,6 +70,8 @@ def _is_safe_url(url: str) -> bool:
                 ip = ipaddress.ip_address(ip_str)
             except (socket.gaierror, socket.herror):
                 return False
+        if settings.allowed_private_ips and _ip_in_allowlist(ip, settings.allowed_private_ips):
+            return True
 
         return ip.is_global and not (
             ip.is_private

--- a/docling_core/utils/file.py
+++ b/docling_core/utils/file.py
@@ -1,6 +1,7 @@
 """File-related utilities."""
 
 import ipaddress
+import logging
 import re
 import tempfile
 from io import BytesIO
@@ -14,8 +15,25 @@ from typing_extensions import deprecated
 
 from docling_core.types.doc.utils import relative_path
 from docling_core.types.io import DocumentStream
+from docling_core.utils.settings import settings
+
+_logger = logging.getLogger(__name__)
 
 _MAX_REDIRECTS = 5
+
+
+def _ip_in_allowlist(ip: ipaddress.IPv4Address, allowlist: list[str]) -> bool:
+    for entry in allowlist:
+        entry = entry.strip()
+        if not entry:
+            continue
+        try:
+            network = ipaddress.ip_network(entry)
+            if ip in network:
+                return True
+        except ValueError:
+            _logger.warning(f"Skipping malformed entry in DOCLINGCORE_ALLOWED_PRIVATE_IPS: {entry!r}")
+    return False
 
 
 def _is_safe_url(url: str) -> bool:
@@ -37,6 +55,8 @@ def _is_safe_url(url: str) -> bool:
                 ip = ipaddress.ip_address(ip_str)
             except (socket.gaierror, socket.herror):
                 return False
+        if settings.allowed_private_ips and _ip_in_allowlist(ip, settings.allowed_private_ips):
+            return True
 
         return ip.is_global and not (
             ip.is_private

--- a/docling_core/utils/file.py
+++ b/docling_core/utils/file.py
@@ -37,7 +37,8 @@ class FileSizeLimitExceededError(ValueError):
         super().__init__(f"Remote file exceeds the maximum allowed size ({size} > {limit} bytes).")
 
 
-def _ip_in_allowlist(ip: ipaddress.IPv4Address, allowlist: list[str]) -> bool:
+def _ip_in_allowlist(ip: ipaddress.IPv4Address | ipaddress.IPv6Address, allowlist: list[str]) -> bool:
+    """Return whether a ip matches any IP addresss or CIDR entry in allowlist."""
     for entry in allowlist:
         entry = entry.strip()
         if not entry:
@@ -47,7 +48,11 @@ def _ip_in_allowlist(ip: ipaddress.IPv4Address, allowlist: list[str]) -> bool:
             if ip in network:
                 return True
         except ValueError:
-            _logger.warning(f"Skipping malformed entry in DOCLINGCORE_ALLOWED_PRIVATE_IPS: {entry!r}")
+            _logger.warning(
+                f"Skipping malformed entry in DOCLINGCORE_ALLOWED_PRIVATE_IPS: {entry!r} "
+                "(if this is a CIDR range, the network address must have no host bits set, "
+                "e.g. '10.0.0.0/8' rather than '10.0.0.5/8')"
+            )
     return False
 
 

--- a/docling_core/utils/file.py
+++ b/docling_core/utils/file.py
@@ -44,14 +44,18 @@ def _ip_in_allowlist(ip: ipaddress.IPv4Address | ipaddress.IPv6Address, allowlis
         if not entry:
             continue
         try:
-            network = ipaddress.ip_network(entry)
+            network = ipaddress.ip_network(entry, strict=False)
+            normalized = str(network)
+            if normalized != entry:
+                _logger.warning(
+                    f"DOCLINGCORE_ALLOWED_PRIVATE_IPS entry {entry!r} was normalized to "
+                    f"{normalized!r}. Consider using the explicit network address."
+                )
             if ip in network:
                 return True
         except ValueError:
             _logger.warning(
                 f"Skipping malformed entry in DOCLINGCORE_ALLOWED_PRIVATE_IPS: {entry!r} "
-                "(if this is a CIDR range, the network address must have no host bits set, "
-                "e.g. '10.0.0.0/8' rather than '10.0.0.5/8')"
             )
     return False
 

--- a/docling_core/utils/file.py
+++ b/docling_core/utils/file.py
@@ -54,9 +54,7 @@ def _ip_in_allowlist(ip: ipaddress.IPv4Address | ipaddress.IPv6Address, allowlis
             if ip in network:
                 return True
         except ValueError:
-            _logger.warning(
-                f"Skipping malformed entry in DOCLINGCORE_ALLOWED_PRIVATE_IPS: {entry!r} "
-            )
+            _logger.warning(f"Skipping malformed entry in DOCLINGCORE_ALLOWED_PRIVATE_IPS: {entry!r} ")
     return False
 
 

--- a/docling_core/utils/settings.py
+++ b/docling_core/utils/settings.py
@@ -6,6 +6,7 @@ class CoreSettings(BaseSettings):
 
     allow_image_file_uri: bool = False
     max_image_decoded_size: int = 20 * 1024 * 1024  # 20MB
+    allowed_private_ips: list[str] = []
 
     # DocLang deserialize budgets (DoS protection for untrusted markup / .dclx)
     max_doclang_xml_bytes: int = 128 * 1024 * 1024  # 128 MiB

--- a/docling_core/utils/settings.py
+++ b/docling_core/utils/settings.py
@@ -6,6 +6,7 @@ class CoreSettings(BaseSettings):
 
     allow_image_file_uri: bool = False
     max_image_decoded_size: int = 20 * 1024 * 1024  # 20MB
+    allowed_private_ips: list[str] = []
 
 
 settings = CoreSettings()

--- a/docling_core/utils/settings.py
+++ b/docling_core/utils/settings.py
@@ -1,3 +1,6 @@
+from typing import Annotated
+
+from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -6,7 +9,18 @@ class CoreSettings(BaseSettings):
 
     allow_image_file_uri: bool = False
     max_image_decoded_size: int = 20 * 1024 * 1024  # 20MB
-    allowed_private_ips: list[str] = []
+    allowed_private_ips: Annotated[
+        list[str],
+        Field(
+            description=(
+                "List of IP addresses and/or CIDR ranges that bypass SSRF protection. "
+                "Defaults to empty, which preserves full SSRF protection."
+            ),
+            examples=[
+                ["192.168.1.0/24", "10.0.0.5", "127.0.0.1"],
+            ],
+        ),
+    ] = []
 
     # DocLang deserialize budgets (DoS protection for untrusted markup / .dclx)
     max_doclang_xml_bytes: int = 128 * 1024 * 1024  # 128 MiB

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -192,7 +192,54 @@ def test_is_safe_url_rejects_private_networks():
     assert _is_safe_url("http://8.8.8.8/file")
     assert _is_safe_url("https://example.com/file")
     assert _is_safe_url("https://github.com/github/file")
+    
+def test_ip_in_allowlist():
+    import ipaddress
+    from docling_core.utils.file import _ip_in_allowlist
 
+    assert _ip_in_allowlist(ipaddress.ip_address("127.0.0.1"), ["127.0.0.1"])
+    assert not _ip_in_allowlist(ipaddress.ip_address("127.0.0.1"), ["127.0.0.2"])
+
+    assert _ip_in_allowlist(ipaddress.ip_address("10.20.30.40"), ["10.0.0.0/8"])
+    assert not _ip_in_allowlist(ipaddress.ip_address("10.21.0.1"), ["10.20.0.0/16"])
+
+    assert _ip_in_allowlist(ipaddress.ip_address("192.168.1.100"), ["192.168.1.0/24"])
+    assert not _ip_in_allowlist(ipaddress.ip_address("192.168.1.100"), ["192.168.1.5/24"])
+
+    assert _ip_in_allowlist(ipaddress.ip_address("127.0.0.1"), ["garbage", "127.0.0.1"])
+    assert not _ip_in_allowlist(ipaddress.ip_address("127.0.0.1"), ["garbage", "300.300.300.300"])
+
+
+
+def test_allowed_private_ips(monkeypatch):
+    import pytest
+    from docling_core.utils.file import resolve_source_to_stream
+    from docling_core.utils.settings import settings
+    from requests import Response
+
+    def mock_get(*args, **kwargs):
+        r = Response()
+        r.status_code = 200
+        r._content = b"ok"
+        return r
+
+    monkeypatch.setattr("requests.Session.get", mock_get)
+
+    monkeypatch.setattr(settings, "allowed_private_ips", [])
+    with pytest.raises(ValueError, match="URL is not allowed"):
+        resolve_source_to_stream("http://10.0.0.1/file")
+
+    monkeypatch.setattr(settings, "allowed_private_ips", [""])
+    with pytest.raises(ValueError, match="URL is not allowed"):
+        resolve_source_to_stream("http://10.0.0.1/file")
+
+    monkeypatch.setattr(settings, "allowed_private_ips", ["127.0.0.1"])
+    assert resolve_source_to_stream("http://127.0.0.1/file").stream.read() == b"ok"
+
+    monkeypatch.setattr(settings, "allowed_private_ips", ["192.168.1.0/24"])
+    assert resolve_source_to_stream("http://192.168.1.42/doc").stream.read() == b"ok"
+    with pytest.raises(ValueError, match="URL is not allowed"):
+        resolve_source_to_stream("http://192.168.2.1/doc")
 
 def test_resolve_remote_filename_sanitizes_content_disposition(monkeypatch):
     """Test filename normalization from Content-Disposition."""

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -231,7 +231,54 @@ def test_is_safe_url_rejects_private_networks(monkeypatch):
     assert _is_safe_url("http://8.8.8.8/file")
     assert _is_safe_url("https://example.com/file")
     assert _is_safe_url("https://github.com/github/file")
+    
+def test_ip_in_allowlist():
+    import ipaddress
+    from docling_core.utils.file import _ip_in_allowlist
 
+    assert _ip_in_allowlist(ipaddress.ip_address("127.0.0.1"), ["127.0.0.1"])
+    assert not _ip_in_allowlist(ipaddress.ip_address("127.0.0.1"), ["127.0.0.2"])
+
+    assert _ip_in_allowlist(ipaddress.ip_address("10.20.30.40"), ["10.0.0.0/8"])
+    assert not _ip_in_allowlist(ipaddress.ip_address("10.21.0.1"), ["10.20.0.0/16"])
+
+    assert _ip_in_allowlist(ipaddress.ip_address("192.168.1.100"), ["192.168.1.0/24"])
+    assert not _ip_in_allowlist(ipaddress.ip_address("192.168.1.100"), ["192.168.1.5/24"])
+
+    assert _ip_in_allowlist(ipaddress.ip_address("127.0.0.1"), ["garbage", "127.0.0.1"])
+    assert not _ip_in_allowlist(ipaddress.ip_address("127.0.0.1"), ["garbage", "300.300.300.300"])
+
+
+
+def test_allowed_private_ips(monkeypatch):
+    import pytest
+    from docling_core.utils.file import resolve_source_to_stream
+    from docling_core.utils.settings import settings
+    from requests import Response
+
+    def mock_get(*args, **kwargs):
+        r = Response()
+        r.status_code = 200
+        r._content = b"ok"
+        return r
+
+    monkeypatch.setattr("requests.Session.get", mock_get)
+
+    monkeypatch.setattr(settings, "allowed_private_ips", [])
+    with pytest.raises(ValueError, match="URL is not allowed"):
+        resolve_source_to_stream("http://10.0.0.1/file")
+
+    monkeypatch.setattr(settings, "allowed_private_ips", [""])
+    with pytest.raises(ValueError, match="URL is not allowed"):
+        resolve_source_to_stream("http://10.0.0.1/file")
+
+    monkeypatch.setattr(settings, "allowed_private_ips", ["127.0.0.1"])
+    assert resolve_source_to_stream("http://127.0.0.1/file").stream.read() == b"ok"
+
+    monkeypatch.setattr(settings, "allowed_private_ips", ["192.168.1.0/24"])
+    assert resolve_source_to_stream("http://192.168.1.42/doc").stream.read() == b"ok"
+    with pytest.raises(ValueError, match="URL is not allowed"):
+        resolve_source_to_stream("http://192.168.2.1/doc")
 
 def test_resolve_remote_filename_sanitizes_content_disposition(monkeypatch):
     """Test filename normalization from Content-Disposition."""

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -231,9 +231,10 @@ def test_is_safe_url_rejects_private_networks(monkeypatch):
     assert _is_safe_url("http://8.8.8.8/file")
     assert _is_safe_url("https://example.com/file")
     assert _is_safe_url("https://github.com/github/file")
-    
+
 def test_ip_in_allowlist():
     import ipaddress
+
     from docling_core.utils.file import _ip_in_allowlist
 
     assert _ip_in_allowlist(ipaddress.ip_address("127.0.0.1"), ["127.0.0.1"])
@@ -252,17 +253,11 @@ def test_ip_in_allowlist():
 
 def test_allowed_private_ips(monkeypatch):
     import pytest
+
     from docling_core.utils.file import resolve_source_to_stream
     from docling_core.utils.settings import settings
-    from requests import Response
 
-    def mock_get(*args, **kwargs):
-        r = Response()
-        r.status_code = 200
-        r._content = b"ok"
-        return r
-
-    monkeypatch.setattr("requests.Session.get", mock_get)
+    monkeypatch.setattr(Session, "get", lambda *args, **kwargs: _closeable_response(content=b"ok"))
 
     monkeypatch.setattr(settings, "allowed_private_ips", [])
     with pytest.raises(ValueError, match="URL is not allowed"):
@@ -279,6 +274,7 @@ def test_allowed_private_ips(monkeypatch):
     assert resolve_source_to_stream("http://192.168.1.42/doc").stream.read() == b"ok"
     with pytest.raises(ValueError, match="URL is not allowed"):
         resolve_source_to_stream("http://192.168.2.1/doc")
+
 
 def test_resolve_remote_filename_sanitizes_content_disposition(monkeypatch):
     """Test filename normalization from Content-Disposition."""

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -244,7 +244,7 @@ def test_ip_in_allowlist():
     assert not _ip_in_allowlist(ipaddress.ip_address("10.21.0.1"), ["10.20.0.0/16"])
 
     assert _ip_in_allowlist(ipaddress.ip_address("192.168.1.100"), ["192.168.1.0/24"])
-    assert not _ip_in_allowlist(ipaddress.ip_address("192.168.1.100"), ["192.168.1.5/24"])
+    assert _ip_in_allowlist(ipaddress.ip_address("192.168.1.100"), ["192.168.1.5/24"])
 
     assert _ip_in_allowlist(ipaddress.ip_address("127.0.0.1"), ["garbage", "127.0.0.1"])
     assert not _ip_in_allowlist(ipaddress.ip_address("127.0.0.1"), ["garbage", "300.300.300.300"])

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -232,6 +232,7 @@ def test_is_safe_url_rejects_private_networks(monkeypatch):
     assert _is_safe_url("https://example.com/file")
     assert _is_safe_url("https://github.com/github/file")
 
+
 def test_ip_in_allowlist():
     import ipaddress
 
@@ -248,7 +249,6 @@ def test_ip_in_allowlist():
 
     assert _ip_in_allowlist(ipaddress.ip_address("127.0.0.1"), ["garbage", "127.0.0.1"])
     assert not _ip_in_allowlist(ipaddress.ip_address("127.0.0.1"), ["garbage", "300.300.300.300"])
-
 
 
 def test_allowed_private_ips(monkeypatch):


### PR DESCRIPTION
Closes #599

Adds an optional "allowed_private_ips" to CoreSettings to specify safe internal IPs as described in the issue
Default behaviour is unchanged