### PR TITLE
fix: render RichTableCell descendants inside the cell

### DIFF
--- a/docling_core/transforms/serializer/html.py
+++ b/docling_core/transforms/serializer/html.py
@@ -230,13 +230,30 @@ class HTMLTextSerializer(BaseModel, BaseTextSerializer):
             # Regular text item
             text = get_html_tag_with_text_direction(html_tag="p", text=text)
 
-        # Apply formatting and hyperlinks
+        # Apply formatting and hyperlinks to the parent's own text+tag.
         if not post_processed:
             text = doc_serializer.post_process(
                 text=text,
                 formatting=item.formatting,
                 hyperlink=item.hyperlink,
             )
+
+        # Recurse into children for branches that don't already consume them.
+        # has_inline_repr already consumed the single InlineGroup child; ListItem
+        # recursion is handled inline in its branch above.
+        if not has_inline_repr and not isinstance(item, ListItem) and item.children:
+            nested_text = "\n".join(
+                r.text
+                for r in doc_serializer.get_parts(
+                    item=item,
+                    is_inline_scope=is_inline_scope,
+                    visited=my_visited,
+                    **kwargs,
+                )
+                if r.text
+            )
+            if nested_text:
+                text = f"{text}\n{nested_text}" if text else nested_text
 
         if text:
             text_res = create_ser_result(text=text, span_source=item)

--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -909,6 +909,87 @@ def test_html_rich_table(rich_table_doc):
     verify(exp_file=exp_file, actual=actual)
 
 
+def test_html_rich_cell_textitem_ref_subtree_inside_and_not_outside():
+    """Descendants of a RichTableCell's TextItem ref render inside the table.
+
+    With HTMLTextSerializer recursing into its item's children, the parent text
+    (CELL-TEXT) and its child (DEEP-LEAK) both render as siblings inside the
+    rich cell. The outer document iteration must not re-emit either of them as
+    standalone content after the table.
+    """
+    doc = DoclingDocument(name="rich_cell_textitem_subtree")
+
+    table = doc.add_table(data=TableData(num_rows=1, num_cols=2))
+    rich_ref = doc.add_text(label=DocItemLabel.TEXT, text="CELL-TEXT", parent=table)
+    doc.add_text(label=DocItemLabel.TEXT, text="DEEP-LEAK", parent=rich_ref)
+
+    doc.add_table_cell(
+        table_item=table,
+        cell=RichTableCell(
+            start_row_offset_idx=0,
+            end_row_offset_idx=1,
+            start_col_offset_idx=0,
+            end_col_offset_idx=1,
+            ref=rich_ref.get_ref(),
+            text="cell 0,0",
+        ),
+    )
+    doc.add_table_cell(
+        table_item=table,
+        cell=TableCell(
+            start_row_offset_idx=0,
+            end_row_offset_idx=1,
+            start_col_offset_idx=1,
+            end_col_offset_idx=2,
+            text="plain",
+        ),
+    )
+
+    out = HTMLDocSerializer(doc=doc).serialize().text
+    body = out[out.find("<body>") : out.find("</body>") + len("</body>")]
+    table_end = body.find("</table>") + len("</table>")
+    inside_table = body[:table_end]
+    after_table = body[table_end:]
+
+    assert "CELL-TEXT" in inside_table, (
+        f"RichTableCell ref content missing from the table:\n{body}"
+    )
+    assert "DEEP-LEAK" in inside_table, (
+        f"RichTableCell ref descendant missing from the table:\n{body}"
+    )
+    assert "CELL-TEXT" not in after_table, (
+        f"RichTableCell ref content leaked outside the table:\n{body}"
+    )
+    assert "DEEP-LEAK" not in after_table, (
+        f"RichTableCell ref descendant leaked outside the table:\n{body}"
+    )
+
+
+def test_html_textitem_with_children_at_document_level():
+    """Doc-level parity: TextItem with TextItem child renders both exactly once.
+
+    Once HTMLTextSerializer recurses into children, the child is rendered by
+    the parent's serialize call instead of by the outer iteration. Both must
+    still appear in document order, exactly once each.
+    """
+    doc = DoclingDocument(name="textitem_with_children")
+    parent = doc.add_text(label=DocItemLabel.TEXT, text="PARENT-TEXT")
+    doc.add_text(label=DocItemLabel.TEXT, text="CHILD-TEXT", parent=parent)
+
+    out = HTMLDocSerializer(doc=doc).serialize().text
+    body = out[out.find("<body>") : out.find("</body>") + len("</body>")]
+
+    assert body.count("PARENT-TEXT") == 1, (
+        f"PARENT-TEXT should appear exactly once:\n{body}"
+    )
+    assert body.count("CHILD-TEXT") == 1, (
+        f"CHILD-TEXT should appear exactly once:\n{body}"
+    )
+    assert body.find("PARENT-TEXT") < body.find("CHILD-TEXT"), (
+        f"PARENT-TEXT should appear before CHILD-TEXT:\n{body}"
+    )
+
+
 def test_html_inline_and_formatting():
     src = Path("./test/data/doc/inline_and_formatting.yaml")
     doc = DoclingDocument.load_from_yaml(src)


### PR DESCRIPTION
## Summary

  - `HTMLTextSerializer` only rendered an item's own text and a few special
    branches (Title/SectionHeader/Formula/Code/ListItem and `text=""` + single
    InlineGroup child). Other `item.children` were silently ignored at the
    serializer level — they were re-emitted by the outer document iteration. At
    the document level this looks fine, but inside a `RichTableCell` it produced
    a leak: descendants of the cell's ref rendered *outside* the table as
    standalone `<p>`s.
  - Fix: after wrapping the parent's text in its tag and applying
    `post_process`, recurse into `item.children` via
    `doc_serializer.get_parts(item=item, visited=my_visited, ...)` and append
    the rendered children as siblings (joined with `\n`). `ListItem` already
    recurses inline, and `has_inline_repr` already consumed its single child —
    both branches are skipped. Children render as proper sibling elements
    (never nested inside `<p>`), and `visited` propagation prevents the outer
    iteration from re-emitting them.
  - Doc-level output is byte-identical for existing fixtures (`rich_table.gt.html`,
    `inline_and_formatting.gt.html`, etc.) — children that previously rendered
    via the outer iteration now render via the parent's serialize call instead,
    in the same order.

  Follow-up work tracked in
  `_plans/fix-html-rich-tablecell-recursion.md`: apply the same recursion
  pattern to `MarkdownTextSerializer`, audit `latex.py` and `doctags.py` for
  the same gap, and consider lifting a shared helper into `common.py`.

## Test plan

  - [ ] `pytest test/test_serialization.py::test_html_rich_cell_textitem_ref_subtree_inside_and_not_outside`
  - [ ] `pytest test/test_serialization.py::test_html_textitem_with_children_at_document_level`
  - [ ] `pytest test/test_serialization.py test/test_serialization_doclang.py test/test_deserializer_doclang.py test/test_metadata.py
  test/test_latex_serialization.py test/test_serialization_doctag.py` — all 185 pass
  - [ ] Reproduce on `main`: the rich-cell test fails with `<p>DEEP-LEAK</p>`
    showing up after `</table>`; with this PR the deep child renders inside
    the cell instead