### PR TITLE
fix: handle page-less documents in table doctags export

### DIFF
--- a/docling_core/types/doc/document.py
+++ b/docling_core/types/doc/document.py
@@ -2590,10 +2590,11 @@ class TableItem(FloatingItem):
                     cell.start_col_offset_idx,
                 )
 
-                if len(doc.pages.keys()):
-                    page_w, page_h = doc.pages[page_no].size.as_tuple()
+                has_page_info = page_no in doc.pages
+
                 cell_loc = ""
-                if cell.bbox is not None:
+                if cell.bbox is not None and has_page_info:
+                    page_w, page_h = doc.pages[page_no].size.as_tuple()
                     cell_loc = DocumentToken.get_location(
                         bbox=cell.bbox.to_bottom_left_origin(page_h).as_tuple(),
                         page_w=page_w,

--- a/test/test_otsl_table_export.py
+++ b/test/test_otsl_table_export.py
@@ -1,5 +1,5 @@
 from docling_core.types.doc.document import DoclingDocument, TableCell, TableData
-
+from docling_core.types.doc.base import BoundingBox
 
 def test_table_export_to_otsl():
     data_table_cells = []
@@ -283,3 +283,28 @@ def test_table_export_to_otsl():
         otsl_string
         == "<rhed><lcel><rhed><fcel><xcel><xcel><nl><rhed><fcel><fcel><xcel><xcel><xcel><nl><rhed><fcel><fcel><fcel><ecel><ecel><nl><ucel><fcel><fcel><fcel><fcel><fcel><nl><srow><lcel><lcel><lcel><lcel><lcel><nl>"
     )
+
+
+def test_table_export_to_otsl_page_less_document_with_cell_bbox():
+    doc = DoclingDocument(name="page_less_doc")
+
+    data = TableData(
+        num_rows=1,
+        num_cols=1,
+        table_cells=[
+            TableCell(
+                text="cell",
+                row_span=1,
+                col_span=1,
+                start_row_offset_idx=0,
+                end_row_offset_idx=1,
+                start_col_offset_idx=0,
+                end_col_offset_idx=1,
+                bbox=BoundingBox(l=0, t=0, r=10, b=10),
+            )
+        ],
+    )
+
+    table = doc.add_table(data=data)
+
+    assert table.export_to_otsl(doc=doc)

--- a/test/test_otsl_table_export.py
+++ b/test/test_otsl_table_export.py
@@ -1,5 +1,6 @@
-from docling_core.types.doc.document import DoclingDocument, TableCell, TableData
 from docling_core.types.doc.base import BoundingBox
+from docling_core.types.doc.document import DoclingDocument, TableCell, TableData
+
 
 def test_table_export_to_otsl():
     data_table_cells = []


### PR DESCRIPTION
## Summary

Fixes #90 by handling page-less documents during table DocTags export.

While investigating the issue, I found that `TableItem.export_to_otsl()` attempted to generate location tokens for table cells with bounding boxes even when the document contained no page metadata. In this situation, `page_w` and `page_h` were unavailable, resulting in:

```python
UnboundLocalError: cannot access local variable 'page_h'
```

## Changes

* Only generate cell location tokens when page information is available.
* Added a regression test covering a page-less document with a table cell that has a bounding box.

## Testing

Added:

* `test_table_export_to_otsl_page_less_document_with_cell_bbox`

Verified that:

* The test reproduces the issue before the fix.
* The test passes after the fix.
* Existing OTSL export tests continue to pass.
