### PR TITLE
feat: support page numbers in Markdown page breaks

### DIFF
--- a/docling_core/transforms/serializer/markdown.py
+++ b/docling_core/transforms/serializer/markdown.py
@@ -153,7 +153,8 @@ class MarkdownParams(CommonParams):
     enable_chart_tables: bool = True
     indent: int = 4
     wrap_width: Optional[PositiveInt] = None
-    page_break_placeholder: Optional[str] = None  # e.g. "<!-- page break -->"
+    # e.g. "<!-- page break -->"; supports {page_no}, {prev_page}, and {next_page}.
+    page_break_placeholder: Optional[str] = None
     escape_underscores: bool = True
     escape_html: bool = True
     mark_meta: bool = Field(default=False, description="Mark meta sections.")
@@ -938,10 +939,30 @@ class MarkdownDocSerializer(DocSerializer):
         text_res = "\n\n".join([p.text for p in parts if p.text])
         if self.requires_page_break():
             page_sep = self.params.page_break_placeholder or ""
-            for full_match, _, _ in self._get_page_breaks(text=text_res):
-                text_res = text_res.replace(full_match, page_sep)
+            for full_match, prev_page, next_page in self._get_page_breaks(text=text_res):
+                text_res = text_res.replace(
+                    full_match,
+                    self._format_page_break_placeholder(
+                        page_sep,
+                        prev_page=prev_page,
+                        next_page=next_page,
+                    ),
+                )
 
         return create_ser_result(text=text_res, span_source=parts)
+
+    @staticmethod
+    def _format_page_break_placeholder(
+        placeholder: str,
+        *,
+        prev_page: int,
+        next_page: int,
+    ) -> str:
+        return (
+            placeholder.replace("{page_no}", str(next_page))
+            .replace("{prev_page}", str(prev_page))
+            .replace("{next_page}", str(next_page))
+        )
 
     @override
     def requires_page_break(self) -> bool:

--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -159,6 +159,28 @@ def test_md_cross_page_list_page_break_non_empty():
     verify(exp_file=src.parent / f"{src.stem}_pb_non_empty.gt.md", actual=actual)
 
 
+def test_md_cross_page_list_page_break_page_number_placeholder():
+    src = Path("./test/data/doc/activities.json")
+    doc = DoclingDocument.load_from_json(src)
+
+    ser = MarkdownDocSerializer(
+        doc=doc,
+        params=MarkdownParams(
+            image_mode=ImageRefMode.PLACEHOLDER,
+            image_placeholder="<!-- image -->",
+            page_break_placeholder="<!-- page {page_no} from {prev_page} to {next_page} -->",
+            labels=_DEFAULT_LABELS - {DocItemLabel.PICTURE},
+        ),
+    )
+    actual = ser.serialize().text
+
+    assert "<!-- page 2 from 1 to 2 -->" in actual
+    assert "<!-- page 3 from 2 to 3 -->" in actual
+    assert "{page_no}" not in actual
+    assert "{prev_page}" not in actual
+    assert "{next_page}" not in actual
+
+
 def test_md_cross_page_list_page_break_p2():
     src = Path("./test/data/doc/activities.json")
     doc = DoclingDocument.load_from_json(src)


### PR DESCRIPTION
## Summary

Adds named page-number placeholders for Markdown `page_break_placeholder` values.

Today `MarkdownParams(page_break_placeholder="<!-- page {page_no} -->")` emits `{page_no}` literally. The internal page-break marker already carries both previous and next page numbers, so this change formats the placeholder when the final Markdown text is assembled.

Supported placeholders:

- `{page_no}`: the page after the break, matching the common “page marker before page N” use case
- `{next_page}`: same value as `{page_no}`
- `{prev_page}`: the page before the break

Existing literal placeholders such as `"<!-- page break -->"`, `""`, and `None` keep their current behavior.

This helps document/RAG pipelines preserve page-level provenance in Markdown exports, which is useful for citations and traceable retrieval chunks. It also addresses the page-number placeholder part of docling-project/docling#2036.

## Tests

- `python -m pytest test/test_serialization.py -q` (48 passed)
- `python -m py_compile docling_core/transforms/serializer/markdown.py test/test_serialization.py`
- `git diff --check`
- `python -m ruff check docling_core/transforms/serializer/markdown.py test/test_serialization.py`