### PR TITLE
fix: forward missing kwargs from save_as_markdown to export_to_markdown

### DIFF
--- a/docling_core/types/doc/document.py
+++ b/docling_core/types/doc/document.py
@@ -6075,7 +6075,8 @@ class DoclingDocument(BaseModel):
         labels: Optional[set[DocItemLabel]] = None,
         strict_text: bool = False,
         escape_html: bool = True,
-        escaping_underscores: bool = True,
+        escape_underscores: bool = True,
+        escaping_underscores: Optional[bool] = None,  # deprecated, use escape_underscores
         image_placeholder: str = "<!-- image -->",
         image_mode: ImageRefMode = ImageRefMode.PLACEHOLDER,
         indent: int = 4,
@@ -6095,6 +6096,15 @@ class DoclingDocument(BaseModel):
         use_legacy_annotations: Optional[bool] = None,  # deprecated
     ):
         """Save to markdown."""
+        if escaping_underscores is not None:
+            import warnings
+            warnings.warn(
+                "Parameter `escaping_underscores` is deprecated, use `escape_underscores` instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            escape_underscores = escaping_underscores
+
         if isinstance(filename, str):
             filename = Path(filename)
         artifacts_dir, reference_path = self._get_output_paths(filename, artifacts_dir)
@@ -6111,7 +6121,7 @@ class DoclingDocument(BaseModel):
             labels=labels,
             strict_text=strict_text,
             escape_html=escape_html,
-            escape_underscores=escaping_underscores,
+            escape_underscores=escape_underscores,
             image_placeholder=image_placeholder,
             image_mode=image_mode,
             indent=indent,

--- a/docling_core/types/doc/document.py
+++ b/docling_core/types/doc/document.py
@@ -6098,6 +6098,7 @@ class DoclingDocument(BaseModel):
         """Save to markdown."""
         if escaping_underscores is not None:
             import warnings
+
             warnings.warn(
                 "Parameter `escaping_underscores` is deprecated, use `escape_underscores` instead.",
                 DeprecationWarning,

--- a/docling_core/types/doc/document.py
+++ b/docling_core/types/doc/document.py
@@ -6085,8 +6085,13 @@ class DoclingDocument(BaseModel):
         page_break_placeholder: Optional[str] = None,
         include_annotations: bool = True,
         compact_tables: bool = False,
+        enable_chart_tables: bool = True,
+        mark_annotations: bool = False,
+        traverse_pictures: bool = False,
         *,
         mark_meta: bool = False,
+        allowed_meta_names: Optional[set[str]] = None,
+        blocked_meta_names: Optional[set[str]] = None,
         use_legacy_annotations: Optional[bool] = None,  # deprecated
     ):
         """Save to markdown."""
@@ -6116,8 +6121,13 @@ class DoclingDocument(BaseModel):
             page_break_placeholder=page_break_placeholder,
             include_annotations=include_annotations,
             compact_tables=compact_tables,
+            enable_chart_tables=enable_chart_tables,
+            mark_annotations=mark_annotations,
+            traverse_pictures=traverse_pictures,
             use_legacy_annotations=use_legacy_annotations,
             mark_meta=mark_meta,
+            allowed_meta_names=allowed_meta_names,
+            blocked_meta_names=blocked_meta_names,
         )
 
         with open(filename, "w", encoding="utf-8") as fw:

--- a/examples/convert_to_doclang.py
+++ b/examples/convert_to_doclang.py
@@ -34,6 +34,7 @@ import numpy as np
 # HF_HUB_DISABLE_XET=1 hf download --repo-type dataset "{hf-repo-id}"
 #
 
+
 def update_tokenizer(tokenizer: PreTrainedTokenizerBase, verbose: bool = False) -> PreTrainedTokenizerBase:
     """Extend tokenizer with Doclang special tokens.
 
@@ -49,6 +50,7 @@ def update_tokenizer(tokenizer: PreTrainedTokenizerBase, verbose: bool = False) 
     if verbose:
         print(f"New vocab size: {tokenizer.vocab_size}")
     return tokenizer
+
 
 def run_dump(cfg: dict[str, Any]) -> int:
     """Dump/serialize documents from a dataset to Doclang strings/files and export a per-row report.
@@ -128,10 +130,14 @@ def run_dump(cfg: dict[str, Any]) -> int:
         invalid_chars = []
         for char in value:
             code = ord(char)
-            if (code == 0x09 or code == 0x0A or code == 0x0D or
-                (0x20 <= code <= 0xD7FF) or
-                (0xE000 <= code <= 0xFFFD) or
-                (0x10000 <= code <= 0x10FFFF)):
+            if (
+                code == 0x09
+                or code == 0x0A
+                or code == 0x0D
+                or (0x20 <= code <= 0xD7FF)
+                or (0xE000 <= code <= 0xFFFD)
+                or (0x10000 <= code <= 0x10FFFF)
+            ):
                 sanitized.append(char)
             else:
                 # Replace invalid character with its Unicode representation
@@ -143,7 +149,7 @@ def run_dump(cfg: dict[str, Any]) -> int:
             preview = value[:50] + "..." if len(value) > 50 else value
             print(f"Warning: Found invalid XML characters {invalid_chars} in cell: {preview}")
 
-        return ''.join(sanitized)
+        return "".join(sanitized)
 
     def _write_report(rows: list[dict[str, str]], path: Path) -> None:
         """Write a two-sheet Excel report (Results + Summary).
@@ -173,12 +179,16 @@ def run_dump(cfg: dict[str, Any]) -> int:
             for esc_mode in EscapeMode:
                 for content in [True, False]:
                     cols.append(f"Serialized Doclang ({mode.value}, escape_mode={esc_mode.value}, content={content})")
-                    cols.append(f"Serialized Doclang ({mode.value}, escape_mode={esc_mode.value}, content={content}) Error")
+                    cols.append(
+                        f"Serialized Doclang ({mode.value}, escape_mode={esc_mode.value}, content={content}) Error"
+                    )
 
-        cols.extend([
-            "Serialized HTML",
-            "Serialized HTML Error",
-        ])
+        cols.extend(
+            [
+                "Serialized HTML",
+                "Serialized HTML Error",
+            ]
+        )
 
         # Ensure all rows have all columns and sanitize cell values
         norm_rows = []
@@ -217,7 +227,7 @@ def run_dump(cfg: dict[str, Any]) -> int:
             df_results = pd.DataFrame(norm_rows, columns=cols)
             df_summary = pd.DataFrame(summary_rows, columns=["Metric", "Count"])
             path.parent.mkdir(parents=True, exist_ok=True)
-            with pd.ExcelWriter(path, engine='openpyxl') as writer:
+            with pd.ExcelWriter(path, engine="openpyxl") as writer:
                 df_results.to_excel(writer, sheet_name="Results", index=False)
                 df_summary.to_excel(writer, sheet_name="Summary", index=False)
 
@@ -242,12 +252,12 @@ def run_dump(cfg: dict[str, Any]) -> int:
                 # Enable text wrapping for all cells in this column
                 for row in range(1, ws_results.max_row + 1):
                     cell = ws_results.cell(row=row, column=col_idx)
-                    cell.alignment = Alignment(wrap_text=True, vertical='top')
+                    cell.alignment = Alignment(wrap_text=True, vertical="top")
 
             # Enable text wrapping for all header cells
             for col_idx in range(1, len(cols) + 1):
                 cell = ws_results.cell(row=1, column=col_idx)
-                cell.alignment = Alignment(wrap_text=True, vertical='top', horizontal='center')
+                cell.alignment = Alignment(wrap_text=True, vertical="top", horizontal="center")
 
             wb.save(path)
             print(f"Wrote report (Excel via pandas) to: {path}")
@@ -287,12 +297,12 @@ def run_dump(cfg: dict[str, Any]) -> int:
                 # Enable text wrapping for all cells in this column
                 for row in range(1, ws_results.max_row + 1):
                     cell = ws_results.cell(row=row, column=col_idx)
-                    cell.alignment = Alignment(wrap_text=True, vertical='top')
+                    cell.alignment = Alignment(wrap_text=True, vertical="top")
 
             # Enable text wrapping for all header cells
             for col_idx in range(1, len(cols) + 1):
                 cell = ws_results.cell(row=1, column=col_idx)
-                cell.alignment = Alignment(wrap_text=True, vertical='top', horizontal='center')
+                cell.alignment = Alignment(wrap_text=True, vertical="top", horizontal="center")
 
             # Summary sheet
             ws_summary = wb.create_sheet(title="Summary")
@@ -323,28 +333,32 @@ def run_dump(cfg: dict[str, Any]) -> int:
         for mode in DoclangSerializationMode:
             for esc_mode in EscapeMode:
                 for content in [True, False]:
-                    row_result[f"Serialized Doclang ({mode.value}, escape_mode={esc_mode.value}, content={content})"] = _yes(False)
-                    row_result[f"Serialized Doclang ({mode.value}, escape_mode={esc_mode}, content={content}) Error"] = ""
+                    row_result[
+                        f"Serialized Doclang ({mode.value}, escape_mode={esc_mode.value}, content={content})"
+                    ] = _yes(False)
+                    row_result[
+                        f"Serialized Doclang ({mode.value}, escape_mode={esc_mode}, content={content}) Error"
+                    ] = ""
 
         try:
             doc = DoclingDocument.model_validate_json(text)
-            page_images = [
-                __ for __ in row["GroundTruthPageImages"]
-            ]
+            page_images = [__ for __ in row["GroundTruthPageImages"]]
             # page_images[0].show()
             row_result["Loaded DoclingDocument"] = _yes(True)
         except Exception as exc:
-            errors.append(
-                f"Parse error: {exc} for {dataset_name}/{dataset_subset}/{dataset_split} idx={idx}"
-            )
+            errors.append(f"Parse error: {exc} for {dataset_name}/{dataset_subset}/{dataset_split} idx={idx}")
             # Record failure outcome for this row
             row_result["Loaded DoclingDocument Error"] = str(exc)
 
             for mode in DoclangSerializationMode:
                 for esc_mode in EscapeMode:
                     for content in [True, False]:
-                        row_result[f"Serialized Doclang ({mode.value}, escape_mode={esc_mode.value}, content={content})"] = _yes(False)
-                        row_result[f"Serialized Doclang ({mode.value}, escape_mode={esc_mode.value}, content={content}) Error"] = "NA"
+                        row_result[
+                            f"Serialized Doclang ({mode.value}, escape_mode={esc_mode.value}, content={content})"
+                        ] = _yes(False)
+                        row_result[
+                            f"Serialized Doclang ({mode.value}, escape_mode={esc_mode.value}, content={content}) Error"
+                        ] = "NA"
 
             results_rows.append(row_result)
             continue
@@ -366,12 +380,20 @@ def run_dump(cfg: dict[str, Any]) -> int:
                         iser_probe = DoclangDocSerializer(doc=doc, params=params_probe)
                         _ = iser_probe.serialize().text
 
-                        row_result[f"Serialized Doclang ({mode.value}, escape_mode={esc_mode}, content={content})"] = _yes(True)
-                        row_result[f"Serialized Doclang ({mode.value}, escape_mode={esc_mode}, content={content}) Error"] = ""
+                        row_result[f"Serialized Doclang ({mode.value}, escape_mode={esc_mode}, content={content})"] = (
+                            _yes(True)
+                        )
+                        row_result[
+                            f"Serialized Doclang ({mode.value}, escape_mode={esc_mode}, content={content}) Error"
+                        ] = ""
 
                     except Exception as exc_:
-                        row_result[f"Serialized Doclang ({mode.value}, escape_mode={esc_mode}, content={content})"] = _yes(False)
-                        row_result[f"Serialized Doclang ({mode.value}, escape_mode={esc_mode}, content={content}) Error"] = str(exc_)
+                        row_result[f"Serialized Doclang ({mode.value}, escape_mode={esc_mode}, content={content})"] = (
+                            _yes(False)
+                        )
+                        row_result[
+                            f"Serialized Doclang ({mode.value}, escape_mode={esc_mode}, content={content}) Error"
+                        ] = str(exc_)
 
         # Attempt HTML export (non-writing) to check serialization capability
         try:
@@ -404,7 +426,9 @@ def run_dump(cfg: dict[str, Any]) -> int:
     for mode in [DoclangSerializationMode.HUMAN_FRIENDLY, DoclangSerializationMode.LLM_FRIENDLY]:
         for esc_mode in [True, False]:
             for content in [True, False]:
-                print(f" - Serialized Doclang ({mode.value}, escape_mode={esc_mode}, content={content}): {_count_yes(results_rows, f'Serialized Doclang ({mode.value}, escape_mode={esc_mode}, content={content})')}")
+                print(
+                    f" - Serialized Doclang ({mode.value}, escape_mode={esc_mode}, content={content}): {_count_yes(results_rows, f'Serialized Doclang ({mode.value}, escape_mode={esc_mode}, content={content})')}"
+                )
     print(f" - Serialized HTML: {_count_yes(results_rows, 'Serialized HTML')}")
 
     if errors:
@@ -489,7 +513,7 @@ def run_analyse(cfg: dict[str, Any]) -> int:
     if ext_lengths:
         arr = np.asarray(ext_lengths)
         print(
-            f"Extended tokenizer lengths — min: {arr.min()}, p50: {np.median(arr)}, p95: {np.percentile(arr,95)}, max: {arr.max()}, mean: {arr.mean():.1f}"
+            f"Extended tokenizer lengths — min: {arr.min()}, p50: {np.median(arr)}, p95: {np.percentile(arr, 95)}, max: {arr.max()}, mean: {arr.mean():.1f}"
         )
 
     # Map special IDs back to tokens and show top-k
@@ -599,8 +623,7 @@ def plot_token_scatter_with_regression(
 
     plt.figure(figsize=(8, 8))
     plt.scatter(x, y, alpha=0.6, color="#4C78A8", label="Documents")
-    plt.plot(x_line, y_line, color="#E45756", linewidth=2,
-             label=f"y = {slope:.3f}x + {intercept:.3f} (R²={r2:.3f})")
+    plt.plot(x_line, y_line, color="#E45756", linewidth=2, label=f"y = {slope:.3f}x + {intercept:.3f} (R²={r2:.3f})")
     plt.xlabel("Original tokens")
     plt.ylabel("Optimal tokens")
     plt.title("Original vs Optimal Tokens with Linear Fit")
@@ -608,6 +631,7 @@ def plot_token_scatter_with_regression(
     plt.legend()
     plt.tight_layout()
     plt.show()
+
 
 def default_config(mode: str) -> dict[str, Any]:
     if mode == "dump":

--- a/examples/document_profiling.py
+++ b/examples/document_profiling.py
@@ -81,7 +81,9 @@ def profile_document_collection():
     print(f"  Total: {stats.total_pages}")
     print(f"  Min: {stats.min_pages}, Max: {stats.max_pages}")
     print(f"  Median (d5): {stats.deciles_pages[4]:.1f}, Mean: {stats.mean_pages:.2f}")
-    print(f"  Deciles: d1={stats.deciles_pages[0]:.1f}, d5={stats.deciles_pages[4]:.1f}, d9={stats.deciles_pages[8]:.1f}")
+    print(
+        f"  Deciles: d1={stats.deciles_pages[0]:.1f}, d5={stats.deciles_pages[4]:.1f}, d9={stats.deciles_pages[8]:.1f}"
+    )
     print(f"  Std Dev: {stats.std_pages:.2f}")
     print(f"  Histogram bins: {len(stats.histogram_pages.bins)}, bin width: {stats.histogram_pages.bin_width:.2f}")
 
@@ -89,28 +91,36 @@ def profile_document_collection():
     print(f"  Total: {stats.total_tables}")
     print(f"  Min: {stats.min_tables}, Max: {stats.max_tables}")
     print(f"  Median (d5): {stats.deciles_tables[4]:.1f}, Mean: {stats.mean_tables:.2f}")
-    print(f"  Deciles: d1={stats.deciles_tables[0]:.1f}, d5={stats.deciles_tables[4]:.1f}, d9={stats.deciles_tables[8]:.1f}")
+    print(
+        f"  Deciles: d1={stats.deciles_tables[0]:.1f}, d5={stats.deciles_tables[4]:.1f}, d9={stats.deciles_tables[8]:.1f}"
+    )
     print(f"  Std Dev: {stats.std_tables:.2f}")
 
     print("\nPictures:")
     print(f"  Total: {stats.total_pictures}")
     print(f"  Min: {stats.min_pictures}, Max: {stats.max_pictures}")
     print(f"  Median (d5): {stats.deciles_pictures[4]:.1f}, Mean: {stats.mean_pictures:.2f}")
-    print(f"  Deciles: d1={stats.deciles_pictures[0]:.1f}, d5={stats.deciles_pictures[4]:.1f}, d9={stats.deciles_pictures[8]:.1f}")
+    print(
+        f"  Deciles: d1={stats.deciles_pictures[0]:.1f}, d5={stats.deciles_pictures[4]:.1f}, d9={stats.deciles_pictures[8]:.1f}"
+    )
     print(f"  Std Dev: {stats.std_pictures:.2f}")
 
     print("\nText Items:")
     print(f"  Total: {stats.total_texts}")
     print(f"  Min: {stats.min_texts}, Max: {stats.max_texts}")
     print(f"  Median (d5): {stats.deciles_texts[4]:.1f}, Mean: {stats.mean_texts:.2f}")
-    print(f"  Deciles: d1={stats.deciles_texts[0]:.1f}, d5={stats.deciles_texts[4]:.1f}, d9={stats.deciles_texts[8]:.1f}")
+    print(
+        f"  Deciles: d1={stats.deciles_texts[0]:.1f}, d5={stats.deciles_texts[4]:.1f}, d9={stats.deciles_texts[8]:.1f}"
+    )
     print(f"  Std Dev: {stats.std_texts:.2f}")
 
     print("\nPictures Requiring OCR:")
     print(f"  Total: {stats.total_pictures_for_ocr}")
     print(f"  Min: {stats.min_pictures_for_ocr}, Max: {stats.max_pictures_for_ocr}")
     print(f"  Median (d5): {stats.deciles_pictures_for_ocr[4]:.1f}, Mean: {stats.mean_pictures_for_ocr:.2f}")
-    print(f"  Deciles: d1={stats.deciles_pictures_for_ocr[0]:.1f}, d5={stats.deciles_pictures_for_ocr[4]:.1f}, d9={stats.deciles_pictures_for_ocr[8]:.1f}")
+    print(
+        f"  Deciles: d1={stats.deciles_pictures_for_ocr[0]:.1f}, d5={stats.deciles_pictures_for_ocr[4]:.1f}, d9={stats.deciles_pictures_for_ocr[8]:.1f}"
+    )
     print(f"  Std Dev: {stats.std_pictures_for_ocr:.2f}")
 
     if stats.mimetype_distribution:
@@ -128,8 +138,10 @@ def profile_document_collection():
         print("\nIndividual Document Statistics:")
         for i, doc_stat in enumerate(stats.document_stats[:3], 1):  # Show first 3
             print(f"\n  Document {i}: {doc_stat.name}")
-            print(f"    Pages: {doc_stat.num_pages}, Tables: {doc_stat.num_tables}, "
-                  f"Pictures: {doc_stat.num_pictures}, Texts: {doc_stat.num_texts}")
+            print(
+                f"    Pages: {doc_stat.num_pages}, Tables: {doc_stat.num_tables}, "
+                f"Pictures: {doc_stat.num_pictures}, Texts: {doc_stat.num_texts}"
+            )
 
 
 def profile_with_generator():
@@ -156,7 +168,7 @@ def profile_with_generator():
     start_time = time.time()
     stats = DocumentProfiler.profile_collection(
         document_generator(),
-        include_individual_stats=False  # Don't store individual stats to save memory
+        include_individual_stats=False,  # Don't store individual stats to save memory
     )
     elapsed_time = time.time() - start_time
 
@@ -247,4 +259,3 @@ if __name__ == "__main__":
     print("\n" + "=" * 80)
     print("Examples completed!")
     print("=" * 80)
-

--- a/examples/stats_visualizer.py
+++ b/examples/stats_visualizer.py
@@ -12,6 +12,7 @@ from typing import Literal
 try:
     import matplotlib.figure
     import matplotlib.pyplot as plt
+
     MATPLOTLIB_AVAILABLE = True
 except ImportError:
     MATPLOTLIB_AVAILABLE = False
@@ -27,8 +28,7 @@ class StatsVisualizer:
         """Check if matplotlib is available."""
         if not MATPLOTLIB_AVAILABLE:
             raise ImportError(
-                "matplotlib is required for visualization. "
-                "Install it with: pip install docling-core[examples]"
+                "matplotlib is required for visualization. Install it with: pip install docling-core[examples]"
             )
 
     @staticmethod
@@ -79,7 +79,7 @@ class StatsVisualizer:
         ax.grid(axis="y", alpha=0.3, linestyle="--")
 
         if log_scale:
-            ax.set_yscale('log')
+            ax.set_yscale("log")
             ax.set_ylabel(f"{ylabel} (log scale)", fontsize=12)
 
         plt.tight_layout()
@@ -316,4 +316,3 @@ class StatsVisualizer:
         """
         StatsVisualizer._check_matplotlib()
         plt.show()
