### PR TITLE
refactor(chunking): vendor semchunk splitter to drop the dependency

### DIFF
--- a/docling_core/transforms/chunker/LICENSE-semchunk
+++ b/docling_core/transforms/chunker/LICENSE-semchunk
@@ -1,0 +1,19 @@
+Copyright (c) 2024-2025 Isaacus Pty Ltd and Umar Butler
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/docling_core/transforms/chunker/_semantic_splitter.py
+++ b/docling_core/transforms/chunker/_semantic_splitter.py
@@ -1,0 +1,270 @@
+"""Token-aware semantic text splitter.
+
+This module is vendored and adapted from ``semchunk`` (version 3.2.5,
+https://github.com/isaacus-dev/semchunk), Copyright (c) 2024-2025 Isaacus Pty Ltd
+and Umar Butler, distributed under the MIT License. It is reduced to the
+single-text, no-overlap code path used by docling-core's chunkers and accepts a
+plain token-counting callable instead of deriving one from a tokenizer object.
+
+The MIT License text accompanying the original work is reproduced in
+``docling_core/transforms/chunker/LICENSE-semchunk``.
+"""
+
+# The splitter table below intentionally contains Unicode punctuation that ruff would
+# otherwise flag as ambiguous (RUF001); these characters are meaningful split points.
+# ruff: noqa: RUF001
+
+import re
+from collections.abc import Callable
+from functools import lru_cache
+from itertools import accumulate
+
+_NON_WHITESPACE_SEMANTIC_SPLITTERS = (
+    # Sentence terminators.
+    ".",
+    "?",
+    "!",
+    "*",
+    # Clause separators.
+    ";",
+    ",",
+    "(",
+    ")",
+    "[",
+    "]",
+    "“",
+    "”",
+    "‘",
+    "’",
+    "'",
+    '"',
+    "`",
+    # Sentence interrupters.
+    ":",
+    "—",
+    "…",
+    # Word joiners.
+    "/",
+    "\\",
+    "–",
+    "&",
+    "-",
+)
+"""Semantically meaningful non-whitespace splitters, ordered most to least desirable."""
+
+_REGEX_ESCAPED_NON_WHITESPACE_SEMANTIC_SPLITTERS = tuple(
+    re.escape(splitter) for splitter in _NON_WHITESPACE_SEMANTIC_SPLITTERS
+)
+
+
+def _split_text(text: str) -> tuple[str, bool, list[str]]:
+    """Split text using the most semantically meaningful splitter possible."""
+    splitter_is_whitespace = True
+
+    # Try splitting at, in order of most desirable to least desirable:
+    # - The largest sequence of newlines and/or carriage returns;
+    # - The largest sequence of tabs;
+    # - The largest sequence of whitespace characters or, if the largest such sequence
+    #   is only a single character and there exists a whitespace character preceded by a
+    #   semantically meaningful non-whitespace splitter, then that whitespace character;
+    # - A semantically meaningful non-whitespace splitter.
+    if "\n" in text or "\r" in text:
+        splitter = max(re.findall(r"[\r\n]+", text), key=len)
+
+    elif "\t" in text:
+        splitter = max(re.findall(r"\t+", text), key=len)
+
+    elif re.search(r"\s", text):
+        splitter = max(re.findall(r"\s+", text), key=len)
+
+        # If the splitter is only a single character, see if we can target whitespace
+        # characters that are preceded by semantically meaningful non-whitespace
+        # splitters to avoid splitting in the middle of sentences.
+        if len(splitter) == 1:
+            for escaped_preceder in _REGEX_ESCAPED_NON_WHITESPACE_SEMANTIC_SPLITTERS:
+                if whitespace_preceded_by_preceder := re.search(rf"{escaped_preceder}(\s)", text):
+                    splitter = whitespace_preceded_by_preceder.group(1)
+                    escaped_splitter = re.escape(splitter)
+
+                    return (
+                        splitter,
+                        splitter_is_whitespace,
+                        re.split(rf"(?<={escaped_preceder}){escaped_splitter}", text),
+                    )
+
+    else:
+        # Identify the most desirable semantically meaningful non-whitespace splitter
+        # present in the text.
+        for splitter in _NON_WHITESPACE_SEMANTIC_SPLITTERS:
+            if splitter in text:
+                splitter_is_whitespace = False
+                break
+
+        # If no semantically meaningful splitter is present in the text, return an empty
+        # string as the splitter and the text as a list of characters.
+        else:  # NOTE only reached if the for loop completes without breaking.
+            return "", splitter_is_whitespace, list(text)
+
+    # Return the splitter and the split text.
+    return splitter, splitter_is_whitespace, text.split(splitter)
+
+
+def _bisect_left(seq: list[int], target: float, low: int, high: int) -> int:
+    """Return the leftmost index at which ``target`` can be inserted to keep order."""
+    while low < high:
+        mid = (low + high) // 2
+
+        if seq[mid] < target:
+            low = mid + 1
+
+        else:
+            high = mid
+
+    return low
+
+
+def _merge_splits(
+    splits: list[str],
+    cum_lens: list[int],
+    chunk_size: int,
+    splitter: str,
+    token_counter: Callable[[str], int],
+    start: int,
+    high: int,
+) -> tuple[int, str]:
+    """Merge splits until the chunk size is reached.
+
+    Returns the index of the last split included in the merged chunk along with the
+    merged chunk itself.
+    """
+    average = 0.2
+    low = start
+
+    offset = cum_lens[start]
+    target = offset + (chunk_size * average)
+
+    while low < high:
+        i = _bisect_left(cum_lens, target, low=low, high=high)
+        midpoint = min(i, high - 1)
+
+        tokens = token_counter(splitter.join(splits[start:midpoint]))
+
+        local_cum = cum_lens[midpoint] - offset
+
+        if local_cum and tokens > 0:
+            average = local_cum / tokens
+            target = offset + (chunk_size * average)
+
+        if tokens > chunk_size:
+            high = midpoint
+
+        else:
+            low = midpoint + 1
+
+    end = low - 1
+    return end, splitter.join(splits[start:end])
+
+
+def _chunk(
+    text: str,
+    chunk_size: int,
+    token_counter: Callable[[str], int],
+    _start: int = 0,
+) -> tuple[list[str], list[tuple[int, int]]]:
+    """Recursively split a text into chunks, returning the chunks and their offsets."""
+    # Split the text using the most semantically meaningful splitter possible.
+    splitter, splitter_is_whitespace, splits = _split_text(text)
+
+    offsets: list[tuple[int, int]] = []
+    splitter_len = len(splitter)
+    split_lens = [len(split) for split in splits]
+    cum_lens = list(accumulate(split_lens, initial=0))
+    split_start_iter = accumulate([0] + [split_len + splitter_len for split_len in split_lens])
+    split_starts = [start + _start for start in split_start_iter]
+    num_splits_plus_one = len(splits) + 1
+
+    chunks: list[str] = []
+    skips: set[int] = set()
+    """Indices of splits to skip because they have already been added to a chunk."""
+
+    # Iterate through the splits.
+    for i, (split, split_start) in enumerate(zip(splits, split_starts)):
+        # Skip the split if it has already been added to a chunk.
+        if i in skips:
+            continue
+
+        # If the split is over the chunk size, recursively chunk it.
+        if token_counter(split) > chunk_size:
+            new_chunks, new_offsets = _chunk(
+                text=split,
+                chunk_size=chunk_size,
+                token_counter=token_counter,
+                _start=split_start,
+            )
+
+            chunks.extend(new_chunks)
+            offsets.extend(new_offsets)
+
+        # If the split is equal to or under the chunk size, add it and any subsequent
+        # splits to a new chunk until the chunk size is reached.
+        else:
+            final_split_in_chunk_i, new_chunk = _merge_splits(
+                splits=splits,
+                cum_lens=cum_lens,
+                chunk_size=chunk_size,
+                splitter=splitter,
+                token_counter=token_counter,
+                start=i,
+                high=num_splits_plus_one,
+            )
+
+            # Mark any splits included in the new chunk for exclusion from future chunks.
+            skips.update(range(i + 1, final_split_in_chunk_i))
+
+            # Add the chunk.
+            chunks.append(new_chunk)
+
+            # Add the chunk's offsets.
+            split_end = split_starts[final_split_in_chunk_i] - splitter_len
+            offsets.append((split_start, split_end))
+
+        # If the splitter is not whitespace and the split is not the last split, add the
+        # splitter to the end of the latest chunk if doing so would not cause it to
+        # exceed the chunk size otherwise add the splitter as a new chunk.
+        if not splitter_is_whitespace and not (
+            i == len(splits) - 1 or all(j in skips for j in range(i + 1, len(splits)))
+        ):
+            if token_counter(last_chunk_with_splitter := chunks[-1] + splitter) <= chunk_size:
+                chunks[-1] = last_chunk_with_splitter
+                start, end = offsets[-1]
+                offsets[-1] = (start, end + splitter_len)
+
+            else:
+                start = offsets[-1][1] if offsets else split_start
+
+                chunks.append(splitter)
+                offsets.append((start, start + splitter_len))
+
+    return chunks, offsets
+
+
+def chunk_text(text: str, chunk_size: int, token_counter: Callable[[str], int]) -> list[str]:
+    """Split a text into semantically meaningful chunks of at most ``chunk_size`` tokens.
+
+    Args:
+        text: The text to be chunked.
+        chunk_size: The maximum number of tokens a chunk may contain.
+        token_counter: A callable returning the number of tokens in a given string.
+
+    Returns:
+        A list of chunks, each at most ``chunk_size`` tokens long, with any whitespace
+        used to split the text removed.
+    """
+    # Memoize the token counter for the duration of this call: the recursive splitting
+    # and merging count tokens for many overlapping substrings.
+    memoized_token_counter = lru_cache(maxsize=None)(token_counter)
+
+    chunks, _offsets = _chunk(text=text, chunk_size=chunk_size, token_counter=memoized_token_counter)
+
+    # Remove empty chunks as well as chunks comprised entirely of whitespace.
+    return [chunk for chunk in chunks if chunk and not chunk.isspace()]

