### PR TITLE
fix: clamp provenance bboxes and DocLang locations to valid page bounds

### DIFF
--- a/docling_core/transforms/serializer/_doclang_utils.py
+++ b/docling_core/transforms/serializer/_doclang_utils.py
@@ -127,20 +127,20 @@ def _xml_error_context(
     return "\n".join(out)
 
 
-def _quantize_to_resolution(value: float, resolution: int) -> int:
-    """Quantize normalized value in [0,1) to [0,resolution)."""
-    n = round(resolution * value)
-    if n < 0:
-        warnings.warn(f"Normalized {value=} less than 0; returning 0", stacklevel=2)
+def _quantize_to_resolution(value: int, resolution: int) -> int:
+    """Clamp discrete location value to ``[0, resolution)``."""
+    if value < 0:
+        warnings.warn(f"Location {value=} less than 0; returning 0", stacklevel=2)
         return 0
-    elif n >= resolution:
+    if value == resolution:
+        return resolution - 1
+    if value > resolution:
         warnings.warn(
-            f"Normalized {value=} greater or equal to 1; returning {resolution-1=}",
+            f"Location {value=} greater than {resolution - 1}; returning {resolution - 1=}",
             stacklevel=2,
         )
         return resolution - 1
-    else:
-        return n
+    return value
 
 
 def _create_location_tokens_for_bbox(
@@ -152,15 +152,15 @@ def _create_location_tokens_for_bbox(
     yres: int,
 ) -> str:
     """Create four `<location .../>` tokens for x0,y0,x1,y1 given a bbox."""
-    x0 = bbox[0] / page_w
-    y0 = bbox[1] / page_h
-    x1 = bbox[2] / page_w
-    y1 = bbox[3] / page_h
+    x0 = min(bbox[0], bbox[2]) / page_w
+    y0 = min(bbox[1], bbox[3]) / page_h
+    x1 = max(bbox[0], bbox[2]) / page_w
+    y1 = max(bbox[1], bbox[3]) / page_h
 
-    x0v = _quantize_to_resolution(min(x0, x1), xres)
-    y0v = _quantize_to_resolution(min(y0, y1), yres)
-    x1v = _quantize_to_resolution(max(x0, x1), xres)
-    y1v = _quantize_to_resolution(max(y0, y1), yres)
+    x0v = _quantize_to_resolution(round(xres * x0), xres)
+    y0v = _quantize_to_resolution(round(yres * y0), yres)
+    x1v = _quantize_to_resolution(round(xres * x1), xres)
+    y1v = _quantize_to_resolution(round(yres * y1), yres)
 
     return (
         DocLangVocabulary._create_location_token(value=x0v, resolution=xres)
@@ -184,7 +184,15 @@ def _create_location_tokens_for_item(
     for prov in item.prov:
         page_w, page_h = doc.pages[prov.page_no].size.as_tuple()
         bbox = prov.bbox.to_top_left_origin(page_h).as_tuple()
-        out.append(_create_location_tokens_for_bbox(bbox=bbox, page_w=page_w, page_h=page_h, xres=xres, yres=yres))
+        out.append(
+            _create_location_tokens_for_bbox(
+                bbox=bbox,
+                page_w=page_w,
+                page_h=page_h,
+                xres=xres,
+                yres=yres,
+            )
+        )
 
     # Multi-provenance items emit one location set per fragment
     if len(out) > 1:

--- a/docling_core/transforms/serializer/doclang.py
+++ b/docling_core/transforms/serializer/doclang.py
@@ -40,7 +40,6 @@ from docling_core.transforms.serializer._doclang_utils import (
     _picture_classification_label_from_doclang,
     _picture_classification_label_to_doclang,
     _provenance_with_charspan,
-    _quantize_to_resolution,
     _thread_table_merge_offset,
     _wrap,
     _wrap_field_kv_markup_if_needed,

--- a/docling_core/types/doc/document.py
+++ b/docling_core/types/doc/document.py
@@ -2890,6 +2890,142 @@ class DoclingDocument(BaseModel):
 
         return dumped
 
+    @staticmethod
+    def _clamp_location_coordinate(
+        *,
+        value: float,
+        lo: float,
+        hi: float,
+        tolerance: float,
+        page_no: int,
+        bbox_label: str,
+        coord_name: str,
+    ) -> float:
+        clamped = min(max(value, lo), hi)
+        if clamped != value and abs(value - clamped) > tolerance:
+            if value < lo:
+                warnings.warn(
+                    f"{bbox_label} coordinate {coord_name} on page {page_no} is outside page bounds: "
+                    f"{value=} < {lo=}; clamping to {lo}",
+                    stacklevel=3,
+                )
+            else:
+                warnings.warn(
+                    f"{bbox_label} coordinate {coord_name} on page {page_no} is outside page bounds: "
+                    f"{value=} > {hi=}; clamping to {hi}",
+                    stacklevel=3,
+                )
+        return clamped
+
+    @classmethod
+    def _clamp_bbox_to_page(
+        cls,
+        *,
+        bbox: BoundingBox,
+        page_size: Size,
+        page_no: int,
+        bbox_label: str,
+    ) -> BoundingBox:
+        page_width = page_size.width
+        page_height = page_size.height
+
+        tolerance_factor = 1e-2
+
+        return bbox.model_copy(
+            update={
+                "l": cls._clamp_location_coordinate(
+                    value=bbox.l,
+                    lo=0.0,
+                    hi=page_width,
+                    tolerance=page_width * tolerance_factor,
+                    page_no=page_no,
+                    bbox_label=bbox_label,
+                    coord_name="l",
+                ),
+                "r": cls._clamp_location_coordinate(
+                    value=bbox.r,
+                    lo=0.0,
+                    hi=page_width,
+                    tolerance=page_width * tolerance_factor,
+                    page_no=page_no,
+                    bbox_label=bbox_label,
+                    coord_name="r",
+                ),
+                "t": cls._clamp_location_coordinate(
+                    value=bbox.t,
+                    lo=0.0,
+                    hi=page_height,
+                    tolerance=page_height * tolerance_factor,
+                    page_no=page_no,
+                    bbox_label=bbox_label,
+                    coord_name="t",
+                ),
+                "b": cls._clamp_location_coordinate(
+                    value=bbox.b,
+                    lo=0.0,
+                    hi=page_height,
+                    tolerance=page_height * tolerance_factor,
+                    page_no=page_no,
+                    bbox_label=bbox_label,
+                    coord_name="b",
+                ),
+            }
+        )
+
+    @classmethod
+    def _clamp_provenance_bbox_to_page(cls, *, prov: ProvenanceItem, page_size: Size) -> None:
+        prov.bbox = cls._clamp_bbox_to_page(
+            bbox=prov.bbox,
+            page_size=page_size,
+            page_no=prov.page_no,
+            bbox_label="Provenance bbox",
+        )
+
+    def _clamp_provenance_bboxes_to_pages(self) -> None:
+        def clamp_prov(prov: ProvenanceItem) -> None:
+            page = self.pages.get(prov.page_no)
+            if page is not None:
+                self._clamp_provenance_bbox_to_page(prov=prov, page_size=page.size)
+
+        def clamp_table_cell_bboxes(table: TableItem) -> None:
+            page_nos = {prov.page_no for prov in table.prov}
+            if len(page_nos) != 1:
+                return
+            page_no = next(iter(page_nos))
+            page = self.pages.get(page_no)
+            if page is None:
+                return
+
+            for cell in table.data.table_cells:
+                if cell.bbox is not None:
+                    cell.bbox = self._clamp_bbox_to_page(
+                        bbox=cell.bbox,
+                        page_size=page.size,
+                        page_no=page_no,
+                        bbox_label="Table cell bbox",
+                    )
+
+        item_lists: tuple[Iterable[NodeItem], ...] = (
+            self.texts,
+            self.pictures,
+            self.tables,
+            self.key_value_items,
+            self.form_items,
+            self.field_regions,
+            self.field_items,
+        )
+        for item_list in item_lists:
+            for item in item_list:
+                if isinstance(item, DocItem):
+                    for prov in item.prov:
+                        clamp_prov(prov)
+                if isinstance(item, TableItem):
+                    clamp_table_cell_bboxes(item)
+                if isinstance(item, KeyValueItem | FormItem):
+                    for cell in item.graph.cells:
+                        if cell.prov is not None:
+                            clamp_prov(cell.prov)
+
     @model_validator(mode="before")
     @classmethod
     def transform_to_content_layer(cls, data: Any) -> Any:
@@ -7499,6 +7635,8 @@ class DoclingDocument(BaseModel):
             warnings.filterwarnings("ignore", category=DeprecationWarning)
             self.validate_tree(self.body, raise_on_error=True)
             self.validate_tree(self.furniture, raise_on_error=True)
+
+        self._clamp_provenance_bboxes_to_pages()
 
         return self
 

--- a/test/data/doc/dummy_doc.yaml
+++ b/test/data/doc/dummy_doc.yaml
@@ -179,7 +179,7 @@ pictures: # All pictures...
         bbox:
           l: 456.3
           t: 145.8
-          b: 623.4
+          b: 583.15
           r: 702.5
         charspan: [ 0,288 ]
   - self_ref: "#/pictures/1"

--- a/test/data/doc/dummy_doc_2.yaml
+++ b/test/data/doc/dummy_doc_2.yaml
@@ -84,7 +84,7 @@ pictures:
     $ref: '#/body'
   prov:
   - bbox:
-      b: 623.4
+      b: 583.15
       coord_origin: TOPLEFT
       l: 456.3
       r: 702.5

--- a/test/data/doc/dummy_doc_2_prec.yaml
+++ b/test/data/doc/dummy_doc_2_prec.yaml
@@ -112,7 +112,7 @@ pictures:
     $ref: '#/body'
   prov:
   - bbox:
-      b: 623.4
+      b: 583.15
       coord_origin: TOPLEFT
       l: 456.3
       r: 702.5

--- a/test/test_docling_doc.py
+++ b/test/test_docling_doc.py
@@ -2641,3 +2641,117 @@ def test_table_data_horizontal_bounding_boxes_with_spans_no_overlap():
             assert a.intersection_area_with(b) == 0, f"row overlap (minimal={minimal})"
         for a, b in itertools.combinations(cols.values(), 2):
             assert a.intersection_area_with(b) == 0, f"col overlap (minimal={minimal})"
+
+
+def _validate_doc(doc: DoclingDocument) -> DoclingDocument:
+    return DoclingDocument.model_validate(doc.model_dump(mode="json"))
+
+
+def test_document_validation_clamps_provenance_bbox_without_warning_within_tolerance() -> None:
+    doc = DoclingDocument(name="test")
+    doc.add_page(page_no=1, size=Size(width=100.0, height=200.0))
+    doc.add_text(
+        label=DocItemLabel.TEXT,
+        text="Hello",
+        prov=ProvenanceItem(
+            page_no=1,
+            bbox=BoundingBox(l=-1.0, t=0.0, r=101.0, b=201.0, coord_origin=CoordOrigin.TOPLEFT),
+            charspan=(0, 5),
+        ),
+    )
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        validated = _validate_doc(doc)
+
+    bbox = validated.texts[0].prov[0].bbox
+    assert (bbox.l, bbox.t, bbox.r, bbox.b) == (0.0, 0.0, 100.0, 200.0)
+    assert not [warning for warning in caught if "outside page bounds" in str(warning.message)]
+
+
+def test_document_validation_warns_when_provenance_bbox_exceeds_tolerance() -> None:
+    doc = DoclingDocument(name="test")
+    doc.add_page(page_no=1, size=Size(width=100.0, height=200.0))
+    doc.add_text(
+        label=DocItemLabel.TEXT,
+        text="Hello",
+        prov=ProvenanceItem(
+            page_no=1,
+            bbox=BoundingBox(l=-1.1, t=0.0, r=100.0, b=202.1, coord_origin=CoordOrigin.TOPLEFT),
+            charspan=(0, 5),
+        ),
+    )
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        validated = _validate_doc(doc)
+
+    bbox = validated.texts[0].prov[0].bbox
+    assert (bbox.l, bbox.t, bbox.r, bbox.b) == (0.0, 0.0, 100.0, 200.0)
+
+    messages = [str(warning.message) for warning in caught]
+    assert any("coordinate l on page 1 is outside page bounds" in message for message in messages)
+    assert any("coordinate b on page 1 is outside page bounds" in message for message in messages)
+
+
+def test_document_validation_clamps_graph_cell_provenance_bbox() -> None:
+    doc = DoclingDocument(name="test")
+    doc.add_page(page_no=1, size=Size(width=100.0, height=200.0))
+    doc.add_key_values(
+        graph=GraphData(
+            cells=[
+                GraphCell(
+                    label=GraphCellLabel.KEY,
+                    cell_id=0,
+                    text="Key",
+                    orig="Key",
+                    prov=ProvenanceItem(
+                        page_no=1,
+                        bbox=BoundingBox(l=0.0, t=-0.5, r=10.0, b=10.0, coord_origin=CoordOrigin.TOPLEFT),
+                        charspan=(0, 3),
+                    ),
+                )
+            ]
+        )
+    )
+
+    validated = _validate_doc(doc)
+    prov = validated.key_value_items[0].graph.cells[0].prov
+    assert prov and prov.bbox.t == 0.0
+
+
+def test_document_validation_clamps_table_cell_bbox() -> None:
+    doc = DoclingDocument(name="test")
+    doc.add_page(page_no=1, size=Size(width=100.0, height=200.0))
+    doc.add_table(
+        data=TableData(
+            num_rows=1,
+            num_cols=1,
+            table_cells=[
+                TableCell(
+                    text="cell",
+                    start_row_offset_idx=0,
+                    end_row_offset_idx=1,
+                    start_col_offset_idx=0,
+                    end_col_offset_idx=1,
+                    bbox=BoundingBox(l=-1.1, t=0.0, r=101.1, b=10.0, coord_origin=CoordOrigin.TOPLEFT),
+                )
+            ],
+        ),
+        prov=ProvenanceItem(
+            page_no=1,
+            bbox=BoundingBox(l=0.0, t=0.0, r=100.0, b=10.0, coord_origin=CoordOrigin.TOPLEFT),
+            charspan=(0, 4),
+        ),
+    )
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        validated = _validate_doc(doc)
+
+    bbox = validated.tables[0].data.table_cells[0].bbox
+    assert bbox and (bbox.l, bbox.t, bbox.r, bbox.b) == (0.0, 0.0, 100.0, 10.0)
+
+    messages = [str(warning.message) for warning in caught]
+    assert any("Table cell bbox coordinate l on page 1 is outside page bounds" in message for message in messages)
+    assert any("Table cell bbox coordinate r on page 1 is outside page bounds" in message for message in messages)

--- a/test/test_serialization_doclang.py
+++ b/test/test_serialization_doclang.py
@@ -1,11 +1,17 @@
 """Unit tests for Doclang create_closing_token helper."""
 
+import warnings
 from itertools import chain
 from pathlib import Path
 from typing import Optional
 
+import pytest
 from pydantic import AnyUrl
 
+from docling_core.transforms.serializer._doclang_utils import (
+    _create_location_tokens_for_bbox,
+    _quantize_to_resolution,
+)
 from docling_core.transforms.serializer.doclang import (
     ContentType,
     DocLangDocSerializer,
@@ -748,6 +754,36 @@ def test_def_prov_512():
     ser_txt = ser_res.text
     exp_file = Path("./test/data/doc/simple_prov_res_512.out.dclg.xml")
     verify_doclang(exp_file=exp_file, actual=ser_txt)
+
+
+def test_quantize_clamp_upper_edge_without_warning() -> None:
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        out = _quantize_to_resolution(512, resolution=512)
+
+    assert out == 511
+    assert not w
+
+
+def test_quantize_clamp_warns_when_genuinely_out_of_range() -> None:
+    with pytest.warns(UserWarning, match=r"greater than 511"):
+        out = _quantize_to_resolution(518, resolution=512)
+
+    assert out == 511
+
+
+def test_location_tokens_tolerates_exact_right_edge() -> None:
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        _create_location_tokens_for_bbox(
+            bbox=(0.0, 0.0, 100.0, 10.0),
+            page_w=100.0,
+            page_h=100.0,
+            xres=512,
+            yres=512,
+        )
+
+    assert not w
 
 
 def test_def_prov_256():


### PR DESCRIPTION
- clamp bbox coordinates during document validation and quantize location tokens at page edges without warning
- emit warnings only when values exceed a 1% page-dimension tolerance