-

--- a/examples/visualize_collection_stats.py
+++ b/examples/visualize_collection_stats.py
@@ -204,8 +204,9 @@ def display_statistics_summary(stats: CollectionStats):
     print(f"  Range: {stats.min_pages} - {stats.max_pages}")
     print(f"  Median (d5): {stats.deciles_pages[4]:.1f}")
     print(f"  Mean: {stats.mean_pages:.2f}")
-    print(f"  Deciles: d1={stats.deciles_pages[0]:.1f}, "
-          f"d5={stats.deciles_pages[4]:.1f}, d9={stats.deciles_pages[8]:.1f}")
+    print(
+        f"  Deciles: d1={stats.deciles_pages[0]:.1f}, d5={stats.deciles_pages[4]:.1f}, d9={stats.deciles_pages[8]:.1f}"
+    )
 
     print("\nTables:")
     print(f"  Range: {stats.min_tables} - {stats.max_tables}")
@@ -253,5 +254,5 @@ if __name__ == "__main__":
     except Exception as e:
         print(f"\nError: {e}")
         import traceback
-        traceback.print_exc()
 
+        traceback.print_exc()

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -457,16 +457,19 @@ def _rich_table_doc_impl() -> DoclingDocument:
 
     return doc
 
+
 @pytest.fixture(scope="session")
 def _rich_table_doc() -> DoclingDocument:
     """Fixture for a rich table document to be reused across the test session."""
     return _rich_table_doc_impl()
+
 
 @pytest.fixture(scope="function")
 def rich_table_doc(_rich_table_doc: DoclingDocument) -> DoclingDocument:
     """Copy of a rich table document for each test function."""
 
     return _rich_table_doc.model_copy(deep=True)
+
 
 def _mixed_hierarchy_doc_impl() -> DoclingDocument:
     doc = DoclingDocument(name="")
@@ -553,16 +556,19 @@ def _mixed_hierarchy_doc_impl() -> DoclingDocument:
 
     return doc
 
+
 @pytest.fixture(scope="session")
 def _mixed_hierarchy_doc() -> DoclingDocument:
     """Fixture for a mixed hierarchy document to be reused across the test session."""
     return _mixed_hierarchy_doc_impl()
+
 
 @pytest.fixture(scope="function")
 def mixed_hierarchy_doc(_mixed_hierarchy_doc: DoclingDocument) -> DoclingDocument:
     """Copy of a mixed hierarchy document for each test function."""
 
     return _mixed_hierarchy_doc.model_copy(deep=True)
+
 
 @pytest.fixture(scope="session")
 def _doc_with_handwritten() -> DoclingDocument:

--- a/test/test_chunk_expander.py
+++ b/test/test_chunk_expander.py
@@ -286,9 +286,7 @@ class TestTreeChunkExpander:
 
             # Expanded chunk text should contain original chunk text (or be a superset)
             assert check_lines_equal_in_order(chunk.text, expanded.text), (
-                f"Expanded chunk should contain original chunk text. "
-                f"original: {chunk.text} "
-                f"expanded: {expanded.text}"
+                f"Expanded chunk should contain original chunk text. original: {chunk.text} expanded: {expanded.text}"
             )
             assert expanded.meta.origin == chunk.meta.origin, "Origin should be preserved"
 
@@ -366,4 +364,3 @@ class TestPageChunkExpander:
 
             # Should return original chunk when no pages
             assert result == chunk, "Should return original chunk when document has no pages"
-

--- a/test/test_deserializer_doclang.py
+++ b/test/test_deserializer_doclang.py
@@ -164,6 +164,7 @@ def test_roundtrip_code():
     """
     assert dt2.strip() == exp_dt.strip()
 
+
 def test_roundtrip_formula():
     doc = DoclingDocument(name="t")
     doc.add_formula(text="E=mc^2")
@@ -375,9 +376,7 @@ def test_roundtrip_page_footer_prov():
 def test_roundtrip_code_prov():
     doc = DoclingDocument(name="t")
     _add_default_page(doc)
-    doc.add_code(
-        text="print('hi')", code_language=CodeLanguageLabel.PYTHON, prov=_default_prov()
-    )
+    doc.add_code(text="print('hi')", code_language=CodeLanguageLabel.PYTHON, prov=_default_prov())
     dt = _serialize(doc)
     if DO_PRINT:
         print("\n", dt)
@@ -821,36 +820,20 @@ def test_roundtrip_multiple_nested_lists_same_level():
 
 def test_roundtrip_list_item_with_inline_group():
 
-
     doc = DoclingDocument(name="t")
 
     add_texts_section(doc)
     add_list_section(doc)
 
     dt = _serialize(doc)
-    exp_ser_file = (
-        Path(__file__).parent
-        / "data"
-        / "doc"
-        / "roundtrip_list_item_with_inline_serialized.dclg.xml"
-    )
+    exp_ser_file = Path(__file__).parent / "data" / "doc" / "roundtrip_list_item_with_inline_serialized.dclg.xml"
     verify(exp_ser_file, dt)
     doc2 = _deserialize(dt)
-    deser_yaml_file = (
-        Path(__file__).parent
-        / "data"
-        / "doc"
-        / "roundtrip_list_item_with_inline_deserialized.yaml"
-    )
+    deser_yaml_file = Path(__file__).parent / "data" / "doc" / "roundtrip_list_item_with_inline_deserialized.yaml"
     doc2.save_as_yaml(deser_yaml_file)
     dt2 = _serialize(doc2)
 
-    exp_dt2_file = (
-        Path(__file__).parent
-        / "data"
-        / "doc"
-        / "roundtrip_list_item_with_inline_reserialized.dclg.xml"
-    )
+    exp_dt2_file = Path(__file__).parent / "data" / "doc" / "roundtrip_list_item_with_inline_reserialized.dclg.xml"
     verify(exp_dt2_file, dt2)
 
 
@@ -937,9 +920,7 @@ def test_roundtrip_picture_with_caption_and_footnotes():
 
     # Create caption and footnotes
     cap = doc.add_text(label=DocItemLabel.CAPTION, text="Figure 1: Sample Image")
-    footnote1 = doc.add_text(
-        label=DocItemLabel.FOOTNOTE, text="Image source: Dataset A"
-    )
+    footnote1 = doc.add_text(label=DocItemLabel.FOOTNOTE, text="Image source: Dataset A")
     footnote2 = doc.add_text(label=DocItemLabel.FOOTNOTE, text="Resolution: 1024x768")
 
     # Add picture with caption
@@ -992,12 +973,8 @@ def test_roundtrip_table_with_rich_cells():
 
     # Create content for rich cells
     # Cell (0, 0): Multiple paragraphs
-    para1 = doc.add_text(
-        parent=table, label=DocItemLabel.TEXT, text="First paragraph in cell."
-    )
-    para2 = doc.add_text(
-        parent=table, label=DocItemLabel.TEXT, text="Second paragraph in cell."
-    )
+    para1 = doc.add_text(parent=table, label=DocItemLabel.TEXT, text="First paragraph in cell.")
+    para2 = doc.add_text(parent=table, label=DocItemLabel.TEXT, text="Second paragraph in cell.")
 
     # Cell (1, 0): A list
     list_group = doc.add_list_group(parent=table)
@@ -1085,9 +1062,7 @@ def test_roundtrip_table_with_rich_cells():
     assert main_table.data.num_cols == 2
 
     # Verify that we have rich table cells
-    rich_cells = [
-        cell for cell in main_table.data.table_cells if isinstance(cell, RichTableCell)
-    ]
+    rich_cells = [cell for cell in main_table.data.table_cells if isinstance(cell, RichTableCell)]
     assert len(rich_cells) >= 1  # At least one rich cell should be preserved
 
     # Verify round-trip serialization
@@ -1110,15 +1085,11 @@ def test_constructed_doc(sample_doc: DoclingDocument):
     doc2 = _deserialize(dt)
     dt2 = _serialize(doc2)
 
-    exp_reserialized_dt_file = (
-        Path(__file__).parent / "data" / "doc" / "constr_doc_reserialized.dclg.xml"
-    )
+    exp_reserialized_dt_file = Path(__file__).parent / "data" / "doc" / "constr_doc_reserialized.dclg.xml"
     verify(exp_reserialized_dt_file, dt2)
 
 
-@pytest.mark.xfail(
-    reason="Known feature incompletenes in deseralization"
-)
+@pytest.mark.xfail(reason="Known feature incompletenes in deseralization")
 def test_constructed_rich_table_doc(rich_table_doc: DoclingDocument):
     doc = rich_table_doc
 
@@ -1129,6 +1100,7 @@ def test_constructed_rich_table_doc(rich_table_doc: DoclingDocument):
     dt2 = _serialize(doc2)
 
     assert dt2 == dt
+
 
 def test_wrapping():
     dt = f"""
