### PR TITLE
fix(markdown): pass kwargs to _serialize_image_part()

### DIFF
--- a/docling_core/transforms/serializer/markdown.py
+++ b/docling_core/transforms/serializer/markdown.py
@@ -614,8 +614,7 @@ class MarkdownPictureSerializer(BasePictureSerializer):
             img_res = self._serialize_image_part(
                 item=item,
                 doc=doc,
-                image_mode=params.image_mode,
-                image_placeholder=params.image_placeholder,
+                **kwargs,
             )
             if img_res.text:
                 res_parts.append(img_res)


### PR DESCRIPTION
This allows passing custom arguments to the `_serialize_image_part()` method.

Then, with a custom serializer, it is possible to specify which image ids to serialize just overriding this method, similar to the [Indexed picture placeholders](https://docling-project.github.io/docling/examples/serialization/#indexed-picture-placeholders) example.