### PR TITLE
fix: Force Unix style path for image URI fix

### DIFF
--- a/docling_core/types/doc/document.py
+++ b/docling_core/types/doc/document.py
@@ -5921,7 +5921,7 @@ class DoclingDocument(BaseModel):
                                 scale = img.size[0] / item.prov[0].bbox.width
                                 item.image = ImageRef.from_pil(image=img, dpi=round(72 * scale))
                             elif item.image is not None:
-                                item.image.uri = Path(obj_path)
+                                item.image.uri = Path(obj_path).as_posix()  # force Unix style, even under Windows for correct html and markdown path
 
                         # if item.image._pil is not None:
                         #    item.image._pil.close()

--- a/docling_core/types/doc/document.py
+++ b/docling_core/types/doc/document.py
@@ -5921,7 +5921,9 @@ class DoclingDocument(BaseModel):
                                 scale = img.size[0] / item.prov[0].bbox.width
                                 item.image = ImageRef.from_pil(image=img, dpi=round(72 * scale))
                             elif item.image is not None:
-                                item.image.uri = Path(obj_path).as_posix()  # force Unix style, even under Windows for correct html and markdown path
+                                item.image.uri = Path(
+                                    obj_path
+                                ).as_posix()  # force Unix style, even under Windows for correct html and markdown path
 
                         # if item.image._pil is not None:
                         #    item.image._pil.close()


### PR DESCRIPTION
Ensure image URI uses Unix style path for compatibility.

Resolves docling-project/docling#3617