@@ -1184,6 +1156,7 @@ def test_wrapping():
     dt2 = _serialize(doc)
     assert dt2.strip() == dt.strip()
 
+
 def test_rich_table_cells():
     dt = f"""
 <doclang xmlns="{DOCLANG_NAMESPACE}" version="{DOCLANG_VERSION}">
@@ -1233,7 +1206,6 @@ def test_picture_tabular_chart_content_cdata_cells():
     assert doc.pictures[0].meta.tabular_chart.chart_data.grid[1][1].text == "111"
 
 
-
 def test_roundtrip_with_layers():
     """Test roundtrip with content layers."""
     from docling_core.types.doc import ContentLayer
@@ -1246,6 +1218,7 @@ def test_roundtrip_with_layers():
 
     # Serialize with ALWAYS mode to ensure layers are included
     from docling_core.experimental.doclang import LayerMode
+
     ser = DoclangDocSerializer(
         doc=doc,
         params=DoclangParams(layer_mode=LayerMode.ALWAYS),
@@ -1261,6 +1234,7 @@ def test_roundtrip_with_layers():
     assert items[0].content_layer == ContentLayer.FURNITURE
     assert items[1].content_layer == ContentLayer.BODY
     assert items[2].content_layer == ContentLayer.FURNITURE
+
 
 def test_roundtrip_with_newlines():
     doclang_str = f"""
@@ -1281,42 +1255,41 @@ bar</content>
     exp_doclang_str = doc.export_to_doclang()
 
 
-
 def test_roundtrip_document_index_table():
     """Test that DOCUMENT_INDEX label is preserved through serialization/deserialization."""
     doc = DoclingDocument(name="test")
     _add_default_page(doc)
-    
+
     # Add a regular table
     table_data = TableData(num_cols=2)
-    table_data.add_row(['Header 1', 'Header 2'])
+    table_data.add_row(["Header 1", "Header 2"])
     table_data.grid[0][0].column_header = True
     table_data.grid[0][1].column_header = True
-    table_data.add_row(['Data 1', 'Data 2'])
+    table_data.add_row(["Data 1", "Data 2"])
     doc.add_table(data=table_data, label=DocItemLabel.TABLE, prov=_default_prov())
-    
+
     # Add a DOCUMENT_INDEX table
     index_data = TableData(num_cols=2)
-    index_data.add_row(['Index 1', 'Page 1'])
-    index_data.add_row(['Index 2', 'Page 2'])
+    index_data.add_row(["Index 1", "Page 1"])
+    index_data.add_row(["Index 2", "Page 2"])
     doc.add_table(data=index_data, label=DocItemLabel.DOCUMENT_INDEX, prov=_default_prov())
-    
+
     # Serialize
     xml_str = _serialize(doc)
-    
+
     # Verify serialization contains class="index"
     assert '<table class="index">' in xml_str
-    
+
     # Deserialize
     doc2 = _deserialize(xml_str)
-    
+
     # Verify we have 2 tables
     assert len(doc2.tables) == 2
-    
+
     # Verify labels are preserved
     assert doc2.tables[0].label == DocItemLabel.TABLE
     assert doc2.tables[1].label == DocItemLabel.DOCUMENT_INDEX
-    
+
     # Verify table data is preserved
     assert doc2.tables[0].data.num_rows == 2
     assert doc2.tables[0].data.num_cols == 2
@@ -1341,10 +1314,10 @@ def test_roundtrip_table_with_data_class():
     <nl/>
   </table>
 </doclang>"""
-    
+
     # Deserialize
     doc = _deserialize(xml_str)
-    
+
     # Verify we have 1 table with TABLE label
     assert len(doc.tables) == 1
     assert doc.tables[0].label == DocItemLabel.TABLE
@@ -1360,7 +1333,7 @@ def test_table_with_invalid_class_raises_error():
     <nl/>
   </table>
 </doclang>"""
-    
+
     # Deserialize should raise ValueError
     with pytest.raises(ValueError, match="Invalid class attribute value 'invalid' for table element"):
         _deserialize(xml_str)

--- a/test/test_docling_doc.py
+++ b/test/test_docling_doc.py
@@ -824,19 +824,13 @@ def test_image_ref_blocks_oversized_base64():
     import base64
 
     large_bytes = b"X" * (28 * 1024 * 1024)
-    large_data = base64.b64encode(large_bytes).decode('ascii')
+    large_data = base64.b64encode(large_bytes).decode("ascii")
     data_uri = f"data:image/png;base64,{large_data}"
 
-    image_ref = ImageRef(
-        dpi=72,
-        mimetype="image/png",
-        size=Size(width=100, height=100),
-        uri=AnyUrl(data_uri)
-    )
+    image_ref = ImageRef(dpi=72, mimetype="image/png", size=Size(width=100, height=100), uri=AnyUrl(data_uri))
 
     with pytest.raises(ValueError, match="exceeds size limit"):
         _ = image_ref.pil_image
-
 
 
 def test_image_ref_accepts_valid_base64():
@@ -850,16 +844,11 @@ def test_image_ref_accepts_valid_base64():
     buffer = BytesIO()
     fig_image.save(buffer, format="PNG")
     img_bytes = buffer.getvalue()
-    img_base64 = base64.b64encode(img_bytes).decode('ascii')
+    img_base64 = base64.b64encode(img_bytes).decode("ascii")
     data_uri = f"data:image/png;base64,{img_base64}"
 
     # Create ImageRef with data URI
-    image_ref = ImageRef(
-        dpi=72,
-        mimetype="image/png",
-        size=Size(width=1, height=1),
-        uri=AnyUrl(data_uri)
-    )
+    image_ref = ImageRef(dpi=72, mimetype="image/png", size=Size(width=1, height=1), uri=AnyUrl(data_uri))
 
     # Should successfully decode the image
     decoded_image = image_ref.pil_image
@@ -937,6 +926,7 @@ def test_max_decoded_size_custom():
             _ = image_ref.pil_image
     finally:
         settings.max_image_decoded_size = orig_max_image_decoded_size
+
 
 def test_max_decoded_size_default():
     """Test that small images work with default 20MB limit."""
@@ -1712,6 +1702,7 @@ def test_misplaced_list_items():
         exp_doc = DoclingDocument.load_from_yaml(exp_file)
         assert doc == exp_doc
 
+
 def test_moving_within_same_parent():
     doc = DoclingDocument(name="")
     doc.add_text(label=DocItemLabel.TEXT, text="bar")
@@ -1826,12 +1817,10 @@ def test_concatenate_shifts_graph_cell_pages_for_keyvalue_and_form():
     assert len(merged.form_items) == 2
 
     kv_item_pages = [
-        sorted({cell.prov.page_no for cell in item.graph.cells if cell.prov})
-        for item in merged.key_value_items
+        sorted({cell.prov.page_no for cell in item.graph.cells if cell.prov}) for item in merged.key_value_items
     ]
     form_item_pages = [
-        sorted({cell.prov.page_no for cell in item.graph.cells if cell.prov})
-        for item in merged.form_items
+        sorted({cell.prov.page_no for cell in item.graph.cells if cell.prov}) for item in merged.form_items
     ]
 
     assert kv_item_pages == [[1], [2]]
@@ -2066,6 +2055,7 @@ def test_invalid_rich_table_doc():
     with pytest.raises(ValueError):
         DoclingDocument.validate_document(doc)
 
+
 def test_invalid_single_linked_rich_table_doc():
     doc = DoclingDocument(name="")
     table_item = doc.add_table(data=TableData(num_rows=2, num_cols=2))
@@ -2095,7 +2085,7 @@ def test_invalid_single_linked_rich_table_doc():
             doc.add_table_cell(table_item=table_item, cell=table_cell)
 
     # delete child reference from table item
-    del(table_item.children[0])
+    del table_item.children[0]
 
     # ensure validate_document() raises:
     with pytest.raises(ValueError):
@@ -2298,6 +2288,7 @@ def test_validate_dupl_refs():
         error_str = str(valid_err_info.value)
         assert "Duplicate ref" in error_str
 
+
 def test_docitem_comments_field():
     """Test that DocItem has a comments field that can hold RefItem references."""
     doc = DoclingDocument(name="test_comments")
@@ -2407,44 +2398,54 @@ def test_table_data_vertical_bounding_boxes():
     cells = [
         TableCell(
             text="r0c0",
-            start_row_offset_idx=0, end_row_offset_idx=1,
-            start_col_offset_idx=0, end_col_offset_idx=1,
+            start_row_offset_idx=0,
+            end_row_offset_idx=1,
+            start_col_offset_idx=0,
+            end_col_offset_idx=1,
             bbox=BoundingBox(l=0, t=2, r=10, b=10, coord_origin=CoordOrigin.TOPLEFT),
         ),
         TableCell(
             text="r1c0",
-            start_row_offset_idx=1, end_row_offset_idx=2,
-            start_col_offset_idx=0, end_col_offset_idx=1,
+            start_row_offset_idx=1,
+            end_row_offset_idx=2,
+            start_col_offset_idx=0,
+            end_col_offset_idx=1,
             bbox=BoundingBox(l=10, t=0, r=20, b=10, coord_origin=CoordOrigin.TOPLEFT),
         ),
         TableCell(
             text="r0c1",
-            start_row_offset_idx=0, end_row_offset_idx=1,
-            start_col_offset_idx=1, end_col_offset_idx=2,
+            start_row_offset_idx=0,
+            end_row_offset_idx=1,
+            start_col_offset_idx=1,
+            end_col_offset_idx=2,
             bbox=BoundingBox(l=0, t=10, r=10, b=20, coord_origin=CoordOrigin.TOPLEFT),
         ),
         TableCell(
             text="r1c1",
-            start_row_offset_idx=1, end_row_offset_idx=2,
-            start_col_offset_idx=1, end_col_offset_idx=2,
+            start_row_offset_idx=1,
+            end_row_offset_idx=2,
+            start_col_offset_idx=1,
+            end_col_offset_idx=2,
             bbox=BoundingBox(l=10, t=10, r=18, b=20, coord_origin=CoordOrigin.TOPLEFT),
         ),
         TableCell(
             text="r0c2",
-            start_row_offset_idx=0, end_row_offset_idx=1,
-            start_col_offset_idx=2, end_col_offset_idx=3,
+            start_row_offset_idx=0,
+            end_row_offset_idx=1,
+            start_col_offset_idx=2,
+            end_col_offset_idx=3,
             bbox=BoundingBox(l=0, t=20, r=10, b=28, coord_origin=CoordOrigin.TOPLEFT),
         ),
         TableCell(
             text="r1c2",
-            start_row_offset_idx=1, end_row_offset_idx=2,
-            start_col_offset_idx=2, end_col_offset_idx=3,
+            start_row_offset_idx=1,
+            end_row_offset_idx=2,
+            start_col_offset_idx=2,
+            end_col_offset_idx=3,
             bbox=BoundingBox(l=10, t=20, r=20, b=30, coord_origin=CoordOrigin.TOPLEFT),
         ),
     ]
-    table = TableData(
-        num_rows=2, num_cols=3, table_cells=cells, orientation=Orientation.ROT_90
-    )
+    table = TableData(num_rows=2, num_cols=3, table_cells=cells, orientation=Orientation.ROT_90)
 
     # Minimal mode — sanity-check the per-row/col enclosing bbox.
     rows_min = table.get_row_bounding_boxes(minimal=True)
@@ -2504,32 +2505,38 @@ def test_table_data_vertical_bounding_boxes_with_spans():
     cells = [
         TableCell(  # row_span=2 in col 0
             text="r0+r1,c0",
-            start_row_offset_idx=0, end_row_offset_idx=2,
-            start_col_offset_idx=0, end_col_offset_idx=1,
+            start_row_offset_idx=0,
+            end_row_offset_idx=2,
+            start_col_offset_idx=0,
+            end_col_offset_idx=1,
             bbox=BoundingBox(l=0, t=0, r=20, b=10, coord_origin=CoordOrigin.TOPLEFT),
         ),
         TableCell(
             text="r0c1+c2",  # col_span=2 in row 0
-            start_row_offset_idx=0, end_row_offset_idx=1,
-            start_col_offset_idx=1, end_col_offset_idx=3,
+            start_row_offset_idx=0,
+            end_row_offset_idx=1,
+            start_col_offset_idx=1,
+            end_col_offset_idx=3,
             bbox=BoundingBox(l=0, t=10, r=10, b=30, coord_origin=CoordOrigin.TOPLEFT),
         ),
         TableCell(
             text="r1c1",
-            start_row_offset_idx=1, end_row_offset_idx=2,
-            start_col_offset_idx=1, end_col_offset_idx=2,
+            start_row_offset_idx=1,
+            end_row_offset_idx=2,
+            start_col_offset_idx=1,
+            end_col_offset_idx=2,
             bbox=BoundingBox(l=10, t=10, r=20, b=20, coord_origin=CoordOrigin.TOPLEFT),
         ),
         TableCell(
             text="r1c2",
-            start_row_offset_idx=1, end_row_offset_idx=2,
-            start_col_offset_idx=2, end_col_offset_idx=3,
+            start_row_offset_idx=1,
+            end_row_offset_idx=2,
+            start_col_offset_idx=2,
+            end_col_offset_idx=3,
             bbox=BoundingBox(l=10, t=20, r=20, b=30, coord_origin=CoordOrigin.TOPLEFT),
         ),
     ]
