### PR TITLE
feat: Make HTTP downloads respect file-size limits and abort early

### DIFF
--- a/docling_core/utils/file.py
+++ b/docling_core/utils/file.py
@@ -17,6 +17,11 @@ from docling_core.types.io import DocumentStream
 
 _MAX_REDIRECTS = 5
 
+# Chunk size for streaming remote downloads. Sized for document payloads (PDFs
+# and similar), which are either small or in the multi-megabyte range, so a
+# large chunk keeps the read loop short without wasting memory.
+_DOWNLOAD_CHUNK_SIZE = 512 * 1024
+
 
 class FileSizeLimitExceededError(ValueError):
     """Raised when a remote file exceeds the configured download size limit."""
@@ -113,12 +118,16 @@ def resolve_source_to_stream(
     """Resolves the source (URL, path) of a file to a binary stream.
 
     Args:
-        source (Path | AnyHttpUrl | str): The file input source. Can be a path or URL.
-        headers (Optional[dict[str, str]]): Optional set of headers to use for fetching
-            the remote URL.
+        source: The file input source. Can be a path or URL.
+        headers: Optional set of headers to use for fetching the remote URL.
+        max_file_size: Optional maximum size, in bytes, for a remote download.
+            When set, the download is rejected upfront if the declared
+            ``Content-Length`` exceeds it, and aborted while streaming as soon as
+            the received bytes exceed it.
 
     Raises:
         ValueError: If source is of unexpected type.
+        FileSizeLimitExceededError: If a remote download exceeds ``max_file_size``.
 
     Returns:
         DocumentStream: The resolved file loaded as a stream.
@@ -210,7 +219,7 @@ def resolve_source_to_stream(
 
                 stream = BytesIO()
                 downloaded = 0
-                for chunk in res.iter_content(chunk_size=8192):
+                for chunk in res.iter_content(chunk_size=_DOWNLOAD_CHUNK_SIZE):
                     if not chunk:
                         continue
                     downloaded += len(chunk)

--- a/docling_core/utils/file.py
+++ b/docling_core/utils/file.py
@@ -18,6 +18,16 @@ from docling_core.types.io import DocumentStream
 _MAX_REDIRECTS = 5
 
 
+class FileSizeLimitExceededError(ValueError):
+    """Raised when a remote file exceeds the configured download size limit."""
+
+    def __init__(self, filename: str, size: int, limit: int):
+        self.filename = filename
+        self.size = size
+        self.limit = limit
+        super().__init__(f"Remote file exceeds the maximum allowed size ({size} > {limit} bytes).")
+
+
 def _is_safe_url(url: str) -> bool:
     """Return whether a URL resolves to a globally routable address."""
     try:
@@ -96,7 +106,9 @@ def resolve_remote_filename(
 
 
 def resolve_source_to_stream(
-    source: Union[Path, AnyHttpUrl, str], headers: Optional[dict[str, str]] = None
+    source: Union[Path, AnyHttpUrl, str],
+    headers: Optional[dict[str, str]] = None,
+    max_file_size: Optional[int] = None,
 ) -> DocumentStream:
     """Resolves the source (URL, path) of a file to a binary stream.
 
@@ -150,9 +162,6 @@ def resolve_source_to_stream(
 
             http_url = TypeAdapter(AnyHttpUrl).validate_python(url_str)
 
-        session = requests.Session()
-        session.max_redirects = _MAX_REDIRECTS
-
         def _check_redirect_safety(response, *args, **kwargs):
             """Validate each redirect target before following it."""
             if response.is_redirect or response.is_permanent_redirect:
@@ -166,21 +175,54 @@ def resolve_source_to_stream(
                     if not _is_safe_url(redirect_url):
                         raise ValueError(f"Redirect target is not allowed: {redirect_url}")
 
-        session.hooks["response"].append(_check_redirect_safety)
+        # Use context managers so the session and the streamed response are
+        # always released, including on the size-limit abort paths below where
+        # the response body is left unconsumed.
+        with requests.Session() as session:
+            session.max_redirects = _MAX_REDIRECTS
+            session.hooks["response"].append(_check_redirect_safety)
 
-        res = session.get(
-            url_str,
-            stream=True,
-            headers=req_headers,
-            allow_redirects=True,
-        )
-        res.raise_for_status()
+            with session.get(
+                url_str,
+                stream=True,
+                headers=req_headers,
+                allow_redirects=True,
+            ) as res:
+                res.raise_for_status()
 
-        response_headers = dict(res.headers)
-        fname = resolve_remote_filename(http_url=http_url, response_headers=response_headers)
+                response_headers = dict(res.headers)
+                fname = resolve_remote_filename(http_url=http_url, response_headers=response_headers)
 
-        stream = BytesIO(res.content)
-        doc_stream = DocumentStream(name=fname, stream=stream)
+                if max_file_size is not None:
+                    content_length = res.headers.get("Content-Length")
+                    if content_length is not None:
+                        try:
+                            content_length_value = int(content_length)
+                        except ValueError:
+                            content_length_value = None
+
+                        if content_length_value is not None and content_length_value > max_file_size:
+                            raise FileSizeLimitExceededError(
+                                filename=fname,
+                                size=content_length_value,
+                                limit=max_file_size,
+                            )
+
+                stream = BytesIO()
+                downloaded = 0
+                for chunk in res.iter_content(chunk_size=8192):
+                    if not chunk:
+                        continue
+                    downloaded += len(chunk)
+                    if max_file_size is not None and downloaded > max_file_size:
+                        raise FileSizeLimitExceededError(
+                            filename=fname,
+                            size=downloaded,
+                            limit=max_file_size,
+                        )
+                    stream.write(chunk)
+                stream.seek(0)
+                doc_stream = DocumentStream(name=fname, stream=stream)
     except ValidationError:
         if isinstance(source, str) and "://" in source:
             scheme = source.split("://", 1)[0].lower()

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -4,13 +4,20 @@ import json
 from io import BytesIO
 from pathlib import Path
 
+import pytest
 from pydantic import Field
-from requests import Response
+from requests import Response, Session
 
 from docling_core.types.doc import DocItemLabel, DoclingDocument, TableData
 from docling_core.types.doc.document import GroupLabel, RichTableCell
 from docling_core.utils.alias import AliasModel
-from docling_core.utils.file import resolve_source_to_path, resolve_source_to_stream
+from docling_core.utils.file import (
+    _MAX_REDIRECTS,
+    _is_safe_url,
+    _sanitize_filename,
+    resolve_source_to_path,
+    resolve_source_to_stream,
+)
 
 from .test_data_gen_flag import GEN_TEST_DATA
 
@@ -193,8 +200,6 @@ def test_resolve_source_to_stream_url_wout_path(monkeypatch):
 
 def test_sanitize_filename_paths():
     """Test filename sanitization for path-like inputs."""
-    from docling_core.utils.file import _sanitize_filename
-
     assert _sanitize_filename("../../etc/config.txt") == "config.txt"
 
     assert _sanitize_filename("/etc/config.txt") == "config.txt"
@@ -214,8 +219,6 @@ def test_sanitize_filename_paths():
 
 def test_is_safe_url_rejects_private_networks():
     """Test URL filtering for non-public network ranges."""
-    from docling_core.utils.file import _is_safe_url
-
     assert not _is_safe_url("http://10.0.0.1/file")
     assert not _is_safe_url("http://172.16.0.1/file")
     assert not _is_safe_url("http://192.168.1.1/file")
@@ -235,9 +238,6 @@ def test_is_safe_url_rejects_private_networks():
 
 def test_resolve_remote_filename_sanitizes_content_disposition(monkeypatch):
     """Test filename normalization from Content-Disposition."""
-    from requests import Response
-
-    from docling_core.utils.file import resolve_source_to_stream
 
     def get_response(*args, **kwargs):
         return _closeable_response(
@@ -255,10 +255,6 @@ def test_resolve_remote_filename_sanitizes_content_disposition(monkeypatch):
 
 def test_resolve_source_rejects_non_public_urls(monkeypatch):
     """Test that non-public URLs are rejected."""
-    import pytest
-
-    from docling_core.utils.file import resolve_source_to_stream
-
     with pytest.raises(ValueError, match="URL is not allowed"):
         resolve_source_to_stream("http://127.0.0.1/file")
 
@@ -274,19 +270,12 @@ def test_resolve_source_rejects_non_public_urls(monkeypatch):
 
 def test_resolve_source_rejects_unsupported_scheme():
     """Test that unsupported URL schemes are rejected before file fallback."""
-    import pytest
-
-    from docling_core.utils.file import resolve_source_to_stream
-
     with pytest.raises(ValueError, match="Unsupported URL scheme"):
         resolve_source_to_stream("ftp://some-server/file.pdf")
 
 
 def test_resolve_source_to_path_sanitizes_filename(monkeypatch, tmp_path):
     """Test that saved filenames stay within the target directory."""
-    from requests import Response
-
-    from docling_core.utils.file import resolve_source_to_path
 
     def get_response(*args, **kwargs):
         return _closeable_response(
@@ -312,10 +301,6 @@ def test_resolve_source_to_path_sanitizes_filename(monkeypatch, tmp_path):
 
 def test_redirect_limit_enforced(monkeypatch):
     """Test that redirect limits are configured on the session."""
-    from requests import Response, Session
-
-    from docling_core.utils.file import _MAX_REDIRECTS
-
     session_created = []
 
     original_init = Session.__init__
@@ -334,8 +319,6 @@ def test_redirect_limit_enforced(monkeypatch):
 
     monkeypatch.setattr(Session, "get", mock_get)
 
-    from docling_core.utils.file import resolve_source_to_stream
-
     try:
         resolve_source_to_stream("https://example.com/file")
     except Exception:
@@ -348,10 +331,6 @@ def test_redirect_limit_enforced(monkeypatch):
 
 def test_redirect_to_non_public_ip_rejected(monkeypatch):
     """Test that redirects to non-public addresses are rejected."""
-    import pytest
-    from requests import Response, Session
-
-    from docling_core.utils.file import resolve_source_to_stream
 
     def mock_get_with_redirect(self, *args, **kwargs):
         r = Response()
@@ -372,11 +351,6 @@ def test_redirect_to_non_public_ip_rejected(monkeypatch):
 
 
 def test_resolve_source_rejects_large_content_length(monkeypatch):
-    import pytest
-    from requests import Response, Session
-
-    from docling_core.utils.file import resolve_source_to_stream
-
     def mock_get(self, *args, **kwargs):
         return _closeable_response(
             content=b"ignored", headers={"Content-Length": "10"}
@@ -389,11 +363,6 @@ def test_resolve_source_rejects_large_content_length(monkeypatch):
 
 
 def test_resolve_source_stops_when_stream_exceeds_limit(monkeypatch):
-    import pytest
-    from requests import Response, Session
-
-    from docling_core.utils.file import resolve_source_to_stream
-
     def mock_get(self, *args, **kwargs):
         r = _closeable_response(headers={"Content-Length": "4"})
 

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,6 +1,7 @@
 """Test the pydantic models in package utils."""
 
 import json
+from io import BytesIO
 from pathlib import Path
 
 from pydantic import Field
@@ -12,6 +13,22 @@ from docling_core.utils.alias import AliasModel
 from docling_core.utils.file import resolve_source_to_path, resolve_source_to_stream
 
 from .test_data_gen_flag import GEN_TEST_DATA
+
+
+def _closeable_response(status_code=200, content=b"", headers=None) -> Response:
+    """Build a Response with a real, closeable ``raw`` like a streamed response.
+
+    ``resolve_source_to_stream`` closes the response (via ``with``) to release the
+    streamed connection, which a bare ``Response()`` (``raw is None``) cannot do.
+    """
+    r = Response()
+    r.status_code = status_code
+    r._content = content
+    r._content_consumed = True
+    r.raw = BytesIO(content)
+    if headers:
+        r.headers.update(headers)
+    return r
 
 
 def build_single_cell_rich_table_doc(text: str) -> DoclingDocument:
@@ -223,11 +240,12 @@ def test_resolve_remote_filename_sanitizes_content_disposition(monkeypatch):
     from docling_core.utils.file import resolve_source_to_stream
 
     def get_response(*args, **kwargs):
-        r = Response()
-        r.status_code = 200
-        r._content = b"test content"
-        r.headers["Content-Disposition"] = 'attachment; filename="../../etc/config.txt"'
-        return r
+        return _closeable_response(
+            content=b"test content",
+            headers={
+                "Content-Disposition": 'attachment; filename="../../etc/config.txt"'
+            },
+        )
 
     monkeypatch.setattr("requests.Session.get", get_response)
 
@@ -271,11 +289,12 @@ def test_resolve_source_to_path_sanitizes_filename(monkeypatch, tmp_path):
     from docling_core.utils.file import resolve_source_to_path
 
     def get_response(*args, **kwargs):
-        r = Response()
-        r.status_code = 200
-        r._content = b"test content"
-        r.headers["Content-Disposition"] = 'attachment; filename="../../../../tmp/output.txt"'
-        return r
+        return _closeable_response(
+            content=b"test content",
+            headers={
+                "Content-Disposition": 'attachment; filename="../../../../tmp/output.txt"'
+            },
+        )
 
     monkeypatch.setattr("requests.Session.get", get_response)
 
@@ -350,3 +369,42 @@ def test_redirect_to_non_public_ip_rejected(monkeypatch):
 
     with pytest.raises(ValueError, match="Redirect target is not allowed"):
         resolve_source_to_stream("https://example.com/redirect")
+
+
+def test_resolve_source_rejects_large_content_length(monkeypatch):
+    import pytest
+    from requests import Response, Session
+
+    from docling_core.utils.file import resolve_source_to_stream
+
+    def mock_get(self, *args, **kwargs):
+        return _closeable_response(
+            content=b"ignored", headers={"Content-Length": "10"}
+        )
+
+    monkeypatch.setattr(Session, "get", mock_get)
+
+    with pytest.raises(ValueError, match="maximum allowed size"):
+        resolve_source_to_stream("https://example.com/file", max_file_size=5)
+
+
+def test_resolve_source_stops_when_stream_exceeds_limit(monkeypatch):
+    import pytest
+    from requests import Response, Session
+
+    from docling_core.utils.file import resolve_source_to_stream
+
+    def mock_get(self, *args, **kwargs):
+        r = _closeable_response(headers={"Content-Length": "4"})
+
+        def iter_content(chunk_size=1):
+            yield b"abcd"
+            yield b"ef"
+
+        r.iter_content = iter_content
+        return r
+
+    monkeypatch.setattr(Session, "get", mock_get)
+
+    with pytest.raises(ValueError, match="maximum allowed size"):
+        resolve_source_to_stream("https://example.com/file", max_file_size=5)


### PR DESCRIPTION
### Summary

Make remote source downloads respect a caller-provided size limit before buffering the full response in memory.

### Problem

`resolve_source_to_stream()` previously fetched remote content with `res.content` and wrapped it in `BytesIO`, which meant the full HTTP response was materialized in memory before any downstream `max_file_size` limit could be enforced.

### Changes

- Added an optional `max_file_size` parameter to `resolve_source_to_stream()`.
- Added an upfront `Content-Length` check and reject the download immediately when the declared size exceeds the configured limit.
- Replaced eager `res.content` loading with chunked `iter_content()` reading.
- Enforced the size limit while streaming so oversized downloads are aborted even when `Content-Length` is missing or incorrect.
- Introduced `FileSizeLimitExceededError` to distinguish size-limit failures from other URL/input errors while preserving safe early termination.

### Resulting behavior

- Remote files with `Content-Length > max_file_size` are rejected before any body bytes are buffered.
- Remote files without a usable `Content-Length` are downloaded only up to the configured limit, then aborted as soon as the streamed byte count exceeds it.
- Accepted remote files are still returned as `DocumentStream(BytesIO(...))`; this change prevents unbounded buffering but does not make the full pipeline end-to-end streaming.