### PR TITLE
fix: collapse consecutive names in concatenate output

### DIFF
--- a/docling_core/types/doc/document.py
+++ b/docling_core/types/doc/document.py
@@ -7707,7 +7707,13 @@ class DoclingDocument(BaseModel):
                 self._max_page = new_max_page
 
         def get_name(self) -> str:
-            return " + ".join(self._names)
+            if not self._names:
+                return ""
+            squeezed: list[str] = [self._names[0]]
+            for name in self._names[1:]:
+                if name != squeezed[-1]:
+                    squeezed.append(name)
+            return " + ".join(squeezed)
 
     def _update_from_index(self, doc_index: "_DocIndex") -> None:
         if doc_index._body is not None:
@@ -7743,7 +7749,7 @@ class DoclingDocument(BaseModel):
         for doc in docs:
             doc_index.index(doc=doc)
 
-        res_doc = DoclingDocument(name=" + ".join([doc.name for doc in docs]))
+        res_doc = DoclingDocument(name=doc_index.get_name())
         res_doc._update_from_index(doc_index)
         return res_doc
 

--- a/test/test_docling_doc.py
+++ b/test/test_docling_doc.py
@@ -1827,6 +1827,21 @@ def test_concatenate_shifts_graph_cell_pages_for_keyvalue_and_form():
     assert form_item_pages == [[1], [2]]
 
 
+def test_concatenate_squeezes_successive_duplicate_names():
+    def _make_doc(name: str) -> DoclingDocument:
+        doc = DoclingDocument(name=name)
+        doc.add_page(page_no=1, size=Size(width=100, height=100))
+        return doc
+
+    assert DoclingDocument.concatenate([_make_doc("a"), _make_doc("a"), _make_doc("a")]).name == "a"
+    assert (
+        DoclingDocument.concatenate(
+            [_make_doc("a"), _make_doc("a"), _make_doc("b"), _make_doc("b"), _make_doc("b"), _make_doc("a")]
+        ).name
+        == "a + b + a"
+    )
+
+
 def test_export_markdown_compact_tables():
     """Test compact_tables parameter for markdown export."""
     doc = DoclingDocument(name="Compact Table Test")


### PR DESCRIPTION
- when merging documents, successive identical source names are deduplicated in the resulting document name (e.g. `a + a + b` → `a + b`)