-    table = TableData(
-        num_rows=2, num_cols=3, table_cells=cells, orientation=Orientation.ROT_90
-    )
+    table = TableData(num_rows=2, num_cols=3, table_cells=cells, orientation=Orientation.ROT_90)
 
     # COLUMNS — col_span=2 cell must NOT stretch col 1 / col 2 along t/b.
     cols = table.get_column_bounding_boxes(minimal=True)
@@ -2570,44 +2577,58 @@ def test_table_data_horizontal_bounding_boxes_with_spans_no_overlap():
     cells = [
         TableCell(
             text="r0c0",
-            start_row_offset_idx=0, end_row_offset_idx=1,
-            start_col_offset_idx=0, end_col_offset_idx=1,
+            start_row_offset_idx=0,
+            end_row_offset_idx=1,
+            start_col_offset_idx=0,
+            end_col_offset_idx=1,
             bbox=BoundingBox(l=0, t=0, r=10, b=10, coord_origin=CoordOrigin.TOPLEFT),
         ),
         TableCell(  # col_span=2
             text="r0c1+c2",
-            start_row_offset_idx=0, end_row_offset_idx=1,
-            start_col_offset_idx=1, end_col_offset_idx=3,
+            start_row_offset_idx=0,
+            end_row_offset_idx=1,
+            start_col_offset_idx=1,
+            end_col_offset_idx=3,
             bbox=BoundingBox(l=10, t=0, r=30, b=10, coord_origin=CoordOrigin.TOPLEFT),
         ),
         TableCell(  # row_span=2
             text="r1+r2,c0",
-            start_row_offset_idx=1, end_row_offset_idx=3,
-            start_col_offset_idx=0, end_col_offset_idx=1,
+            start_row_offset_idx=1,
+            end_row_offset_idx=3,
+            start_col_offset_idx=0,
+            end_col_offset_idx=1,
             bbox=BoundingBox(l=0, t=10, r=10, b=30, coord_origin=CoordOrigin.TOPLEFT),
         ),
         TableCell(
             text="r1c1",
-            start_row_offset_idx=1, end_row_offset_idx=2,
-            start_col_offset_idx=1, end_col_offset_idx=2,
+            start_row_offset_idx=1,
+            end_row_offset_idx=2,
+            start_col_offset_idx=1,
+            end_col_offset_idx=2,
             bbox=BoundingBox(l=10, t=10, r=20, b=20, coord_origin=CoordOrigin.TOPLEFT),
         ),
         TableCell(
             text="r1c2",
-            start_row_offset_idx=1, end_row_offset_idx=2,
-            start_col_offset_idx=2, end_col_offset_idx=3,
+            start_row_offset_idx=1,
+            end_row_offset_idx=2,
+            start_col_offset_idx=2,
+            end_col_offset_idx=3,
             bbox=BoundingBox(l=20, t=10, r=30, b=20, coord_origin=CoordOrigin.TOPLEFT),
         ),
         TableCell(
             text="r2c1",
-            start_row_offset_idx=2, end_row_offset_idx=3,
-            start_col_offset_idx=1, end_col_offset_idx=2,
+            start_row_offset_idx=2,
+            end_row_offset_idx=3,
+            start_col_offset_idx=1,
+            end_col_offset_idx=2,
             bbox=BoundingBox(l=10, t=20, r=20, b=30, coord_origin=CoordOrigin.TOPLEFT),
         ),
         TableCell(
             text="r2c2",
-            start_row_offset_idx=2, end_row_offset_idx=3,
-            start_col_offset_idx=2, end_col_offset_idx=3,
+            start_row_offset_idx=2,
+            end_row_offset_idx=3,
+            start_col_offset_idx=2,
+            end_col_offset_idx=3,
             bbox=BoundingBox(l=20, t=20, r=30, b=30, coord_origin=CoordOrigin.TOPLEFT),
         ),
     ]

--- a/test/test_hierarchical_chunker.py
+++ b/test/test_hierarchical_chunker.py
@@ -48,7 +48,6 @@ def test_chunk_custom_serializer():
     assert_or_generate_json_ground_truth(act_data, "test/data/chunker/0b_out_chunks.json")
 
 
-
 def test_traverse_pictures():
     """Test that traverse_pictures parameter works correctly with HierarchicalChunker."""
 
@@ -65,9 +64,7 @@ def test_traverse_pictures():
                 has_non_caption_text_in_picture = True
                 break
 
-    assert has_non_caption_text_in_picture, (
-        "Test document should have non-caption TextItem children of PictureItem"
-    )
+    assert has_non_caption_text_in_picture, "Test document should have non-caption TextItem children of PictureItem"
 
     # Test 1: Default behavior (traverse_pictures=False)
     # Only caption TextItems should be included
@@ -115,9 +112,7 @@ def test_traverse_pictures():
         f"children of PictureItems should NOT be included. Found {non_caption_count_default}"
     )
 
-    assert caption_count_default > 0, (
-        "Caption TextItems should be included even with traverse_pictures=False"
-    )
+    assert caption_count_default > 0, "Caption TextItems should be included even with traverse_pictures=False"
 
     assert non_caption_count_traverse > 0, (
         f"With traverse_pictures=True, non-caption TextItems that are children of "
@@ -239,18 +234,14 @@ def test_triplet_table_serializer_handles_empty_table_output():
     empty_rich_doc = build_single_cell_rich_table_doc("")
     empty_rich_serializer = ChunkingSerializerProvider().get_serializer(empty_rich_doc)
     empty_visited: set[str] = set()
-    empty_rich_result = empty_rich_serializer.serialize(
-        item=empty_rich_doc.tables[0], visited=empty_visited
-    )
+    empty_rich_result = empty_rich_serializer.serialize(item=empty_rich_doc.tables[0], visited=empty_visited)
     assert empty_rich_result.text == ""
     assert empty_visited == {empty_rich_doc.tables[0].self_ref}
 
     rich_chunks = list(HierarchicalChunker().chunk(dl_doc=rich_doc))
     assert len(rich_chunks) == 1
     assert rich_chunks[0].text == "Important body text inside layout table"
-    assert [item.self_ref for item in rich_chunks[0].meta.doc_items] == [
-        rich_doc.tables[0].self_ref
-    ]
+    assert [item.self_ref for item in rich_chunks[0].meta.doc_items] == [rich_doc.tables[0].self_ref]
 
 
 def test_chunk_rich_table_custom_serializer(rich_table_doc: DoclingDocument):
@@ -269,8 +260,6 @@ def test_chunk_rich_table_custom_serializer(rich_table_doc: DoclingDocument):
     )
 
     chunks = chunker.chunk(dl_doc=doc)
-    act_data = dict(
-        root=[DocChunk.model_validate(n).export_json_dict() for n in chunks]
-    )
+    act_data = dict(root=[DocChunk.model_validate(n).export_json_dict() for n in chunks])
 
     assert_or_generate_json_ground_truth(act_data, "test/data/chunker/0c_out_chunks.json")

--- a/test/test_hierarchy.py
+++ b/test/test_hierarchy.py
@@ -14,8 +14,9 @@ def test_flatten(mixed_hierarchy_doc: DoclingDocument):
     _verify_doc(doc=doc, exp_json=exp_json)
 
     exp_dclg = Path("./test/data/doc/flattened.dclg.xml")
-    actual=doc.export_to_doclang()
+    actual = doc.export_to_doclang()
     verify(actual=actual, exp_file=exp_dclg)
+
 
 def test_hierarchize(mixed_hierarchy_doc):
     doc: DoclingDocument = mixed_hierarchy_doc
@@ -27,5 +28,5 @@ def test_hierarchize(mixed_hierarchy_doc):
     _verify_doc(doc=doc, exp_json=exp_json)
 
     exp_dclg = Path("./test/data/doc/hierarchized.dclg.xml")
-    actual=doc.export_to_doclang()
+    actual = doc.export_to_doclang()
     verify(actual=actual, exp_file=exp_dclg)

--- a/test/test_hybrid_chunker.py
+++ b/test/test_hybrid_chunker.py
@@ -412,13 +412,12 @@ def test_shadowed_headings_wout_content():
         chunker = setup.chunker
         chunk_iter = chunker.chunk(dl_doc=doc)
         chunks = list(chunk_iter)
-        act_data = dict(
-            root=[DocChunk.model_validate(n).export_json_dict() for n in chunks]
-        )
+        act_data = dict(root=[DocChunk.model_validate(n).export_json_dict() for n in chunks])
         assert_or_generate_json_ground_truth(
             act_data,
             setup.exp,
         )
+
 
 def test_chunk_with_repeat_table_header():
     """Test that table headers are repeated when a table is split across chunks."""
@@ -437,7 +436,7 @@ def test_chunk_with_repeat_table_header():
             return ChunkingDocSerializer(
                 doc=doc,
                 table_serializer=MarkdownTableSerializer(),
-                params = MarkdownParams(compact_tables=True),  # Use compact table format to reduce token count
+                params=MarkdownParams(compact_tables=True),  # Use compact table format to reduce token count
             )
 
     chunker = HybridChunker(
@@ -458,7 +457,7 @@ def test_chunk_with_repeat_table_header():
         # Serialize the table
         ser_result = serializer.serialize(
             item=table_item,
-            )
+        )
         table_contents[table_item.self_ref] = ser_result.text
 
     chunks = list(chunker.chunk(dl_doc=dl_doc))
@@ -470,9 +469,7 @@ def test_chunk_with_repeat_table_header():
     for table_ref, table_text in table_contents.items():
         # Get header and body lines from the serialized table
         if table_text:
-            header_lines, body_lines = serializer.table_serializer.get_header_and_body_lines(
-                table_text=table_text
-            )
+            header_lines, body_lines = serializer.table_serializer.get_header_and_body_lines(table_text=table_text)
 
             # Find all chunks that contain content from this table
             chunks_with_table = [chunk for chunk in chunks if table_ref in [i.self_ref for i in chunk.meta.doc_items]]
@@ -485,10 +482,7 @@ def test_chunk_with_repeat_table_header():
                 # Each chunk with table content should have the header
                 for chunk in chunks_with_table:
                     # Check if header lines are present
-                    has_header = all(
-                        header_line.strip() in chunk.text
-                        for header_line in header_lines
-                    )
+                    has_header = all(header_line.strip() in chunk.text for header_line in header_lines)
                     assert has_header, (
                         f"Table {table_ref} split across chunks should have header repeated in each chunk. "
                         f"Missing header in chunk: {chunk.text[:200]}..."
@@ -507,7 +501,7 @@ def test_chunk_with_repeat_table_header():
             "meta": {
                 "doc_items": [item.self_ref for item in chunk.meta.doc_items] if chunk.meta.doc_items else [],
                 "headings": chunk.meta.headings,
-            }
+            },
         }
         for chunk in chunks
     ]
@@ -519,13 +513,13 @@ def test_chunk_html_table_serializer():
     """Test chunking with HTML table serializer."""
     INPUT_FILE = "test/data/chunker/0_inp_dl_doc.json"
     EXPECTED_OUT_FILE = "test/data/chunker/0e_out_chunks.json"
-    MAX_TOKENS= 250
+    MAX_TOKENS = 250
 
     with open(INPUT_FILE, encoding="utf-8") as f:
         data_json = f.read()
     dl_doc = DLDocument.model_validate_json(data_json)
 
-# Verify the document has tables
+    # Verify the document has tables
     assert len(dl_doc.tables) > 0, "Input file should contain at least one table"
 
     class HTMLSerializerProvider(ChunkingSerializerProvider):
@@ -538,23 +532,22 @@ def test_chunk_html_table_serializer():
     chunker = HybridChunker(
         tokenizer=HuggingFaceTokenizer(
             tokenizer=INNER_TOKENIZER,
-            max_tokens=MAX_TOKENS*2,
+            max_tokens=MAX_TOKENS * 2,
         ),
         merge_peers=True,
         repeat_table_header=True,
         serializer_provider=HTMLSerializerProvider(),
     )
 
-
     serializer = chunker.serializer_provider.get_serializer(dl_doc)
 
-# Serialize each table item individually to get expected content
+    # Serialize each table item individually to get expected content
     table_contents = {}
     for table_item in dl_doc.tables:
         # Serialize the table
         ser_result = serializer.serialize(
             item=table_item,
-            )
+        )
         table_contents[table_item.self_ref] = ser_result.text
 
     chunks = list(chunker.chunk(dl_doc=dl_doc))
@@ -566,9 +559,7 @@ def test_chunk_html_table_serializer():
     for table_ref, table_text in table_contents.items():
         # Get header and body lines from the serialized table
         if table_text:
-            header_lines, body_lines = serializer.table_serializer.get_header_and_body_lines(
-                table_text=table_text
-            )
+            header_lines, body_lines = serializer.table_serializer.get_header_and_body_lines(table_text=table_text)
 
             # Find all chunks that contain content from this table
             chunks_with_table = [chunk for chunk in chunks if table_ref in [i.self_ref for i in chunk.meta.doc_items]]
@@ -581,10 +572,7 @@ def test_chunk_html_table_serializer():
                 # Each chunk with table content should have the header
                 for chunk in chunks_with_table:
                     # Check if header lines are present
