### PR TITLE
fix(doctags): tolerate inverted bbox in DocumentToken.get_location

### DIFF
--- a/docling_core/types/doc/tokens.py
+++ b/docling_core/types/doc/tokens.py
@@ -303,9 +303,10 @@ class DocumentToken(str, Enum):
         self_closing: bool = False,
     ):
         """Get the location string give bbox and page-dim."""
-        assert bbox[0] <= bbox[2], f"bbox[0]<=bbox[2] => {bbox[0]}<={bbox[2]}"
-        assert bbox[1] <= bbox[3], f"bbox[1]<=bbox[3] => {bbox[1]}<={bbox[3]}"
-
+        # bbox coordinates may arrive slightly inverted (e.g. a near-zero-height
+        # element from a layout-model regression). The min()/max() calls below
+        # already emit correctly-ordered location tokens, so no ordering
+        # precondition is required here.
         x0 = bbox[0] / page_w
         y0 = bbox[1] / page_h
         x1 = bbox[2] / page_w

--- a/docling_core/types/legacy_doc/tokens.py
+++ b/docling_core/types/legacy_doc/tokens.py
@@ -173,9 +173,10 @@ class DocumentToken(Enum):
         page_i: int = -1,
     ):
         """Get the location string give bbox and page-dim."""
-        assert bbox[0] <= bbox[2], f"bbox[0]<=bbox[2] => {bbox[0]}<={bbox[2]}"
-        assert bbox[1] <= bbox[3], f"bbox[1]<=bbox[3] => {bbox[1]}<={bbox[3]}"
-
+        # bbox coordinates may arrive slightly inverted (e.g. a near-zero-height
+        # element from a layout-model regression). The min()/max() calls below
+        # already emit correctly-ordered location tokens, so no ordering
+        # precondition is required here.
         x0 = bbox[0] / page_w
         y0 = bbox[1] / page_h
         x1 = bbox[2] / page_w

--- a/test/test_tokens.py
+++ b/test/test_tokens.py
@@ -1,0 +1,50 @@
+"""Tests for location-token generation in DocumentToken."""
+
+from docling_core.types.doc.tokens import DocumentToken
+from docling_core.types.legacy_doc.tokens import (
+    DocumentToken as LegacyDocumentToken,
+)
+
+
+def test_get_location_accepts_inverted_bbox():
+    """A slightly inverted bbox must not crash get_location.
+
+    Near-zero-height/width elements (e.g. a layout-model regression artifact)
+    can produce bbox coordinates where the "min" corner is greater than the
+    "max" corner. The method's own min()/max() normalization already orders the
+    output, so such input must be tolerated rather than raising AssertionError.
+    """
+    page_w, page_h = 600.0, 800.0
+    inverted = (100.0, 633.39, 110.0, 625.68)
+    normalized = (100.0, 625.68, 110.0, 633.39)
+
+    # Must not raise.
+    inverted_loc = DocumentToken.get_location(bbox=inverted, page_w=page_w, page_h=page_h)
+    normalized_loc = DocumentToken.get_location(bbox=normalized, page_w=page_w, page_h=page_h)
+
+    # Inverted input yields the same correctly-ordered tokens as its
+    # normalized counterpart.
+    assert inverted_loc == normalized_loc
+
+
+def test_get_location_inverted_x_axis():
+    """Inversion on the x-axis is also tolerated and normalized."""
+    page_w, page_h = 600.0, 800.0
+    inverted = (110.0, 100.0, 100.0, 200.0)
+    normalized = (100.0, 100.0, 110.0, 200.0)
+
+    assert DocumentToken.get_location(bbox=inverted, page_w=page_w, page_h=page_h) == DocumentToken.get_location(
+        bbox=normalized, page_w=page_w, page_h=page_h
+    )
+
+
+def test_legacy_get_location_accepts_inverted_bbox():
+    """The legacy DocumentToken.get_location has the same contract."""
+    page_w, page_h = 600.0, 800.0
+    inverted = [100.0, 633.39, 110.0, 625.68]
+    normalized = [100.0, 625.68, 110.0, 633.39]
+
+    inverted_loc = LegacyDocumentToken.get_location(bbox=inverted, page_w=page_w, page_h=page_h)
+    normalized_loc = LegacyDocumentToken.get_location(bbox=normalized, page_w=page_w, page_h=page_h)
+
+    assert inverted_loc == normalized_loc


### PR DESCRIPTION
## Summary

`DocumentToken.get_location()` asserted `bbox[0] <= bbox[2]` and `bbox[1] <= bbox[3]`, but the `min()` / `max()` calls right below already emit correctly-ordered location tokens regardless of input ordering. The asserts were redundant with that normalization, yet still crashed `export_to_doctags(add_location=True)` on near-degenerate elements (e.g. a near-zero-height layout-model artifact whose regressed bbox is slightly inverted):

```
File ".../docling_core/types/doc/tokens.py", line 307, in get_location
    assert bbox[1] <= bbox[3], f"bbox[1]<=bbox[3] => {bbox[1]}<={bbox[3]}"
AssertionError: bbox[1]<=bbox[3] => 633.39<=625.68
```

The probability of hitting at least one such element grows with page count, so it bites long documents in particular.

## Fix

Drop the two redundant asserts in both `docling_core/types/doc/tokens.py` and `docling_core/types/legacy_doc/tokens.py`. The existing `min()` / `max()` logic already produces correctly-ordered output, so inverted input is normalized rather than fatal.

## Tests

Added `test/test_tokens.py`:
- inverted-y, inverted-x, and legacy `get_location` all no longer raise and yield the same tokens as their normalized counterparts.

Closes #620