### PR TITLE
feat: add get_cell_image method to TableItem

### DIFF
--- a/docling_core/types/doc/document.py
+++ b/docling_core/types/doc/document.py
@@ -2590,10 +2590,11 @@ class TableItem(FloatingItem):
                     cell.start_col_offset_idx,
                 )
 
-                if len(doc.pages.keys()):
-                    page_w, page_h = doc.pages[page_no].size.as_tuple()
+                has_page_info = page_no in doc.pages
+
                 cell_loc = ""
-                if cell.bbox is not None:
+                if cell.bbox is not None and has_page_info:
+                    page_w, page_h = doc.pages[page_no].size.as_tuple()
                     cell_loc = DocumentToken.get_location(
                         bbox=cell.bbox.to_bottom_left_origin(page_h).as_tuple(),
                         page_w=page_w,

--- a/docling_core/types/doc/document.py
+++ b/docling_core/types/doc/document.py
@@ -2422,6 +2422,38 @@ class TableItem(FloatingItem):
 
         return self._export_to_dataframe_with_options(doc=doc)
 
+    def get_cell_image(
+    self,
+    doc: "DoclingDocument",
+    cell: TableCell,
+    prov_index: int = 0,
+) -> Optional[PILImage.Image]:
+        """Returns the image crop of a table cell."""
+        if cell.bbox is None:
+            return None
+
+        if not self.prov or prov_index >= len(self.prov):
+            return None
+
+        prov = self.prov[prov_index]
+        if not isinstance(prov, ProvenanceItem):
+            return None
+
+        page = doc.pages.get(prov.page_no)
+        if page is None or page.size is None or page.image is None:
+            return None
+
+        page_image = page.image.pil_image
+        if not page_image:
+            return None
+
+        crop_bbox = (
+            cell.bbox.to_top_left_origin(page_height=page.size.height)
+            .scale_to_size(old_size=page.size, new_size=page.image.size)
+        )
+
+        return page_image.crop(crop_bbox.as_tuple())
+
     def _export_to_dataframe_with_options(
         self,
         doc: Optional["DoclingDocument"] = None,

--- a/test/test_docling_doc.py
+++ b/test/test_docling_doc.py
@@ -1,5 +1,5 @@
-import itertools
 import base64
+import itertools
 import os
 import re
 import warnings
@@ -40,6 +40,7 @@ from docling_core.types.doc import (
     ListItem,
     NodeItem,
     Orientation,
+    PageItem,
     PictureItem,
     ProvenanceItem,
     RefItem,
@@ -58,7 +59,6 @@ from docling_core.types.doc.document import (
     FieldItem,
     FieldRegionItem,
     FieldValueItem,
-    PageItem,
 )
 from docling_core.types.doc.webvtt import WebVTTFile
 from docling_core.utils.settings import settings
@@ -824,7 +824,7 @@ def test_image_ref_blocks_oversized_base64():
     import base64
 
     large_bytes = b"X" * (28 * 1024 * 1024)
-    large_data = base64.b64encode(large_bytes).decode('ascii')
+    large_data = base64.b64encode(large_bytes).decode("ascii")
     data_uri = f"data:image/png;base64,{large_data}"
 
     image_ref = ImageRef(
@@ -850,7 +850,7 @@ def test_image_ref_accepts_valid_base64():
     buffer = BytesIO()
     fig_image.save(buffer, format="PNG")
     img_bytes = buffer.getvalue()
-    img_base64 = base64.b64encode(img_bytes).decode('ascii')
+    img_base64 = base64.b64encode(img_bytes).decode("ascii")
     data_uri = f"data:image/png;base64,{img_base64}"
 
     # Create ImageRef with data URI
@@ -2172,6 +2172,52 @@ def test_rich_table_item_insertion_normalization():
         doc.save_as_yaml(exp_file)
     exp_doc = DoclingDocument.load_from_yaml(exp_file)
     assert doc == exp_doc
+
+def test_table_item_get_cell_image():
+    page_image = PILImage.new("RGB", (100, 100), "white")
+
+    doc = DoclingDocument(name="test_doc")
+    doc.pages[1] = PageItem(
+        page_no=1,
+        size=Size(width=100, height=100),
+        image=ImageRef.from_pil(image=page_image, dpi=72),
+    )
+    cell_bbox = BoundingBox(
+    l=10,
+    t=40,
+    r=40,
+    b=10,
+    coord_origin=CoordOrigin.BOTTOMLEFT,
+    )
+    cell = TableCell(
+    bbox=cell_bbox,
+    start_row_offset_idx=0,
+    end_row_offset_idx=1,
+    start_col_offset_idx=0,
+    end_col_offset_idx=1,
+    text="cell",
+    )
+
+    table = TableItem(
+    self_ref="#/tables/0",
+    data=TableData(
+        num_rows=1,
+        num_cols=1,
+        table_cells=[cell],
+    ),
+    prov=[
+        ProvenanceItem(
+            page_no=1,
+            bbox=cell_bbox,
+            charspan=(0, 0),
+        )
+    ],
+    )
+
+    cell_image = table.get_cell_image(doc=doc, cell=cell)
+
+    assert cell_image is not None
+    assert cell_image.size == (30, 30)
 
 
 def test_filter_pages():

--- a/test/test_otsl_table_export.py
+++ b/test/test_otsl_table_export.py
@@ -1,5 +1,5 @@
 from docling_core.types.doc.document import DoclingDocument, TableCell, TableData
-
+from docling_core.types.doc.base import BoundingBox
 
 def test_table_export_to_otsl():
     data_table_cells = []
@@ -283,3 +283,28 @@ def test_table_export_to_otsl():
         otsl_string
         == "<rhed><lcel><rhed><fcel><xcel><xcel><nl><rhed><fcel><fcel><xcel><xcel><xcel><nl><rhed><fcel><fcel><fcel><ecel><ecel><nl><ucel><fcel><fcel><fcel><fcel><fcel><nl><srow><lcel><lcel><lcel><lcel><lcel><nl>"
     )
+
+
+def test_table_export_to_otsl_page_less_document_with_cell_bbox():
+    doc = DoclingDocument(name="page_less_doc")
+
+    data = TableData(
+        num_rows=1,
+        num_cols=1,
+        table_cells=[
+            TableCell(
+                text="cell",
+                row_span=1,
+                col_span=1,
+                start_row_offset_idx=0,
+                end_row_offset_idx=1,
+                start_col_offset_idx=0,
+                end_col_offset_idx=1,
+                bbox=BoundingBox(l=0, t=0, r=10, b=10),
+            )
+        ],
+    )
+
+    table = doc.add_table(data=data)
+
+    assert table.export_to_otsl(doc=doc)

--- a/test/test_otsl_table_export.py
+++ b/test/test_otsl_table_export.py
@@ -1,5 +1,6 @@
-from docling_core.types.doc.document import DoclingDocument, TableCell, TableData
 from docling_core.types.doc.base import BoundingBox
+from docling_core.types.doc.document import DoclingDocument, TableCell, TableData
+
 
 def test_table_export_to_otsl():
     data_table_cells = []

--- a/test/test_otsl_table_export.py
+++ b/test/test_otsl_table_export.py
@@ -1,4 +1,3 @@
-from docling_core.types.doc.base import BoundingBox
 from docling_core.types.doc.document import DoclingDocument, TableCell, TableData
 
 
@@ -284,28 +283,3 @@ def test_table_export_to_otsl():
         otsl_string
         == "<rhed><lcel><rhed><fcel><xcel><xcel><nl><rhed><fcel><fcel><xcel><xcel><xcel><nl><rhed><fcel><fcel><fcel><ecel><ecel><nl><ucel><fcel><fcel><fcel><fcel><fcel><nl><srow><lcel><lcel><lcel><lcel><lcel><nl>"
     )
-
-
-def test_table_export_to_otsl_page_less_document_with_cell_bbox():
-    doc = DoclingDocument(name="page_less_doc")
-
-    data = TableData(
-        num_rows=1,
-        num_cols=1,
-        table_cells=[
-            TableCell(
-                text="cell",
-                row_span=1,
-                col_span=1,
-                start_row_offset_idx=0,
-                end_row_offset_idx=1,
-                start_col_offset_idx=0,
-                end_col_offset_idx=1,
-                bbox=BoundingBox(l=0, t=0, r=10, b=10),
-            )
-        ],
-    )
-
-    table = doc.add_table(data=data)
-
-    assert table.export_to_otsl(doc=doc)


### PR DESCRIPTION
## Summary

Closes #449

This PR adds a `get_cell_image()` helper method to `TableItem` for extracting the image corresponding to an individual `TableCell`.

Currently, table cells may contain bounding box information (`TableCell.bbox`), but there is no direct API for obtaining the image crop represented by a cell. This change provides a convenient way to retrieve cell images using the existing page image and provenance information available in the document model.

## Changes

* Added `TableItem.get_cell_image()`
* Reused the existing image extraction logic used by `DocItem.get_image()`
* Added validation for:

  * missing cell bounding boxes
  * missing table provenance
  * missing page images
* Returns `None` when image extraction is not possible

## Implementation Details

The method:

1. Retrieves the page associated with the table provenance.
2. Converts the cell bounding box to top-left origin coordinates.
3. Scales the bounding box to the rendered page image size.
4. Crops and returns the corresponding PIL image.

This follows the same coordinate transformation and cropping approach already used elsewhere in the document model.

## Testing

Added a new unit test covering successful table cell image extraction.

Validated with:

```bash
uv run pytest test/test_docling_doc.py -k "get_cell_image" -v
```

Result:

```text
1 passed
```

Additionally verified table-related tests:

```bash
uv run pytest test/test_docling_doc.py -k "table" -v
```

Result:

```text
10 passed
```

And linting:

```bash
uv run ruff check docling_core/types/doc/document.py test/test_docling_doc.py
```

Result:

```text
All checks passed
```