-                    has_header = all(
-                        header_line.strip() in chunk.text
-                        for header_line in header_lines
-                    )
+                    has_header = all(header_line.strip() in chunk.text for header_line in header_lines)
                     assert has_header, (
                         f"Table {table_ref} split across chunks should have header repeated in each chunk. "
                         f"Missing header in chunk: {chunk.text[:200]}..."
@@ -602,7 +590,6 @@ def test_chunk_html_table_serializer():
         act_data,
         EXPECTED_OUT_FILE,
     )
-
 
 
 def test_html_parser_error_handling():

--- a/test/test_line_chunker.py
+++ b/test/test_line_chunker.py
@@ -190,14 +190,15 @@ def test_chunk_text_with_prefix_and_long_lines(default_tokenizer):
         assert token_count <= MAX_TOKENS
 
 
-
 def test_chunk_document(default_tokenizer):
     """Test the chunk() method with a DoclingDocument."""
     # Create a simple DoclingDocument
     doc = DLDocument(name="test_doc")
-    paragraphs = ["This is the first paragraph with some content.",
-    "This is the second paragraph with more content",
-    "This is the third paragraph with even more content."]
+    paragraphs = [
+        "This is the first paragraph with some content.",
+        "This is the second paragraph with more content",
+        "This is the third paragraph with even more content.",
+    ]
 
     # Add some text items to the document
     for t in paragraphs:
@@ -225,7 +226,7 @@ def test_chunk_document(default_tokenizer):
         token_count = chunker.tokenizer.count_tokens(chunk.text)
         assert token_count <= MAX_TOKENS
 
-     # Verify each paragraph resides fully in a chunk
+    # Verify each paragraph resides fully in a chunk
     for t in paragraphs:
         assert any(t in c.text for c in chunks)
 
@@ -257,10 +258,7 @@ def test_chunk_document_with_long_content(default_tokenizer):
     long_text = "This is a sentence with multiple words. " * 50
     doc.add_text(label=DocItemLabel.PARAGRAPH, text=long_text)
 
-    chunker = LineBasedTokenChunker(
-        tokenizer=default_tokenizer,
-        prefix=prefix
-    )
+    chunker = LineBasedTokenChunker(tokenizer=default_tokenizer, prefix=prefix)
 
     # Chunk the document
     chunks = list(chunker.chunk(doc))
@@ -362,8 +360,7 @@ def test_character_level_fallback_on_zero_available(default_tokenizer):
     # Verify second line is indeed > max_tokens
     second_line_tokens = chunker.tokenizer.count_tokens(second_line)
     assert second_line_tokens > MAX_TOKENS, (
-        f"Second line must exceed max_tokens for test to work: "
-        f"{second_line_tokens} <= {MAX_TOKENS}"
+        f"Second line must exceed max_tokens for test to work: {second_line_tokens} <= {MAX_TOKENS}"
     )
 
     lines = [first_line, second_line]
@@ -397,7 +394,7 @@ def test_omit_prefix_on_overflow_false(default_tokenizer):
 
     # Create a line that fits without prefix but not with prefix
     # prefix_len is around 2 tokens, create a line that's just 1 token short
-    line = "word " * (MAX_TOKENS - 1) 
+    line = "word " * (MAX_TOKENS - 1)
     line_tokens = chunker.tokenizer.count_tokens(line)
 
     # Verify test setup: line should fit alone but not with prefix
@@ -571,7 +568,9 @@ def test_omit_prefix_on_overflow_with_line_splitting(default_tokenizer):
     # At least the overflow chunks (after the first) should not have prefix
     if len(chunks) > 1:
         for i in range(1, len(chunks)):
-            assert not chunks[i].startswith(prefix), f"Overflow chunk {i} should NOT have prefix with omit_prefix_on_overflow=True"
+            assert not chunks[i].startswith(prefix), (
+                f"Overflow chunk {i} should NOT have prefix with omit_prefix_on_overflow=True"
+            )
 
 
 def test_omit_prefix_on_overflow_false_with_line_splitting(default_tokenizer):
@@ -603,6 +602,7 @@ def test_omit_prefix_on_overflow_false_with_line_splitting(default_tokenizer):
 
         # All chunks should have the prefix when omit_prefix_on_overflow=False
         assert chunk.startswith(prefix), f"Chunk {i} should have prefix with omit_prefix_on_overflow=False"
+
 
 def test_omit_prefix_on_overflow_warning(default_tokenizer):
     """Test that a warning is issued once when prefix is actually omitted."""
@@ -648,6 +648,7 @@ def test_omit_prefix_on_overflow_no_warning_when_not_omitted(default_tokenizer):
 
     # Should NOT warn since prefix is never omitted
     import warnings as warnings_module
+
     with warnings_module.catch_warnings(record=True) as warning_list:
         warnings_module.simplefilter("always")
         lines = [small_line, small_line, small_line]
@@ -747,4 +748,3 @@ def test_omit_prefix_on_overflow_all_lines_overflow(default_tokenizer):
     for line in lines:
         line_found = any(line.strip() in chunk for chunk in chunks)
         assert line_found, f"Line content should be preserved: {line.strip()}"
-

--- a/test/test_plain_text_serialization.py
+++ b/test/test_plain_text_serialization.py
@@ -38,6 +38,7 @@ def test_plain_text_no_inline_markers(sample_doc):
     assert "~~" not in result
     # single '*' could appear in list markers, so check for italic wrapping pattern
     import re
+
     assert not re.search(r"\*[^*\n]+\*", result), "Unexpected italic markers found"
 
 

--- a/test/test_profiler.py
+++ b/test/test_profiler.py
@@ -376,11 +376,7 @@ def test_profile_sample_document(sample_doc):
     # Verify computed fields
     assert stats.total_items > 0
     assert stats.total_items == (
-        stats.num_texts
-        + stats.num_tables
-        + stats.num_pictures
-        + stats.num_key_value_items
-        + stats.num_form_items
+        stats.num_texts + stats.num_tables + stats.num_pictures + stats.num_key_value_items + stats.num_form_items
     )
 
     # sample_doc has no pages, so avg_items_per_page should be 0

--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -962,18 +962,10 @@ def test_html_rich_cell_textitem_ref_subtree_inside_and_not_outside():
     inside_table = body[:table_end]
     after_table = body[table_end:]
 
-    assert "CELL-TEXT" in inside_table, (
-        f"RichTableCell ref content missing from the table:\n{body}"
-    )
-    assert "DEEP-LEAK" in inside_table, (
-        f"RichTableCell ref descendant missing from the table:\n{body}"
-    )
-    assert "CELL-TEXT" not in after_table, (
-        f"RichTableCell ref content leaked outside the table:\n{body}"
-    )
-    assert "DEEP-LEAK" not in after_table, (
-        f"RichTableCell ref descendant leaked outside the table:\n{body}"
-    )
+    assert "CELL-TEXT" in inside_table, f"RichTableCell ref content missing from the table:\n{body}"
+    assert "DEEP-LEAK" in inside_table, f"RichTableCell ref descendant missing from the table:\n{body}"
+    assert "CELL-TEXT" not in after_table, f"RichTableCell ref content leaked outside the table:\n{body}"
+    assert "DEEP-LEAK" not in after_table, f"RichTableCell ref descendant leaked outside the table:\n{body}"
 
 
 def test_html_textitem_with_children_at_document_level():
@@ -990,15 +982,9 @@ def test_html_textitem_with_children_at_document_level():
     out = HTMLDocSerializer(doc=doc).serialize().text
     body = out[out.find("<body>") : out.find("</body>") + len("</body>")]
 
-    assert body.count("PARENT-TEXT") == 1, (
-        f"PARENT-TEXT should appear exactly once:\n{body}"
-    )
-    assert body.count("CHILD-TEXT") == 1, (
-        f"CHILD-TEXT should appear exactly once:\n{body}"
-    )
-    assert body.find("PARENT-TEXT") < body.find("CHILD-TEXT"), (
-        f"PARENT-TEXT should appear before CHILD-TEXT:\n{body}"
-    )
+    assert body.count("PARENT-TEXT") == 1, f"PARENT-TEXT should appear exactly once:\n{body}"
+    assert body.count("CHILD-TEXT") == 1, f"CHILD-TEXT should appear exactly once:\n{body}"
+    assert body.find("PARENT-TEXT") < body.find("CHILD-TEXT"), f"PARENT-TEXT should appear before CHILD-TEXT:\n{body}"
 
 
 def test_html_inline_and_formatting():
@@ -1087,7 +1073,9 @@ def test_html_meta_emits_xhtml_compatible_attributes():
         )
     ]
 
-    text = doc.add_text(label=DocItemLabel.TEXT, text="Output of HTML serializer must be parseable by a strict XML parser")
+    text = doc.add_text(
+        label=DocItemLabel.TEXT, text="Output of HTML serializer must be parseable by a strict XML parser"
+    )
     text.meta = BaseMeta(
         summary=SummaryMetaField(text="XHTML-compliant"),
         language=LanguageMetaField(code="en"),
@@ -1102,7 +1090,7 @@ def test_html_meta_emits_xhtml_compatible_attributes():
                     text="XML parser",
                     label="software",
                     charspan=CharSpan((56, 66)),
-                )
+                ),
             ]
         ),
     )

--- a/test/test_serialization_doclang.py
+++ b/test/test_serialization_doclang.py
@@ -36,7 +36,15 @@ from docling_core.types.doc import (
     TabularChartMetaField,
 )
 from docling_core.types.doc.base import ImageRefMode
-from docling_core.types.doc.document import ContentLayer, GraphCell, GraphData, GraphLink, ImageRef, RichTableCell, TableCell
+from docling_core.types.doc.document import (
+    ContentLayer,
+    GraphCell,
+    GraphData,
+    GraphLink,
+    ImageRef,
+    RichTableCell,
+    TableCell,
+)
 from docling_core.types.doc.labels import GraphCellLabel, GraphLinkLabel
 from test.test_serialization import verify
 from test.test_data_gen_flag import GEN_TEST_DATA
@@ -60,6 +68,7 @@ def add_texts_section(doc: DoclingDocument):
         text=" (to be shown)",
         parent=inline1,
     )
+
 
 def add_list_section(doc: DoclingDocument):
     doc.add_page(page_no=1, size=Size(width=100, height=100), image=None)
@@ -136,6 +145,7 @@ def add_list_section(doc: DoclingDocument):
     doc.add_list_item(text="sublist item b", parent=lg_sub)
 
     doc.add_list_item(text="final element", parent=lg)
+
 
 # ===============================
 # Doclang tests