--- a/docling_core/transforms/chunker/hybrid_chunker.py
+++ b/docling_core/transforms/chunker/hybrid_chunker.py
@@ -3,10 +3,11 @@
 import warnings
 from collections.abc import Iterable, Iterator
 from functools import cached_property
-from typing import Any, Optional, Union, cast
+from typing import Any, Optional, Union
 
 from pydantic import BaseModel, ConfigDict, Field, computed_field, model_validator
 
+from docling_core.transforms.chunker._semantic_splitter import chunk_text
 from docling_core.transforms.chunker.hierarchical_chunker import (
     ChunkingDocSerializer,
     ChunkingSerializerProvider,
@@ -18,7 +19,6 @@ from docling_core.transforms.serializer.base import BaseDocSerializer
 from docling_core.types.doc.document import SectionHeaderItem, TableItem, TitleItem
 
 try:
-    import semchunk
     from transformers import PreTrainedTokenizerBase
 except ImportError:
     raise RuntimeError(
@@ -261,9 +261,11 @@ class HybridChunker(BaseChunker):
             )
             segments = line_chunker.chunk_text(lines=body_lines)
         else:
-            sem_chunker = semchunk.chunkerify(self.tokenizer.get_tokenizer(), chunk_size=available_length)
-            sem_segments = sem_chunker(doc_chunk.text)
-            segments = cast(list[str], sem_segments)
+            segments = chunk_text(
+                text=doc_chunk.text,
+                chunk_size=available_length,
+                token_counter=self.tokenizer.count_tokens,
+            )
         return segments
 
     def _merge_chunks_with_matching_metadata(self, chunks: list[DocChunk]):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,6 @@ docling-serialize = "docling_core.cli.serialize:app"
 [project.optional-dependencies]
 chunking = [
     # common:
-    'semchunk (>=2.2.0,<4.0.0)',
     'tree-sitter (>=0.25.0,<0.27.0)',
     'tree-sitter-python >=0.23.6',
     'tree-sitter-c >=0.23.4',
@@ -81,7 +80,6 @@ chunking = [
 ]
 chunking-openai = [
     # common:
-    'semchunk (>=2.2.0,<4.0.0)',
     'tree-sitter (>=0.25.0,<0.27.0)',
     'tree-sitter-python >=0.23.6',
     'tree-sitter-c >=0.23.4',
@@ -222,7 +220,6 @@ module = [
     "jsonref.*",
     "jsonschema.*",
     "requests.*",
-    "semchunk.*",
     "tabulate.*",
     "transformers.*",
     "tree_sitter_java_orchard.*",

--- a/test/test_semantic_splitter.py
+++ b/test/test_semantic_splitter.py
@@ -1,0 +1,59 @@
+"""Tests for the vendored token-aware semantic text splitter.
+
+These exercise the splitter's contract directly with deterministic token counters,
+so they run without downloading any tokenizer model.
+"""
+
+from docling_core.transforms.chunker._semantic_splitter import chunk_text
+
+
+def _word_counter(text: str) -> int:
+    return len(text.split())
+
+
+def _char_counter(text: str) -> int:
+    return len(text)
+
+
+SAMPLE = (
+    "Docling parses documents into a unified representation. "
+    "It supports PDF, DOCX, HTML, and Markdown inputs. "
+    "Chunking splits long passages into smaller, token-bounded segments "
+    "so that downstream retrieval and generation stay within model limits."
+)
+
+
+def test_short_text_is_returned_as_single_chunk():
+    text = "A short sentence."
+    chunks = chunk_text(text, chunk_size=100, token_counter=_word_counter)
+    assert chunks == [text]
+
+
+def test_every_chunk_respects_the_token_budget():
+    chunk_size = 5
+    chunks = chunk_text(SAMPLE, chunk_size=chunk_size, token_counter=_word_counter)
+    assert len(chunks) > 1  # the sample must actually get split
+    assert all(_word_counter(chunk) <= chunk_size for chunk in chunks)
+
+
+def test_no_empty_or_whitespace_only_chunks():
+    chunks = chunk_text(SAMPLE, chunk_size=4, token_counter=_word_counter)
+    assert chunks
+    assert all(chunk and not chunk.isspace() for chunk in chunks)
+
+
+def test_content_is_preserved_in_order():
+    chunks = chunk_text(SAMPLE, chunk_size=3, token_counter=_word_counter)
+    # Whitespace used as a split point is dropped, but the words themselves and their
+    # order must be preserved across the concatenation of chunks.
+    assert " ".join(chunks).split() == SAMPLE.split()
+
+
+def test_recurses_into_oversized_splits_with_character_budget():
+    # A single long token forces the recursive sub-word splitting path.
+    word = "supercalifragilisticexpialidocious"
+    chunk_size = 8
+    chunks = chunk_text(word, chunk_size=chunk_size, token_counter=_char_counter)
+    assert len(chunks) > 1
+    assert all(_char_counter(chunk) <= chunk_size for chunk in chunks)
+    assert "".join(chunks) == word

--- a/uv.lock
+++ b/uv.lock
@@ -974,7 +974,6 @@ dependencies = [
 
 [package.optional-dependencies]
 chunking = [
-    { name = "semchunk" },
     { name = "transformers" },
     { name = "tree-sitter" },
     { name = "tree-sitter-c" },
@@ -983,7 +982,6 @@ chunking = [
     { name = "tree-sitter-typescript" },
 ]
 chunking-openai = [
-    { name = "semchunk" },
     { name = "tiktoken" },
     { name = "tree-sitter" },
     { name = "tree-sitter-c" },
@@ -1039,8 +1037,6 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.6.0,!=2.10.0,!=2.10.1,!=2.10.2,<3.0.0" },
     { name = "pydantic-settings", specifier = ">=2.14.0" },
     { name = "pyyaml", specifier = ">=5.1,<7.0.0" },
-    { name = "semchunk", marker = "extra == 'chunking'", specifier = ">=2.2.0,<4.0.0" },
-    { name = "semchunk", marker = "extra == 'chunking-openai'", specifier = ">=2.2.0,<4.0.0" },
     { name = "tabulate", specifier = ">=0.9.0,<0.11.0" },
     { name = "tiktoken", marker = "extra == 'chunking-openai'", specifier = ">=0.9.0,<0.13.0" },
     { name = "transformers", marker = "extra == 'chunking'", specifier = ">=4.34.0,<6.0.0" },
@@ -2146,25 +2142,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ea/5d/38b681d3fce7a266dd9ab73c66959406d565b3e85f21d5e66e1181d93721/more_itertools-10.8.0.tar.gz", hash = "sha256:f638ddf8a1a0d134181275fb5d58b086ead7c6a72429ad725c67503f13ba30bd", size = 137431, upload-time = "2025-09-02T15:23:11.018Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a4/8e/469e5a4a2f5855992e425f3cb33804cc07bf18d48f2db061aec61ce50270/more_itertools-10.8.0-py3-none-any.whl", hash = "sha256:52d4362373dcf7c52546bc4af9a86ee7c4579df9a8dc268be0a2f949d376cc9b", size = 69667, upload-time = "2025-09-02T15:23:09.635Z" },
-]
-
-[[package]]
-name = "mpire"
-version = "2.10.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pygments" },
-    { name = "pywin32", marker = "sys_platform == 'win32'" },
-    { name = "tqdm" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/3a/93/80ac75c20ce54c785648b4ed363c88f148bf22637e10c9863db4fbe73e74/mpire-2.10.2.tar.gz", hash = "sha256:f66a321e93fadff34585a4bfa05e95bd946cf714b442f51c529038eb45773d97", size = 271270, upload-time = "2024-05-07T14:00:31.815Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/20/14/1db1729ad6db4999c3a16c47937d601fcb909aaa4224f5eca5a2f145a605/mpire-2.10.2-py3-none-any.whl", hash = "sha256:d627707f7a8d02aa4c7f7d59de399dec5290945ddf7fbd36cbb1d6ebb37a51fb", size = 272756, upload-time = "2024-05-07T14:00:29.633Z" },
-]
-
-[package.optional-dependencies]
-dill = [
-    { name = "multiprocess" },
 ]
 
 [[package]]
@@ -3527,28 +3504,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pywin32"
-version = "311"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7b/40/44efbb0dfbd33aca6a6483191dae0716070ed99e2ecb0c53683f400a0b4f/pywin32-311-cp310-cp310-win32.whl", hash = "sha256:d03ff496d2a0cd4a5893504789d4a15399133fe82517455e78bad62efbb7f0a3", size = 8760432, upload-time = "2025-07-14T20:13:05.9Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/bf/360243b1e953bd254a82f12653974be395ba880e7ec23e3731d9f73921cc/pywin32-311-cp310-cp310-win_amd64.whl", hash = "sha256:797c2772017851984b97180b0bebe4b620bb86328e8a884bb626156295a63b3b", size = 9590103, upload-time = "2025-07-14T20:13:07.698Z" },
-    { url = "https://files.pythonhosted.org/packages/57/38/d290720e6f138086fb3d5ffe0b6caa019a791dd57866940c82e4eeaf2012/pywin32-311-cp310-cp310-win_arm64.whl", hash = "sha256:0502d1facf1fed4839a9a51ccbcc63d952cf318f78ffc00a7e78528ac27d7a2b", size = 8778557, upload-time = "2025-07-14T20:13:11.11Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/af/449a6a91e5d6db51420875c54f6aff7c97a86a3b13a0b4f1a5c13b988de3/pywin32-311-cp311-cp311-win32.whl", hash = "sha256:184eb5e436dea364dcd3d2316d577d625c0351bf237c4e9a5fabbcfa5a58b151", size = 8697031, upload-time = "2025-07-14T20:13:13.266Z" },
-    { url = "https://files.pythonhosted.org/packages/51/8f/9bb81dd5bb77d22243d33c8397f09377056d5c687aa6d4042bea7fbf8364/pywin32-311-cp311-cp311-win_amd64.whl", hash = "sha256:3ce80b34b22b17ccbd937a6e78e7225d80c52f5ab9940fe0506a1a16f3dab503", size = 9508308, upload-time = "2025-07-14T20:13:15.147Z" },
-    { url = "https://files.pythonhosted.org/packages/44/7b/9c2ab54f74a138c491aba1b1cd0795ba61f144c711daea84a88b63dc0f6c/pywin32-311-cp311-cp311-win_arm64.whl", hash = "sha256:a733f1388e1a842abb67ffa8e7aad0e70ac519e09b0f6a784e65a136ec7cefd2", size = 8703930, upload-time = "2025-07-14T20:13:16.945Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/ab/01ea1943d4eba0f850c3c61e78e8dd59757ff815ff3ccd0a84de5f541f42/pywin32-311-cp312-cp312-win32.whl", hash = "sha256:750ec6e621af2b948540032557b10a2d43b0cee2ae9758c54154d711cc852d31", size = 8706543, upload-time = "2025-07-14T20:13:20.765Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/a8/a0e8d07d4d051ec7502cd58b291ec98dcc0c3fff027caad0470b72cfcc2f/pywin32-311-cp312-cp312-win_amd64.whl", hash = "sha256:b8c095edad5c211ff31c05223658e71bf7116daa0ecf3ad85f3201ea3190d067", size = 9495040, upload-time = "2025-07-14T20:13:22.543Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/3a/2ae996277b4b50f17d61f0603efd8253cb2d79cc7ae159468007b586396d/pywin32-311-cp312-cp312-win_arm64.whl", hash = "sha256:e286f46a9a39c4a18b319c28f59b61de793654af2f395c102b4f819e584b5852", size = 8710102, upload-time = "2025-07-14T20:13:24.682Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/be/3fd5de0979fcb3994bfee0d65ed8ca9506a8a1260651b86174f6a86f52b3/pywin32-311-cp313-cp313-win32.whl", hash = "sha256:f95ba5a847cba10dd8c4d8fefa9f2a6cf283b8b88ed6178fa8a6c1ab16054d0d", size = 8705700, upload-time = "2025-07-14T20:13:26.471Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/28/e0a1909523c6890208295a29e05c2adb2126364e289826c0a8bc7297bd5c/pywin32-311-cp313-cp313-win_amd64.whl", hash = "sha256:718a38f7e5b058e76aee1c56ddd06908116d35147e133427e59a3983f703a20d", size = 9494700, upload-time = "2025-07-14T20:13:28.243Z" },
-    { url = "https://files.pythonhosted.org/packages/04/bf/90339ac0f55726dce7d794e6d79a18a91265bdf3aa70b6b9ca52f35e022a/pywin32-311-cp313-cp313-win_arm64.whl", hash = "sha256:7b4075d959648406202d92a2310cb990fea19b535c7f4a78d3f5e10b926eeb8a", size = 8709318, upload-time = "2025-07-14T20:13:30.348Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/31/097f2e132c4f16d99a22bfb777e0fd88bd8e1c634304e102f313af69ace5/pywin32-311-cp314-cp314-win32.whl", hash = "sha256:b7a2c10b93f8986666d0c803ee19b5990885872a7de910fc460f9b0c2fbf92ee", size = 8840714, upload-time = "2025-07-14T20:13:32.449Z" },
-    { url = "https://files.pythonhosted.org/packages/90/4b/07c77d8ba0e01349358082713400435347df8426208171ce297da32c313d/pywin32-311-cp314-cp314-win_amd64.whl", hash = "sha256:3aca44c046bd2ed8c90de9cb8427f581c479e594e99b5c0bb19b29c10fd6cb87", size = 9656800, upload-time = "2025-07-14T20:13:34.312Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/d2/21af5c535501a7233e734b8af901574572da66fcc254cb35d0609c9080dd/pywin32-311-cp314-cp314-win_arm64.whl", hash = "sha256:a508e2d9025764a8270f93111a970e1d0fbfc33f4153b388bb649b7eec4f9b42", size = 8932540, upload-time = "2025-07-14T20:13:36.379Z" },
-]
-
-[[package]]
 name = "pywin32-ctypes"
 version = "0.2.3"
 source = { registry = "https://pypi.org/simple" }
@@ -4076,19 +4031,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/46/f5af3402b579fd5e11573ce652019a67074317e18c1935cc0b4ba9b35552/secretstorage-3.5.0-py3-none-any.whl", hash = "sha256:0ce65888c0725fcb2c5bc0fdb8e5438eece02c523557ea40ce0703c266248137", size = 15554, upload-time = "2025-11-23T19:02:51.545Z" },
-]
-
-[[package]]
-name = "semchunk"
-version = "3.2.5"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "mpire", extra = ["dill"] },
-    { name = "tqdm" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/a9/a0/ce7e3d6cc76498fd594e667d10a03f17d7cced129e46869daec23523bf5a/semchunk-3.2.5.tar.gz", hash = "sha256:ee15e9a06a69a411937dd8fcf0a25d7ef389c5195863140436872a02c95b0218", size = 17667, upload-time = "2025-10-28T02:12:38.025Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f8/95/12d226ee4d207cb1f77a216baa7e1a8bae2639733c140abe8d0316d23a18/semchunk-3.2.5-py3-none-any.whl", hash = "sha256:fd09cc5f380bd010b8ca773bd81893f7eaf11d37dd8362a83d46cedaf5dae076", size = 13048, upload-time = "2025-10-28T02:12:36.724Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Removes the `semchunk` runtime dependency by vendoring the small slice of its
algorithm that the chunkers actually use.

`HybridChunker` only used `semchunk` for token-aware plain-text splitting of a
**single string** — no overlap, no offsets, no batching, no multiprocessing
(see `segment()` in `hybrid_chunker.py`). Despite that narrow use, `semchunk`
pulls in `mpire[dill]` (and, transitively, `pywin32`) for a parallel-chunking
path that this project never exercises.

This PR ports `semchunk`'s core splitting algorithm into a small internal module
and drops the dependency.

## What changed

| File | Change |
|---|---|
| `docling_core/transforms/chunker/_semantic_splitter.py` | **New.** Faithful port of `semchunk`'s recursive splitter (`_split_text` → `_merge_splits` → `chunk_text`), reduced to the single-text / no-overlap path. Accepts a plain `token_counter` callable. |
| `docling_core/transforms/chunker/LICENSE-semchunk` | **New.** `semchunk`'s MIT license text, for attribution. |
| `docling_core/transforms/chunker/hybrid_chunker.py` | Drop `import semchunk`; `segment()` now calls `chunk_text(..., token_counter=self.tokenizer.count_tokens)`. |
| `pyproject.toml` | Remove `semchunk` from the `chunking` and `chunking-openai` extras and from the mypy `ignore_missing_imports` overrides. |
| `uv.lock` | Re-resolved: removes `semchunk`, `mpire`, and `pywin32`. Nothing else changes. |
| `test/test_semantic_splitter.py` | **New.** Model-free unit tests for the vendored splitter's contract. |

## Behavior is unchanged (verified)

The vendored splitter is wired to `BaseTokenizer.count_tokens`, which yields the
same token counts `semchunk` derived internally (HuggingFace: `tokenize()` length
== `encode(add_special_tokens=False)` length; OpenAI: both use tiktoken `encode`).

The existing committed reference-chunk fixtures pass **byte-for-byte unchanged**
for both the HuggingFace (`sentence-transformers/all-MiniLM-L6-v2`) and OpenAI
(`gpt-4o`) tokenizer paths.

## Dependency impact

Removes three transitive packages from the `chunking` install footprint:
`semchunk`, `mpire`, `pywin32`. No new dependencies are introduced.

## Note on the dropped `max_token_chars` heuristic

`semchunk`'s `chunkerify` includes a `max_token_chars` speed shortcut for
pathologically long single splits. It only ever returned a conservative
over-estimate in a branch where the true token count *also* exceeded the limit,
so it cannot change chunk boundaries — only performance, and only for a single
unsplittable run longer than ~6× the chunk size in characters. The reference
fixtures confirm identical output without it.

## Test plan

- [x] `pytest test/` — full suite: **457 passed, 1 xfailed**
- [x] Chunker tests pass with `semchunk` **uninstalled** from the environment
- [x] HuggingFace and OpenAI tokenizer reference fixtures unchanged (byte-for-byte)
- [x] `ruff check` / `ruff format` clean
- [x] `mypy docling_core test` — no issues (132 source files)
- [x] `uv lock --check` in sync
