### PR TITLE
perf: string join instead of concatenation

### DIFF
--- a/docling_core/types/doc/document.py
+++ b/docling_core/types/doc/document.py
@@ -358,10 +358,8 @@ class TableCell(BaseModel):
             if not len(text):
                 text_cells = data.pop("text_cell_bboxes", None)
                 if text_cells:
-                    for el in text_cells:
-                        text += el["token"] + " "
+                    text = " ".join(el["token"] for el in text_cells)
 
-                text = text.strip()
             data["text"] = text
 
         return data


### PR DESCRIPTION
##Summary + Explaination
Small efficiency change. Python strings are immutable. This means that when we execute the following code:
```
s1 = "Hello"
s2 = "World"
result = s1 + " " + s2 
```
Python will create a new string and copy data each time the `+` operator is used.

If we concatenate strings with `join()` such as:
```
strings = ["Hello", "World"]
result = " ".join(strings)
```
It will only create a new string once.

Normally it shouldn't be noticeable, but at scale every bit counts