@@ -247,6 +257,7 @@ def test_doclang_crop_embedded():
     """.strip()
     assert actual.endswith(exp_suffix)
 
+
 def test_doclang_crop_placeholder():
     src = Path("./test/data/doc/activities_simplified.yaml")
     doc = DoclingDocument.load_from_yaml(src)
@@ -258,6 +269,7 @@ def test_doclang_crop_placeholder():
     actual = serializer.serialize().text
     exp_file = src.parent / f"{src.stem}_cropped_placeholder.dclg.xml"
     verify(exp_file=exp_file, actual=actual)
+
 
 def _create_escape_test_doc(inp_doc: DoclingDocument):
     doc = inp_doc.model_copy(deep=True)
@@ -333,9 +345,7 @@ def test_strikethrough_formatting():
     formatting = Formatting(strikethrough=True)
     doc.add_text(label=DocItemLabel.TEXT, text="Strike text", formatting=formatting)
 
-    result = serialize_doclang(
-        doc, params=DoclangParams(add_location=False)
-    )
+    result = serialize_doclang(doc, params=DoclangParams(add_location=False))
     assert "<strikethrough>Strike text</strikethrough>" in result
 
 
@@ -345,9 +355,7 @@ def test_subscript_formatting():
     formatting = Formatting(script=Script.SUB)
     doc.add_text(label=DocItemLabel.TEXT, text="H2O", formatting=formatting)
 
-    result = serialize_doclang(
-        doc, params=DoclangParams(add_location=False)
-    )
+    result = serialize_doclang(doc, params=DoclangParams(add_location=False))
     assert "<subscript>H2O</subscript>" in result
 
 
@@ -357,9 +365,7 @@ def test_superscript_formatting():
     formatting = Formatting(script=Script.SUPER)
     doc.add_text(label=DocItemLabel.TEXT, text="x^2", formatting=formatting)
 
-    result = serialize_doclang(
-        doc, params=DoclangParams(add_location=False)
-    )
+    result = serialize_doclang(doc, params=DoclangParams(add_location=False))
     assert "<superscript>x^2</superscript>" in result
 
 
@@ -369,15 +375,11 @@ def test_combined_formatting():
     formatting = Formatting(bold=True, italic=True)
     doc.add_text(label=DocItemLabel.TEXT, text="Bold and italic", formatting=formatting)
 
-    result = serialize_doclang(
-        doc, params=DoclangParams(add_location=False)
-    )
+    result = serialize_doclang(doc, params=DoclangParams(add_location=False))
     # When both bold and italic are applied, they should be nested
     assert "<bold>" in result
     assert "<italic>" in result
     assert "Bold and italic" in result
-
-
 
 
 def _create_content_filtering_doc(inp_doc: DoclingDocument):
@@ -388,18 +390,14 @@ def _create_content_filtering_doc(inp_doc: DoclingDocument):
         bbox=BoundingBox.from_tuple((1, 2, 3, 4), origin=CoordOrigin.BOTTOMLEFT),
         charspan=(0, 2),
     )
-    pic = doc.add_picture(
-        caption=doc.add_text(label=DocItemLabel.CAPTION, text="Picture Caption")
-    )
+    pic = doc.add_picture(caption=doc.add_text(label=DocItemLabel.CAPTION, text="Picture Caption"))
     pic.prov = [prov]
     pic.meta = PictureMeta(
         summary=SummaryMetaField(text="Picture Summary"),
         description=DescriptionMetaField(text="Picture Description"),
     )
 
-    chart = doc.add_picture(
-        caption=doc.add_text(label=DocItemLabel.CAPTION, text="Picture Caption")
-    )
+    chart = doc.add_picture(caption=doc.add_text(label=DocItemLabel.CAPTION, text="Picture Caption"))
     chart.prov = [prov]
     chart.meta = PictureMeta(
         summary=SummaryMetaField(text="Picture Summary"),
@@ -563,6 +561,7 @@ def test_mini_inline():
     exp_file = Path("./test/data/doc/mini_inline.gt.dclg.xml")
     verify(exp_file=exp_file, actual=ser_txt)
 
+
 def _create_wrapping_test_doc():
     doc = DoclingDocument(name="test")
     doc.add_page(page_no=1, size=Size(width=100, height=100), image=None)
@@ -585,6 +584,7 @@ def _create_wrapping_test_doc():
 
     return doc
 
+
 def test_content_wrapping_mode_when_needed():
     doc = _create_wrapping_test_doc()
     ser = DoclangDocSerializer(
@@ -597,6 +597,7 @@ def test_content_wrapping_mode_when_needed():
     ser_txt = ser_res.text
     exp_file = Path("./test/data/doc/wrapping_when_needed.gt.dclg.xml")
     verify(exp_file=exp_file, actual=ser_txt)
+
 
 def test_content_wrapping_mode_always():
     doc = _create_wrapping_test_doc()
@@ -611,6 +612,7 @@ def test_content_wrapping_mode_always():
     exp_file = Path("./test/data/doc/wrapping_always.gt.dclg.xml")
     verify(exp_file=exp_file, actual=ser_txt)
 
+
 def test_default_mode():
     doc = DoclingDocument(name="test")
     add_texts_section(doc)
@@ -621,6 +623,7 @@ def test_default_mode():
     ser_txt = ser_res.text
     exp_file = Path("./test/data/doc/default_mode.gt.dclg.xml")
     verify(exp_file=exp_file, actual=ser_txt)
+
 
 def test_vlm_mode():
     doc = DoclingDocument(name="test")
@@ -643,6 +646,7 @@ def test_vlm_mode():
     ser_txt = ser_res.text
     exp_file = Path("./test/data/doc/vlm_mode.gt.dclg.xml")
     verify(exp_file=exp_file, actual=ser_txt)
+
 
 def test_rich_cells(rich_table_doc):
     ser = DoclangDocSerializer(
@@ -667,6 +671,7 @@ def _create_simple_prov_doc():
     doc.add_text(label=DocItemLabel.TEXT, text="World", prov=prov)
     return doc
 
+
 def test_checkboxes():
     doc = DoclingDocument(name="")
     doc.add_text(label=DocItemLabel.CHECKBOX_UNSELECTED, text="TODO")
@@ -676,6 +681,7 @@ def test_checkboxes():
     ser_txt = ser_res.text
     exp_file = Path("./test/data/doc/checkboxes.out.dclg.xml")
     verify(exp_file=exp_file, actual=ser_txt)
+
 
 def test_def_prov_512():
     doc = _create_simple_prov_doc()
@@ -706,6 +712,7 @@ def test_def_prov_256():
     exp_file = Path("./test/data/doc/simple_prov_res_256.out.dclg.xml")
     verify(exp_file=exp_file, actual=ser_txt)
 
+
 def test_chart():
     doc = DoclingDocument.load_from_json("./test/data/doc/barchart.json")
     ser = DoclangDocSerializer(
@@ -723,6 +730,7 @@ def _verify_doc(doc: DoclingDocument, exp_json: Path):
     else:
         exp_doc = DoclingDocument.load_from_json(filename=exp_json)
         assert doc == exp_doc
+
 
 def test_kv():
     doc = DoclingDocument(name="")
@@ -799,7 +807,6 @@ def test_kv():
     ser_txt = doc.export_to_doclang()
     exp_file = Path("./test/data/doc/kv.out.dclg.xml")
     verify(exp_file=exp_file, actual=ser_txt)
-
 
 
 def _create_kv_invoice_doc() -> DoclingDocument:
@@ -915,7 +922,11 @@ def test_kv_advanced_inline():
 
     kve = doc.add_field_item(parent=inl_outer)
     doc.add_field_value(text="", parent=kve, kind="fillable")
-    doc.add_text(label=DocItemLabel.TEXT, text=" (name, address, and employer idenficiation number of seller) as follows (complete as applicable): ", parent=inl_outer)
+    doc.add_text(
+        label=DocItemLabel.TEXT,
+        text=" (name, address, and employer idenficiation number of seller) as follows (complete as applicable): ",
+        parent=inl_outer,
+    )
 
     kve = doc.add_field_item(parent=inl_outer)
     doc.add_field_value(text="", parent=kve, kind="fillable")
@@ -927,6 +938,7 @@ def test_kv_advanced_inline():
     ser_txt = doc.export_to_doclang()
     exp_file = Path("./test/data/doc/kv_advanced_inline.out.dclg.xml")
     verify(exp_file=exp_file, actual=ser_txt)
+
 
 def test_kv_nested():
     doc = DoclingDocument(name="")
@@ -967,6 +979,7 @@ def test_kv_nested():
     exp_file = Path("./test/data/doc/kv_nested.out.dclg.xml")
     verify(exp_file=exp_file, actual=ser_txt)
 
+
 def test_kv_form_with_table():
     doc = DoclingDocument(name="")
     doc.add_page(page_no=1, size=Size(width=100, height=100), image=None)
@@ -985,8 +998,8 @@ def test_kv_form_with_table():
 
     table_vals = [
         ["Description of property", "Cost or other basis, plus improvements and expense of sale", "Gain or loss"],
-        [""  ,                      "gain",                                                       "150,997"],
-        ["",                        "loss",                                                       "114,676"],
+        ["", "gain", "150,997"],
+        ["", "loss", "114,676"],
     ]
     num_rows = len(table_vals)
     num_cols = len(table_vals[0])
@@ -1050,7 +1063,6 @@ def test_kv_migration_self_contained_scenario():
                     text="Duck",
                     orig="Duck",
                 ),
-
                 # TO_PARENT & TO_CHILD links:
                 GraphCell(
                     label=GraphCellLabel.KEY,
@@ -1064,7 +1076,6 @@ def test_kv_migration_self_contained_scenario():
                     text="Anatidae",
                     orig="Anatidae",
                 ),
-
                 # multiple TO_VALUE links:
                 GraphCell(
                     label=GraphCellLabel.KEY,
@@ -1152,6 +1163,7 @@ def test_kv_migration_self_contained_scenario():
     ser_txt = doc.export_to_doclang()
     exp_file = Path("./test/data/doc/kv_migration.out.dclg.xml")
     verify(exp_file=exp_file, actual=ser_txt)
+
 
 def test_kv_migration_annot_scenario():
     roots = [
@@ -1305,26 +1317,27 @@ def test_empty_table_preserved_by_default():
     assert "<group" in result
     assert "<table" not in result
 
+
 def test_document_index_serialization():
     """Test that DOCUMENT_INDEX tables are serialized with class='index' attribute."""
     doc = DoclingDocument(name="test")
-    
+
     # Add a regular table
     table_data = TableData(num_cols=2)
-    table_data.add_row(['Header 1', 'Header 2'])
+    table_data.add_row(["Header 1", "Header 2"])
     table_data.grid[0][0].column_header = True
     table_data.grid[0][1].column_header = True
-    table_data.add_row(['Data 1', 'Data 2'])
+    table_data.add_row(["Data 1", "Data 2"])
     doc.add_table(data=table_data, label=DocItemLabel.TABLE)
-    
+
     # Add a DOCUMENT_INDEX table
     index_data = TableData(num_cols=2)
-    index_data.add_row(['Index 1', 'Page 1'])
-    index_data.add_row(['Index 2', 'Page 2'])
+    index_data.add_row(["Index 1", "Page 1"])
+    index_data.add_row(["Index 2", "Page 2"])
     doc.add_table(data=index_data, label=DocItemLabel.DOCUMENT_INDEX)
-    
+
     result = serialize_doclang(doc)
-    
+
     # Verify against expected output
     exp_file = Path("./test/data/doc/document_index.gt.dclg.xml")
     verify(exp_file=exp_file, actual=result)
@@ -1588,22 +1601,22 @@ def test_list_item_with_code_child_and_bbox():
 
 def _create_virtual_text_test_doc(add_location: bool = False) -> DoclingDocument:
     """Helper to create a test document for virtual text testing.
-    
+
     Args:
         add_location: If True, add provenance/location info to items.
