### PR TITLE
fix(doctags): stop extract_inner_text deleting text between < and >

### DIFF
--- a/docling_core/types/doc/document.py
+++ b/docling_core/types/doc/document.py
@@ -6491,7 +6491,11 @@ class DoclingDocument(BaseModel):
 
         def extract_inner_text(text_chunk: str) -> str:
             """Strip all <...> tags (except <_..._>) to get the raw text content."""
-            return re.sub(r"<(?!_.*?_>).*?>", "", text_chunk, flags=re.DOTALL).strip()
+            # The tag name must start with a letter or "/", and the match must
+            # not cross a ">" boundary. This avoids deleting spans of plain text
+            # that merely contain "<" followed by a later ">" (e.g. statistical
+            # notation like "P < 0.05 ... P > 0.05"). See #618.
+            return re.sub(r"<(?!_.*?_>)[a-zA-Z/][^>]*>", "", text_chunk).strip()
 
         def extract_caption(
             text_chunk: str,

--- a/test/test_doctags_load.py
+++ b/test/test_doctags_load.py
@@ -139,6 +139,19 @@ def test_doctags_picture_provenances_and_captions():
         assert len(picture.captions) > 0
 
 
+def test_doctags_load_preserves_angle_brackets_in_text():
+    # Regression for #618: text nodes containing a "<" followed by a later ">"
+    # (e.g. statistical notation like "P < 0.05 ... P > 0.05") had the whole
+    # span between the two characters silently deleted by extract_inner_text.
+    original = "We found (r = -0.36, P < 0.05), but not (r = -0.08, P > 0.05), lending support."
+    doctags = f"<doctag><text><loc_10><loc_10><loc_400><loc_20>{original}</text></doctag>"
+
+    doctags_doc = DocTagsDocument.from_doctags_and_image_pairs([doctags], None)
+    doc = DoclingDocument.load_from_doctags(doctags_doc)
+
+    assert [t.text for t in doc.texts] == [original]
+
+
 def test_doctags_inline():
     src_path = Path("test/data/doc/2408.09869v3_enriched.dt")
     with open(src_path) as f:


### PR DESCRIPTION
## Problem

`load_from_doctags` uses a nested helper `extract_inner_text` to strip structural DocTags from text-node content:

```python
return re.sub(r"<(?!_.*?_>).*?>", "", text_chunk, flags=re.DOTALL).strip()
```

The lazy `.*?` with `re.DOTALL` matches forward to the **next** `>` anywhere in the string. So any plain text containing a `<` followed by a later `>` has the whole span between them silently deleted. This is common in scientific text, e.g. statistical comparisons:

```
We found (r = -0.36, P < 0.05), but not (r = -0.08, P > 0.05), lending support.
```

becomes

```
We found (r = -0.36, P  0.05), lending support.
```

## Fix

Require the tag to start with a letter or `/` and use `[^>]*` so a match can never cross a `>` boundary:

```python
return re.sub(r"<(?!_.*?_>)[a-zA-Z/][^>]*>", "", text_chunk).strip()
```

Real DocTags (`<text>`, `<loc_10>`, `</otsl>`, ...) all start with a letter or `/` and are still stripped. `<_..._>` tags remain preserved. `re.DOTALL` is no longer needed since `[^>]*` already spans newlines inside a tag.

## Tests

Added `test_doctags_load_preserves_angle_brackets_in_text` (regression for #618). It fails on `main` (the span is dropped) and passes with the fix. Full `test_doctags_load.py` suite passes; `mypy docling_core test` is clean.

Fixes #618