### PR TITLE
feat: add page metadata support

### DIFF
--- a/docling_core/types/doc/__init__.py
+++ b/docling_core/types/doc/__init__.py
@@ -46,6 +46,7 @@ from .document import (
     OrderedList,
     Orientation,
     PageItem,
+    PageMeta,
     PictureBarChartData,
     PictureChartData,
     PictureClassificationClass,

--- a/docling_core/types/doc/document.py
+++ b/docling_core/types/doc/document.py
@@ -1679,6 +1679,10 @@ class FloatingMeta(BaseMeta):
     description: Optional[DescriptionMetaField] = None
 
 
+class PageMeta(BaseMeta):
+    """Metadata model for pages."""
+
+
 class CodeMetaField(BasePrediction):
     """Code representation for the respective item."""
 
@@ -2870,6 +2874,7 @@ class PageItem(BaseModel):
     # only referencing items on the page
     size: Size
     image: Optional[ImageRef] = None
+    meta: Optional[PageMeta] = None
     page_no: int
 
 
@@ -7539,14 +7544,22 @@ class DoclingDocument(BaseModel):
 
         return "\n".join(result)
 
-    def add_page(self, page_no: int, size: Size, image: Optional[ImageRef] = None) -> PageItem:
+    def add_page(
+        self,
+        page_no: int,
+        size: Size,
+        image: Optional[ImageRef] = None,
+        meta: Optional[PageMeta] = None,
+    ) -> PageItem:
         """add_page.
 
         :param page_no: int:
         :param size: Size:
+        :param image: Optional[ImageRef]:
+        :param meta: Optional[PageMeta]:
 
         """
-        pitem = PageItem(page_no=page_no, size=size, image=image)
+        pitem = PageItem(page_no=page_no, size=size, image=image, meta=meta)
 
         self.pages[page_no] = pitem
         return pitem

--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -24,8 +24,8 @@ from docling_core.transforms.serializer.markdown import (
 )
 from docling_core.transforms.serializer.webvtt import WebVTTDocSerializer, WebVTTParams
 from docling_core.transforms.visualizer.layout_visualizer import LayoutVisualizer
-from docling_core.types.doc import DoclingDocument
-from docling_core.types.doc.base import ImageRefMode
+from docling_core.types.doc import DoclingDocument, PageMeta
+from docling_core.types.doc.base import ImageRefMode, Size
 from docling_core.types.doc.document import (
     BaseMeta,
     CharSpan,
@@ -72,6 +72,48 @@ def verify(exp_file: Path, actual: str):
 # ===============================
 # Markdown tests
 # ===============================
+
+
+def test_page_item_meta_round_trips_in_exported_document():
+    doc = DoclingDocument(name="page meta")
+    page_meta = PageMeta(
+        summary=SummaryMetaField(
+            text="Summary of page 1",
+            created_by="page-summary-model",
+        ),
+    )
+    page_meta.set_custom_field(
+        namespace="research",
+        name="source_scope",
+        value={"source_type": "10-K", "valid_as_of": "2026-06-18"},
+    )
+
+    doc.add_page(
+        page_no=1,
+        size=Size(width=612, height=792),
+        meta=page_meta,
+    )
+
+    exported = doc.export_to_dict()
+    assert exported["pages"]["1"]["meta"]["summary"] == {
+        "text": "Summary of page 1",
+        "created_by": "page-summary-model",
+    }
+    assert exported["pages"]["1"]["meta"]["research__source_scope"] == {
+        "source_type": "10-K",
+        "valid_as_of": "2026-06-18",
+    }
+
+    loaded = DoclingDocument.model_validate(exported)
+    assert loaded.pages[1].meta is not None
+    assert loaded.pages[1].meta.summary is not None
+    assert loaded.pages[1].meta.summary.text == "Summary of page 1"
+    assert loaded.pages[1].meta.get_custom_part() == {
+        "research__source_scope": {
+            "source_type": "10-K",
+            "valid_as_of": "2026-06-18",
+        },
+    }
 
 
 def test_md_cross_page_list_page_break():


### PR DESCRIPTION
## Summary
- add `PageMeta` as the page-level metadata model
- allow `PageItem` and `DoclingDocument.add_page(...)` to carry optional page metadata
- add JSON export/model-validation round-trip coverage for page summaries and namespaced custom metadata

## Why
Refs docling-project/docling#1005.

Floating items already expose `meta`, but pages did not have an equivalent metadata slot. This gives downstream document hierarchy, Doc2KG, and RAG pipelines a structured place to carry page-level summaries, entities, source-scope tags, or other namespaced metadata without changing default output when no metadata is supplied.

## Tests
- `python -m pytest test\test_serialization.py -q`
- `python -m ruff check docling_core\types\doc\document.py docling_core\types\doc\__init__.py test\test_serialization.py`
- `python -m ruff format --check docling_core\types\doc\document.py docling_core\types\doc\__init__.py test\test_serialization.py`
- `python -m py_compile docling_core\types\doc\document.py docling_core\types\doc\__init__.py test\test_serialization.py`
- `git diff --check`