-    
+
     Returns:
         DoclingDocument with list items and table cells for testing.
     """
     doc = DoclingDocument(name="test_virtual_texts")
-    
+
     # Add page if we need location
     if add_location:
         doc.add_page(page_no=1, size=Size(width=100, height=100), image=None)
-    
+
     # Add a list with various item types
     lg = doc.add_list_group()
-    
+
     # Regular list item with text
     prov = None
     if add_location:
@@ -1613,7 +1626,7 @@ def _create_virtual_text_test_doc(add_location: bool = False) -> DoclingDocument
             charspan=(0, 12),
         )
     doc.add_list_item(text="Regular item", parent=lg, prov=prov)
-    
+
     # List item with empty text and CodeItem child
     li_with_code = doc.add_list_item(text="", parent=lg)
     doc.add_code(
@@ -1621,7 +1634,7 @@ def _create_virtual_text_test_doc(add_location: bool = False) -> DoclingDocument
         parent=li_with_code,
         code_language=CodeLanguageLabel.PYTHON,
     )
-    
+
     # List item with text
     prov2 = None
     if add_location:
@@ -1631,7 +1644,7 @@ def _create_virtual_text_test_doc(add_location: bool = False) -> DoclingDocument
             charspan=(0, 12),
         )
     doc.add_list_item(text="Another item", parent=lg, prov=prov2)
-    
+
     # Add a table with cells (mix of regular and rich cells)
     # Add provenance to the table so cell locations can be serialized
     table_prov = None
@@ -1642,7 +1655,7 @@ def _create_virtual_text_test_doc(add_location: bool = False) -> DoclingDocument
             charspan=(0, 50),
         )
     table = doc.add_table(data=TableData(num_rows=2, num_cols=2), prov=table_prov)
-    
+
     cell: TableCell
     # Add cells to the table
     for i in range(2):
@@ -1668,21 +1681,21 @@ def _create_virtual_text_test_doc(add_location: bool = False) -> DoclingDocument
                     bbox=prov2.bbox if prov2 and i + j == 0 else None,
                 )
             doc.add_table_cell(table_item=table, cell=cell)
-    
+
     return doc
 
 
 def test_virtual_texts_true_no_location():
     """Test use_virtual_texts=True without location info."""
     doc = _create_virtual_text_test_doc(add_location=False)
-    
+
     params = DoclangParams(
         use_virtual_texts=True,
         add_location=False,
     )
     serializer = DoclangDocSerializer(doc=doc, params=params)
     ser_txt = serializer.serialize().text
-    
+
     exp_file = Path("./test/data/doc/virtual_texts_true_no_loc.gt.dclg.xml")
     verify(exp_file=exp_file, actual=ser_txt)
 
@@ -1690,7 +1703,7 @@ def test_virtual_texts_true_no_location():
 def test_virtual_texts_true_with_location():
     """Test use_virtual_texts=True with location info."""
     doc = _create_virtual_text_test_doc(add_location=True)
-    
+
     params = DoclangParams(
         use_virtual_texts=True,
         add_location=True,
@@ -1698,7 +1711,7 @@ def test_virtual_texts_true_with_location():
     )
     serializer = DoclangDocSerializer(doc=doc, params=params)
     ser_txt = serializer.serialize().text
-    
+
     exp_file = Path("./test/data/doc/virtual_texts_true_with_loc.gt.dclg.xml")
     verify(exp_file=exp_file, actual=ser_txt)
 
@@ -1706,14 +1719,14 @@ def test_virtual_texts_true_with_location():
 def test_virtual_texts_false_no_location():
     """Test use_virtual_texts=False (default) without location info."""
     doc = _create_virtual_text_test_doc(add_location=False)
-    
+
     params = DoclangParams(
         use_virtual_texts=False,
         add_location=False,
     )
     serializer = DoclangDocSerializer(doc=doc, params=params)
     ser_txt = serializer.serialize().text
-    
+
     exp_file = Path("./test/data/doc/virtual_texts_false_no_loc.gt.dclg.xml")
     verify(exp_file=exp_file, actual=ser_txt)
 
@@ -1721,7 +1734,7 @@ def test_virtual_texts_false_no_location():
 def test_virtual_texts_false_with_location():
     """Test use_virtual_texts=False (default) with location info."""
     doc = _create_virtual_text_test_doc(add_location=True)
-    
+
     params = DoclangParams(
         use_virtual_texts=False,
         add_location=True,
@@ -1729,6 +1742,6 @@ def test_virtual_texts_false_with_location():
     )
     serializer = DoclangDocSerializer(doc=doc, params=params)
     ser_txt = serializer.serialize().text
-    
+
     exp_file = Path("./test/data/doc/virtual_texts_false_with_loc.gt.dclg.xml")
     verify(exp_file=exp_file, actual=ser_txt)

--- a/test/test_serialization_outline.py
+++ b/test/test_serialization_outline.py
@@ -55,8 +55,11 @@ def test_outline_serializer_mode_toc_custom():
     exp_path = doc_path.with_suffix(".custom.gt.md")
 
     doc = DoclingDocument.load_from_json(filename=doc_path)
-    params = OutlineParams(include_non_meta=True, mode=OutlineMode.TABLE_OF_CONTENTS, labels={
-        DocItemLabel.TITLE, DocItemLabel.SECTION_HEADER, DocItemLabel.TABLE})
+    params = OutlineParams(
+        include_non_meta=True,
+        mode=OutlineMode.TABLE_OF_CONTENTS,
+        labels={DocItemLabel.TITLE, DocItemLabel.SECTION_HEADER, DocItemLabel.TABLE},
+    )
     ser = OutlineDocSerializer(doc=doc, params=params)
     result = ser.serialize()
 
@@ -113,8 +116,7 @@ def test_outline_serializer_include_non_meta_false():
 
     assert isinstance(result.text, str)
     assert len(result.text) > 0, (
-        "Outline should show structure (references) and metadata (summaries) "
-        "even when include_non_meta=False"
+        "Outline should show structure (references) and metadata (summaries) even when include_non_meta=False"
     )
     assert "\\[ref=" in result.text, "Should include references"
 
@@ -126,9 +128,7 @@ def test_outline_serializer_empty_document():
     # Create a minimal document
     doc = DoclingDocument(name="test_doc")
 
-    params = OutlineParams(
-        include_non_meta=True, mode=OutlineMode.TABLE_OF_CONTENTS
-    )
+    params = OutlineParams(include_non_meta=True, mode=OutlineMode.TABLE_OF_CONTENTS)
     ser = OutlineDocSerializer(doc=doc, params=params)
     result = ser.serialize()
 
@@ -144,11 +144,7 @@ def test_outline_serializer_json_format():
     doc = DoclingDocument.load_from_json(filename=doc_path)
 
     # Test with include_non_meta=True (includes titles)
-    params = OutlineParams(
-        include_non_meta=True,
-        mode=OutlineMode.TABLE_OF_CONTENTS,
-        format=OutlineFormat.JSON
-    )
+    params = OutlineParams(include_non_meta=True, mode=OutlineMode.TABLE_OF_CONTENTS, format=OutlineFormat.JSON)
     ser = OutlineDocSerializer(doc=doc, params=params)
     result = ser.serialize()
 
@@ -206,11 +202,7 @@ def test_outline_serializer_json_format():
     doc_path = Path("test/data/doc/2408.09869v5_enriched_summary.json")
     exp_path_hier = doc_path.with_suffix(".outline.gt.json")
     doc = DoclingDocument.load_from_json(filename=doc_path)
-    params = OutlineParams(
-        include_non_meta=True,
-        mode=OutlineMode.OUTLINE,
-        format=OutlineFormat.JSON
-    )
+    params = OutlineParams(include_non_meta=True, mode=OutlineMode.OUTLINE, format=OutlineFormat.JSON)
     ser = OutlineDocSerializer(doc=doc, params=params)
     result = ser.serialize()
 
@@ -228,7 +220,9 @@ def test_outline_serializer_json_format():
     has_table = any(item["item"] == "table" for item in data)
     assert has_table, f"In document {doc_path.name} at least some items should be of type 'table' in outline mode"
     has_table_summary = any(item["item"] == "table" and "summary" in item for item in data)
-    assert has_table_summary, f"In document {doc_path.name} at least a table has a summary and should appear in outline mode"
+    assert has_table_summary, (
+        f"In document {doc_path.name} at least a table has a summary and should appear in outline mode"
+    )
 
     assert_or_generate_ground_truth(result.text, exp_path_hier, is_json=True)
 
@@ -240,11 +234,7 @@ def test_outline_serializer_json_format_without_non_meta():
     doc = DoclingDocument.load_from_json(filename=doc_path)
 
     # Test with include_non_meta=False (no titles, only refs and summaries)
-    params = OutlineParams(
-        include_non_meta=False,
-        mode=OutlineMode.TABLE_OF_CONTENTS,
-        format=OutlineFormat.JSON
-    )
+    params = OutlineParams(include_non_meta=False, mode=OutlineMode.TABLE_OF_CONTENTS, format=OutlineFormat.JSON)
     ser = OutlineDocSerializer(doc=doc, params=params)
     result = ser.serialize()
 
@@ -273,11 +263,7 @@ def test_outline_serializer_itxt_format():
     doc = DoclingDocument.load_from_json(filename=doc_path)
 
     # Test with include_non_meta=True (includes titles)
-    params = OutlineParams(
-        include_non_meta=True,
-        mode=OutlineMode.TABLE_OF_CONTENTS,
-        format=OutlineFormat.ITXT
-    )
+    params = OutlineParams(include_non_meta=True, mode=OutlineMode.TABLE_OF_CONTENTS, format=OutlineFormat.ITXT)
     ser = OutlineDocSerializer(doc=doc, params=params)
     result = ser.serialize()
 
@@ -322,11 +308,7 @@ def test_outline_serializer_itxt_format_without_non_meta():
     doc = DoclingDocument.load_from_json(filename=doc_path)
 
     # Test with include_non_meta=False (no titles, only refs and summaries)
-    params = OutlineParams(
-        include_non_meta=False,
-        mode=OutlineMode.TABLE_OF_CONTENTS,
-        format=OutlineFormat.ITXT
-    )
+    params = OutlineParams(include_non_meta=False, mode=OutlineMode.TABLE_OF_CONTENTS, format=OutlineFormat.ITXT)
     ser = OutlineDocSerializer(doc=doc, params=params)
     result = ser.serialize()
 
@@ -345,7 +327,9 @@ def test_outline_serializer_itxt_format_without_non_meta():
             # Format without title: [ref=...] summary
             # Format with title: [ref=...] [Title] summary
             bracket_count = line.count("[")
-            assert bracket_count == 1, f"Should only have ref bracket when include_non_meta=False, got {bracket_count} in: {line}"
+            assert bracket_count == 1, (
+                f"Should only have ref bracket when include_non_meta=False, got {bracket_count} in: {line}"
+            )
 
 
 def test_format_indented_text_line():
@@ -353,11 +337,7 @@ def test_format_indented_text_line():
 
     # Test with short summary (should not be truncated)
     item_short = OutlineItemData(
-        ref="#/texts/0",
-        item="section_header",
-        title="Introduction",
-        summary="This is a short summary.",
-        level=1
+        ref="#/texts/0", item="section_header", title="Introduction", summary="This is a short summary.", level=1
     )
     result = _format_indented_text_line(item_short, indent_size=2, max_summary_length=100)
     assert result == "  [ref=#/texts/0] [Introduction] This is a short summary."
@@ -366,11 +346,7 @@ def test_format_indented_text_line():
     # Test with long summary (should be truncated)
     long_summary = "A" * 150  # 150 characters
     item_long = OutlineItemData(
-        ref="#/texts/1",
-        item="section_header",
-        title="Long Section",
-        summary=long_summary,
-        level=2
+        ref="#/texts/1", item="section_header", title="Long Section", summary=long_summary, level=2
     )
     result = _format_indented_text_line(item_long, indent_size=2, max_summary_length=50)
     assert result.startswith("    [ref=#/texts/1] [Long Section] ")
@@ -378,37 +354,24 @@ def test_format_indented_text_line():
     assert len(result.split("] ")[-1]) == 50, "Truncated summary should be exactly max_summary_length"
 
     # Test without title
-    item_no_title = OutlineItemData(
-        ref="#/texts/2",
-        item="paragraph",
-        summary="Summary without title",
-        level=0
-    )
+    item_no_title = OutlineItemData(ref="#/texts/2", item="paragraph", summary="Summary without title", level=0)
     result = _format_indented_text_line(item_no_title, indent_size=2, max_summary_length=100)
     assert result == "[ref=#/texts/2] Summary without title"
     assert "[" not in result.split("] ", 1)[1], "Should not have title brackets"
 
     # Test without summary
-    item_no_summary = OutlineItemData(
-        ref="#/texts/3",
-        item="title",
-        title="Title Only",
-        level=1
-    )
+    item_no_summary = OutlineItemData(ref="#/texts/3", item="title", title="Title Only", level=1)
     result = _format_indented_text_line(item_no_summary, indent_size=2, max_summary_length=100)
     assert result == "  [ref=#/texts/3] [Title Only]"
 
     # Test with different indent sizes
     item_indent = OutlineItemData(
-        ref="#/texts/4",
-        item="section_header",
-        title="Nested",
-        summary="Nested content",
-        level=3
+        ref="#/texts/4", item="section_header", title="Nested", summary="Nested content", level=3
     )
     result = _format_indented_text_line(item_indent, indent_size=3, max_summary_length=100)
     assert result.startswith(" " * 9)  # 3 spaces * level 3
     assert "[ref=#/texts/4] [Nested] Nested content" in result
+
 
 @pytest.mark.filterwarnings("ignore:Pydantic serializer warnings:UserWarning")
 def test_outline_serialization_from_item():
@@ -416,11 +379,7 @@ def test_outline_serialization_from_item():
 
     doc_path = Path("test/data/doc/2408.09869v5_hierarchical_enriched_summary.json")
     doc = DoclingDocument.load_from_json(filename=doc_path)
-    params = OutlineParams(
-        include_non_meta=True,
-        mode=OutlineMode.TABLE_OF_CONTENTS,
-        format=OutlineFormat.JSON
-    )
+    params = OutlineParams(include_non_meta=True, mode=OutlineMode.TABLE_OF_CONTENTS, format=OutlineFormat.JSON)
 
     ser = OutlineDocSerializer(doc=doc, params=params)
     doc_out = ser.serialize()
@@ -429,10 +388,7 @@ def test_outline_serialization_from_item():
     # Test 1: Serialize from a nested item using start_item parameter
     nested_item = RefItem(cref="#/texts/25").resolve(doc)
     params_with_start = OutlineParams(
-        include_non_meta=True,
-        mode=OutlineMode.TABLE_OF_CONTENTS,
-        format=OutlineFormat.JSON,
-        start_item=nested_item
+        include_non_meta=True, mode=OutlineMode.TABLE_OF_CONTENTS, format=OutlineFormat.JSON, start_item=nested_item
     )
     ser_nested = OutlineDocSerializer(doc=doc, params=params_with_start)
     nested_out = ser_nested.serialize()
@@ -448,8 +404,9 @@ def test_outline_serialization_from_item():
 
     # Check that the nested item is included
     nested_ref = nested_item.self_ref
-    assert any(item_data["ref"] == nested_ref for item_data in nested_data), \
+    assert any(item_data["ref"] == nested_ref for item_data in nested_data), (
         f"Nested item {nested_ref} should be in the output"
+    )
 
     # Verify that all items in nested_data are either the nested_item or its descendants
     # Expected: #/texts/25 (level 2) and its 7 children (all level 3)
@@ -465,10 +422,7 @@ def test_outline_serialization_from_item():
 
     # Test 2: Serialize with maximum level
     params_with_max_level = OutlineParams(
-        include_non_meta=True,
-        mode=OutlineMode.TABLE_OF_CONTENTS,
-        format=OutlineFormat.JSON,
-        max_level=2
+        include_non_meta=True, mode=OutlineMode.TABLE_OF_CONTENTS, format=OutlineFormat.JSON, max_level=2
     )
     ser_max_level = OutlineDocSerializer(doc=doc, params=params_with_max_level)
     max_level_out = ser_max_level.serialize()
@@ -489,7 +443,7 @@ def test_outline_serialization_from_item():
         mode=OutlineMode.TABLE_OF_CONTENTS,
         format=OutlineFormat.JSON,
         start_item=nested_item,
-        max_level=2
+        max_level=2,
     )
     ser_combined = OutlineDocSerializer(doc=doc, params=params_combined)
     combined_out = ser_combined.serialize()
@@ -503,10 +457,7 @@ def test_outline_serialization_from_item():
 
     # Test 4: Test with OUTLINE mode (includes all items, not just headings)
     params_outline_max = OutlineParams(
-        include_non_meta=True,
-        mode=OutlineMode.OUTLINE,
-        format=OutlineFormat.JSON,
-        max_level=2
+        include_non_meta=True, mode=OutlineMode.OUTLINE, format=OutlineFormat.JSON, max_level=2
     )
     ser_outline_max = OutlineDocSerializer(doc=doc, params=params_outline_max)
     outline_max_out = ser_outline_max.serialize()
@@ -519,10 +470,7 @@ def test_outline_serialization_from_item():
 
     # Test 5: Test with Markdown format
     params_md_max = OutlineParams(
-        include_non_meta=True,
-        mode=OutlineMode.TABLE_OF_CONTENTS,
-        format=OutlineFormat.MARKDOWN,
-        max_level=2
+        include_non_meta=True, mode=OutlineMode.TABLE_OF_CONTENTS, format=OutlineFormat.MARKDOWN, max_level=2
     )
     ser_md_max = OutlineDocSerializer(doc=doc, params=params_md_max)
     md_max_out = ser_md_max.serialize()
@@ -534,10 +482,7 @@ def test_outline_serialization_from_item():
     assert "#### OCR\n\\[ref=#/texts/58\\]" not in md_max_out.text
 
     params_md_start = OutlineParams(
-        include_non_meta=True,
-        mode=OutlineMode.TABLE_OF_CONTENTS,
-        format=OutlineFormat.MARKDOWN,
-        start_item=nested_item
+        include_non_meta=True, mode=OutlineMode.TABLE_OF_CONTENTS, format=OutlineFormat.MARKDOWN, start_item=nested_item
     )
     ser_md_start = OutlineDocSerializer(doc=doc, params=params_md_start)
     md_start_out = ser_md_start.serialize()
@@ -552,10 +497,7 @@ def test_outline_serialization_from_item():
 
     # Test 6: Test with ITXT format
     params_itxt_max = OutlineParams(
-        include_non_meta=True,
-        mode=OutlineMode.TABLE_OF_CONTENTS,
-        format=OutlineFormat.ITXT,
-        max_level=2
+        include_non_meta=True, mode=OutlineMode.TABLE_OF_CONTENTS, format=OutlineFormat.ITXT, max_level=2
     )
     ser_itxt_max = OutlineDocSerializer(doc=doc, params=params_itxt_max)
     itxt_max_out = ser_itxt_max.serialize()
@@ -567,10 +509,7 @@ def test_outline_serialization_from_item():
     assert "[ref=#/texts/58]" not in itxt_max_out.text
 
     params_itxt_start = OutlineParams(
-        include_non_meta=True,
-        mode=OutlineMode.TABLE_OF_CONTENTS,
-        format=OutlineFormat.ITXT,
-        start_item=nested_item
+        include_non_meta=True, mode=OutlineMode.TABLE_OF_CONTENTS, format=OutlineFormat.ITXT, start_item=nested_item
     )
     ser_itxt_start = OutlineDocSerializer(doc=doc, params=params_itxt_start)
     itxt_start_out = ser_itxt_start.serialize()
@@ -592,126 +531,106 @@ def test_outline_serialization_from_item():
     assert first_line.startswith("[ref=#/texts/25]"), "First line should be the start_item"
 
 
-
 @pytest.mark.filterwarnings("ignore:Pydantic serializer warnings:UserWarning")
 def test_outline_serialization_spans():
     """Test that serialization results preserve spans for get_unique_doc_items()."""
     doc_path = Path("test/data/doc/2408.09869v5_hierarchical_enriched_summary.json")
     doc = DoclingDocument.load_from_json(filename=doc_path)
-    
+
     # Get a nested item to use as start_item
     nested_item = RefItem(cref="#/texts/25").resolve(doc)
-    
+
     # Test 1: JSON format with start_item
     params_json = OutlineParams(
-        include_non_meta=True,
-        mode=OutlineMode.TABLE_OF_CONTENTS,
-        format=OutlineFormat.JSON,
-        start_item=nested_item
+        include_non_meta=True, mode=OutlineMode.TABLE_OF_CONTENTS, format=OutlineFormat.JSON, start_item=nested_item
     )
     ser_json = OutlineDocSerializer(doc=doc, params=params_json)
     result_json = ser_json.serialize()
-    
+
     # Verify spans are present
     assert len(result_json.spans) > 0, "JSON format should have spans"
-    
+
     # Get unique doc items
     doc_items_json = result_json.get_unique_doc_items()
     assert len(doc_items_json) > 0, "Should have doc items from spans"
-    
+
     # Verify the items match what's in the JSON output
     json_data = json.loads(result_json.text)
     json_refs = {item["ref"] for item in json_data}
     span_refs = {item.self_ref for item in doc_items_json}
-    
+
     # All items in JSON should have corresponding spans
     assert json_refs == span_refs, f"JSON refs {json_refs} should match span refs {span_refs}"
-    
+
     # Test 2: Markdown format with max_level
     params_md = OutlineParams(
-        include_non_meta=True,
-        mode=OutlineMode.TABLE_OF_CONTENTS,
-        format=OutlineFormat.MARKDOWN,
-        max_level=2
+        include_non_meta=True, mode=OutlineMode.TABLE_OF_CONTENTS, format=OutlineFormat.MARKDOWN, max_level=2
     )
     ser_md = OutlineDocSerializer(doc=doc, params=params_md)
     result_md = ser_md.serialize()
-    
+
     # Verify spans are present
     assert len(result_md.spans) > 0, "Markdown format should have spans"
-    
+
     # Get unique doc items
     doc_items_md = result_md.get_unique_doc_items()
     assert len(doc_items_md) > 0, "Should have doc items from spans"
-    
+
     # Verify items are in the markdown text
     for item in doc_items_md:
-        assert f"\\[ref={item.self_ref}\\]" in result_md.text, \
-            f"Item {item.self_ref} should be in markdown text"
-    
+        assert f"\\[ref={item.self_ref}\\]" in result_md.text, f"Item {item.self_ref} should be in markdown text"
+
     # Test 3: ITXT format with start_item
     params_itxt = OutlineParams(
-        include_non_meta=True,
-        mode=OutlineMode.TABLE_OF_CONTENTS,
-        format=OutlineFormat.ITXT,
-        start_item=nested_item
+        include_non_meta=True, mode=OutlineMode.TABLE_OF_CONTENTS, format=OutlineFormat.ITXT, start_item=nested_item
     )
     ser_itxt = OutlineDocSerializer(doc=doc, params=params_itxt)
     result_itxt = ser_itxt.serialize()
-    
+
     # Verify spans are present
     assert len(result_itxt.spans) > 0, "ITXT format should have spans"
-    
+
     # Get unique doc items
     doc_items_itxt = result_itxt.get_unique_doc_items()
     assert len(doc_items_itxt) > 0, "Should have doc items from spans"
-    
+
     # Verify items are in the ITXT text
     for item in doc_items_itxt:
-        assert f"[ref={item.self_ref}]" in result_itxt.text, \
-            f"Item {item.self_ref} should be in ITXT text"
-    
+        assert f"[ref={item.self_ref}]" in result_itxt.text, f"Item {item.self_ref} should be in ITXT text"
+
     # Test 4: Verify filtering consistency across formats
     # All three formats with the same start_item should have the same doc items
     params_json_filtered = OutlineParams(
-        include_non_meta=True,
-        mode=OutlineMode.TABLE_OF_CONTENTS,
-        format=OutlineFormat.JSON,
-        start_item=nested_item
+        include_non_meta=True, mode=OutlineMode.TABLE_OF_CONTENTS, format=OutlineFormat.JSON, start_item=nested_item
     )
     params_md_filtered = OutlineParams(
-        include_non_meta=True,
-        mode=OutlineMode.TABLE_OF_CONTENTS,
-        format=OutlineFormat.MARKDOWN,
-        start_item=nested_item
+        include_non_meta=True, mode=OutlineMode.TABLE_OF_CONTENTS, format=OutlineFormat.MARKDOWN, start_item=nested_item
     )
     params_itxt_filtered = OutlineParams(
-        include_non_meta=True,
-        mode=OutlineMode.TABLE_OF_CONTENTS,
-        format=OutlineFormat.ITXT,
-        start_item=nested_item
+        include_non_meta=True, mode=OutlineMode.TABLE_OF_CONTENTS, format=OutlineFormat.ITXT, start_item=nested_item
     )
-    
+
     ser_json_f = OutlineDocSerializer(doc=doc, params=params_json_filtered)
     ser_md_f = OutlineDocSerializer(doc=doc, params=params_md_filtered)
     ser_itxt_f = OutlineDocSerializer(doc=doc, params=params_itxt_filtered)
-    
+
     result_json_f = ser_json_f.serialize()
     result_md_f = ser_md_f.serialize()
     result_itxt_f = ser_itxt_f.serialize()
-    
+
     items_json_f = result_json_f.get_unique_doc_items()
     items_md_f = result_md_f.get_unique_doc_items()
     items_itxt_f = result_itxt_f.get_unique_doc_items()
-    
+
     refs_json_f = {item.self_ref for item in items_json_f}
     refs_md_f = {item.self_ref for item in items_md_f}
     refs_itxt_f = {item.self_ref for item in items_itxt_f}
-    
+
     # All formats should have the same set of item references
-    assert refs_json_f == refs_md_f == refs_itxt_f, \
+    assert refs_json_f == refs_md_f == refs_itxt_f, (
         f"All formats should have same items: JSON={refs_json_f}, MD={refs_md_f}, ITXT={refs_itxt_f}"
-    
+    )
+
     # Verify the expected items are present (nested_item and its 7 children)
     assert len(items_json_f) == 8, f"Expected 8 items, got {len(items_json_f)}"
     assert nested_item.self_ref in refs_json_f, "Start item should be included"

--- a/test/test_webvtt.py
+++ b/test/test_webvtt.py
@@ -135,20 +135,12 @@ def test_vtt_cue_commponents() -> None:
     valid_classes = ["class1", "class2"]
     invalid_classes = ["class\nwith\nnewlines", ""]
     with pytest.raises(ValidationError):
-        WebVTTCueSpanStartTagAnnotated(
-            name="v", annotation=annotation, classes=invalid_classes
-        )
-    assert WebVTTCueSpanStartTagAnnotated(
-        name="v", annotation=annotation, classes=valid_classes
-    )
+        WebVTTCueSpanStartTagAnnotated(name="v", annotation=annotation, classes=invalid_classes)
+    assert WebVTTCueSpanStartTagAnnotated(name="v", annotation=annotation, classes=valid_classes)
 
     """Test that components validation works correctly."""
     annotation = "speaker name"
-    valid_components = [
-        WebVTTCueComponentWithTerminator(
-            component=WebVTTCueTextSpan(text="random text")
-        )
-    ]
+    valid_components = [WebVTTCueComponentWithTerminator(component=WebVTTCueTextSpan(text="random text"))]
     invalid_components = [123, "not a component"]
     with pytest.raises(ValidationError):
         WebVTTCueInternalText(components=invalid_components)
@@ -156,15 +148,9 @@ def test_vtt_cue_commponents() -> None:
 
     """Test valid cue voice spans."""
     cue_span = WebVTTCueVoiceSpan(
-        start_tag=WebVTTCueSpanStartTagAnnotated(
-            name="v", annotation="speaker", classes=["loud", "clear"]
-        ),
+        start_tag=WebVTTCueSpanStartTagAnnotated(name="v", annotation="speaker", classes=["loud", "clear"]),
         internal_text=WebVTTCueInternalText(
-            components=[
-                WebVTTCueComponentWithTerminator(
-                    component=WebVTTCueTextSpan(text="random text")
-                )
-            ]
+            components=[WebVTTCueComponentWithTerminator(component=WebVTTCueTextSpan(text="random text"))]
         ),
     )
     expected_str = "<v.loud.clear speaker>random text</v>"
@@ -173,11 +159,7 @@ def test_vtt_cue_commponents() -> None:
     cue_span = WebVTTCueVoiceSpan(
         start_tag=WebVTTCueSpanStartTagAnnotated(name="v", annotation="speaker"),
         internal_text=WebVTTCueInternalText(
-            components=[
-                WebVTTCueComponentWithTerminator(
-                    component=WebVTTCueTextSpan(text="random text")
-                )
-            ]
+            components=[WebVTTCueComponentWithTerminator(component=WebVTTCueTextSpan(text="random text"))]
         ),
     )
     expected_str = "<v speaker>random text</v>"
@@ -186,24 +168,18 @@ def test_vtt_cue_commponents() -> None:
 
 def test_webvttcueblock_parse() -> None:
     """Test the method parse of _WebVTTCueBlock class."""
-    raw: str = (
-        "04:02.500 --> 04:05.000\n" "J’ai commencé le basket à l'âge de 13, 14 ans\n"  # noqa: RUF001
-    )
+    raw: str = "04:02.500 --> 04:05.000\nJ’ai commencé le basket à l'âge de 13, 14 ans\n"  # noqa: RUF001
     block: WebVTTCueBlock = WebVTTCueBlock.parse(raw)
     assert str(block.timings) == "04:02.500 --> 04:05.000"
     assert len(block.payload) == 1
     assert isinstance(block.payload[0], WebVTTCueComponentWithTerminator)
     assert isinstance(block.payload[0].component, WebVTTCueTextSpan)
     assert (
-        block.payload[0].component.text
-        == "J’ai commencé le basket à l'âge de 13, 14 ans"  # noqa: RUF001
+        block.payload[0].component.text == "J’ai commencé le basket à l'âge de 13, 14 ans"  # noqa: RUF001
     )
     assert raw == str(block)
 
-    raw = (
-        "04:05.001 --> 04:07.800\n"
-        "Sur les <i.foreignphrase><lang en>playground</lang></i>, ici à Montpellier\n"
-    )
+    raw = "04:05.001 --> 04:07.800\nSur les <i.foreignphrase><lang en>playground</lang></i>, ici à Montpellier\n"
     block = WebVTTCueBlock.parse(raw)
     assert str(block.timings) == "04:05.001 --> 04:07.800"
     assert len(block.payload) == 3
@@ -215,9 +191,7 @@ def test_webvttcueblock_parse() -> None:
     assert len(block.payload[1].component.internal_text.components) == 1
     lang_span = block.payload[1].component.internal_text.components[0].component
     assert isinstance(lang_span, WebVTTCueLanguageSpan)
-    assert isinstance(
-        lang_span.internal_text.components[0].component, WebVTTCueTextSpan
-    )
+    assert isinstance(lang_span.internal_text.components[0].component, WebVTTCueTextSpan)
     assert lang_span.internal_text.components[0].component.text == "playground"
     assert isinstance(block.payload[2], WebVTTCueComponentWithTerminator)
     assert isinstance(block.payload[2].component, WebVTTCueTextSpan)
@@ -250,16 +224,8 @@ def test_webvtt_file() -> None:
         content = f.read()
         vtt = WebVTTFile.parse(content)
     assert len(vtt) == 4
-    reverse = (
-        "WEBVTT\n\nNOTE Copyright © 2019 World Wide Web Consortium. "
-        "https://www.w3.org/TR/webvtt1/\n\n"
-    )
-    reverse += "\n".join(
-        [
-            block.format(omit_hours_if_zero=True, omit_voice_end=True)
-            for block in vtt.cue_blocks
-        ]
-    )
+    reverse = "WEBVTT\n\nNOTE Copyright © 2019 World Wide Web Consortium. https://www.w3.org/TR/webvtt1/\n\n"
+    reverse += "\n".join([block.format(omit_hours_if_zero=True, omit_voice_end=True) for block in vtt.cue_blocks])
     assert content == reverse.rstrip()
 
     with open("./test/data/webvtt/webvtt_example_03.vtt", encoding="utf-8") as f:


### PR DESCRIPTION
## Summary

`save_as_markdown()` was missing five parameters that exist in `export_to_markdown()`
and were never forwarded to the internal call.

Fixes #619 (docling-project/docling)

## Changes

Added the following parameters to `save_as_markdown()` and forwarded them to `export_to_markdown()`:
- `enable_chart_tables` (default: `True`)
- `mark_annotations` (default: `False`)
- `traverse_pictures` (default: `False`)
- `allowed_meta_names` (default: `None`)
- `blocked_meta_names` (default: `None`)

Also addressed the naming inconsistency:
- Added `escape_underscores` as the canonical parameter name (consistent with `export_to_markdown`)
- Kept `escaping_underscores` as a deprecated alias with a `DeprecationWarning` for backward compatibility

## Impact Analysis

`save_as_markdown` is a wrapper that calls `export_to_markdown` internally.
The added parameters are simply forwarded — no logic changes, no side effects.
All new parameters have safe defaults matching `export_to_markdown` behavior,
so existing callers are unaffected.

For `escaping_underscores`, the deprecated alias path only triggers when
explicitly passed, so backward compatibility is preserved.

## Verification

Tested all new parameters against the Docling technical report PDF:

```
✅ traverse_pictures: OK
✅ allowed_meta_names: OK
✅ blocked_meta_names: OK
✅ enable_chart_tables: OK
✅ mark_annotations: OK
✅ escaping_underscores deprecated alias: OK (warning: 'Parameter `escaping_underscores` is deprecated, use `escape_underscores` instead.')
```

All cases work as expected. Existing callers are unaffected.

## Testing

Existing markdown tests pass.