### PR TITLE
fix: doclang suppress content filtered shells

### DIFF
--- a/docling_core/transforms/serializer/doclang.py
+++ b/docling_core/transforms/serializer/doclang.py
@@ -239,6 +239,10 @@ class DocLangParams(CommonParams):
         _advanced_field(detail="Types of content to serialize (only relevant if add_content is True)."),
     ] = _DEFAULT_CONTENT_TYPES
     layer_mode: Annotated[LayerMode, _advanced_field()] = LayerMode.AUTO
+    emit_picture_layer: Annotated[
+        bool,
+        _advanced_field(detail="Whether to emit `<layer .../>` in picture element heads."),
+    ] = True
     # DocLang formatting
     pretty_indentation: Annotated[
         Optional[str],
@@ -249,8 +253,11 @@ class DocLangParams(CommonParams):
         bool,
         _advanced_field(
             detail=(
-                "When True, text items that produce no content (no text, no location) are "
-                "completely omitted rather than emitting an empty open/close tag pair."
+                "When True, elements that produce no serialized body content are completely "
+                "omitted rather than emitting an empty open/close tag pair or a head-only "
+                "shell (e.g. layer/thread/location metadata without text). When "
+                "``content_types`` excludes an item's body type, head-only shells are "
+                "suppressed as well."
             ),
         ),
     ] = False
@@ -275,12 +282,23 @@ class DocLangParams(CommonParams):
     ] = False
 
 
+def _text_item_content_type_active(item: TextItem, params: DocLangParams) -> bool:
+    """Return whether the item's primary text content type is enabled in ``params``."""
+    if isinstance(item, CodeItem):
+        return ContentType.TEXT_CODE in params.content_types
+    if isinstance(item, FormulaItem):
+        return ContentType.TEXT_FORMULA in params.content_types
+    return ContentType.TEXT_OTHER in params.content_types
+
+
 def _create_layer_token(
     *,
     item: DocItem,
     params: DocLangParams,
 ) -> str:
     """Create `<layer value="..."/>` in element head."""
+    if isinstance(item, PictureItem) and not params.emit_picture_layer:
+        return ""
     if params.layer_mode == LayerMode.ALWAYS or (
         params.layer_mode == LayerMode.AUTO and item.content_layer != ContentLayer.BODY
     ):
@@ -954,20 +972,33 @@ class DocLangTextSerializer(BaseModel, BaseTextSerializer):
                     )
                     text_part = checkbox_token + text_part
 
-            if text_part:
-                parts.append(text_part)
-
+        cap_text = ""
         if params.add_referenced_caption and isinstance(item, FloatingItem):
             cap_text = doc_serializer.serialize_captions(item=item, **kwargs).text
             if cap_text:
                 cap_text = _escape_text(cap_text, params)
-                parts.append(cap_text)
 
+        ftn_text = ""
         if params.add_referenced_footnote and isinstance(item, FloatingItem):
             ftn_text = doc_serializer.serialize_footnotes(item=item, **kwargs).text
             if ftn_text:
                 ftn_text = _escape_text(ftn_text, params)
-                parts.append(ftn_text)
+
+        if (
+            params.suppress_empty_elements
+            and not _text_item_content_type_active(item, params)
+            and not text_part
+            and not cap_text
+            and not ftn_text
+        ):
+            return create_ser_result(text="", span_source=item)
+
+        if text_part:
+            parts.append(text_part)
+        if cap_text:
+            parts.append(cap_text)
+        if ftn_text:
+            parts.append(ftn_text)
 
         text_res = "".join(parts)
 
@@ -1144,6 +1175,8 @@ class DocLangPictureSerializer(BasePictureSerializer):
             raw_label=_picture_classification_label_value(item),
             params=params,
         )
+        # ``<picture>`` in the task prompt enables classification labels only.
+        label_for_head = picture_label if any_match else None
         custom_head = ""
         if any_match and item.meta:
             meta_kwargs = dict(**kwargs)
@@ -1194,7 +1227,7 @@ class DocLangPictureSerializer(BasePictureSerializer):
             item=item,
             doc=doc,
             params=params,
-            label_value=picture_label,
+            label_value=label_for_head,
             caption_text=caption_head or None,
             custom_text=custom_head or None,
         )
@@ -1211,6 +1244,18 @@ class DocLangPictureSerializer(BasePictureSerializer):
             if ftn_res.text:
                 footnote_text = ftn_res.text
                 res_parts.append(ftn_res)
+
+        if (
+            not any_match
+            and not picture_body_parts
+            and not footnote_text
+            and not (
+                params.add_location
+                and item.prov
+                and params.content_types
+            )
+        ):
+            return create_ser_result()
 
         if not inner and not footnote_text:
             if params.suppress_empty_elements:
@@ -1446,6 +1491,13 @@ class DocLangTableSerializer(BaseTableSerializer):
                 footnote_text = ftn_res.text
                 res_parts.append(ftn_res)
 
+        if (
+            params.suppress_empty_elements
+            and ContentType.TABLE not in params.content_types
+            and not inner_parts
+            and not footnote_text
+        ):
+            return create_ser_result()
         if not (head or inner_parts) and not footnote_text:
             if params.suppress_empty_elements:
                 return create_ser_result()

--- a/docling_core/transforms/serializer/doclang.py
+++ b/docling_core/transforms/serializer/doclang.py
@@ -990,6 +990,7 @@ class DocLangTextSerializer(BaseModel, BaseTextSerializer):
             and not text_part
             and not cap_text
             and not ftn_text
+            and not (params.add_location and item.prov)
         ):
             return create_ser_result(text="", span_source=item)
 
@@ -1175,8 +1176,13 @@ class DocLangPictureSerializer(BasePictureSerializer):
             raw_label=_picture_classification_label_value(item),
             params=params,
         )
-        # ``<picture>`` in the task prompt enables classification labels only.
-        label_for_head = picture_label if any_match else None
+        # Under content-filtered suppression (opt-in via ``suppress_empty_elements``),
+        # the classification label is emitted only when picture/chart/chemistry content
+        # is requested. Default behavior keeps the resolved label unchanged.
+        if params.suppress_empty_elements and not any_match:
+            label_for_head = None
+        else:
+            label_for_head = picture_label
         custom_head = ""
         if any_match and item.meta:
             meta_kwargs = dict(**kwargs)
@@ -1246,14 +1252,11 @@ class DocLangPictureSerializer(BasePictureSerializer):
                 res_parts.append(ftn_res)
 
         if (
-            not any_match
+            params.suppress_empty_elements
+            and not any_match
             and not picture_body_parts
             and not footnote_text
-            and not (
-                params.add_location
-                and item.prov
-                and params.content_types
-            )
+            and not (params.add_location and item.prov)
         ):
             return create_ser_result()
 
@@ -1496,6 +1499,7 @@ class DocLangTableSerializer(BaseTableSerializer):
             and ContentType.TABLE not in params.content_types
             and not inner_parts
             and not footnote_text
+            and not (params.add_location and item.prov)
         ):
             return create_ser_result()
         if not (head or inner_parts) and not footnote_text:

--- a/test/test_serialization_doclang.py
+++ b/test/test_serialization_doclang.py
@@ -1396,6 +1396,238 @@ def test_suppress_empty_picture():
     assert "<picture" not in result
 
 
+def test_suppress_content_filtered_text_shells():
+    """Head-only text shells are omitted when ``content_types`` excludes body text."""
+    doc = DoclingDocument(name="picture_only_page")
+    doc.add_page(page_no=1, size=Size(width=820, height=500), image=None)
+
+    doc.add_text(
+        label=DocItemLabel.PAGE_HEADER,
+        text="Header title",
+        content_layer=ContentLayer.FURNITURE,
+    )
+
+    pic = doc.add_picture()
+    pic.meta = PictureMeta(
+        classification=PictureClassificationMetaField(
+            predictions=[
+                PictureClassificationPrediction(
+                    label=PictureClassificationLabel.LOGO,
+                    confidence=0.9,
+                )
+            ]
+        )
+    )
+
+    doc.add_text(label=DocItemLabel.TEXT, text="Body paragraph")
+
+    part1 = "Footer line one "
+    part2 = "continues"
+    footer_text = part1 + part2
+    prov = ProvenanceItem(
+        page_no=1,
+        bbox=BoundingBox.from_tuple((10, 450, 400, 480), origin=CoordOrigin.TOPLEFT),
+        charspan=(0, len(part1)),
+    )
+    footer = doc.add_text(label=DocItemLabel.TEXT, text=footer_text, prov=prov)
+    footer.orig = footer_text
+    footer.prov.append(
+        ProvenanceItem(
+            page_no=1,
+            bbox=BoundingBox.from_tuple((420, 450, 810, 480), origin=CoordOrigin.TOPLEFT),
+            charspan=(len(part1), len(footer_text)),
+        )
+    )
+
+    params = DocLangParams(
+        include_version=False,
+        suppress_empty_elements=True,
+        add_location=False,
+        content_types={ContentType.PICTURE},
+    )
+    result = serialize_doclang(doc, params=params)
+
+    assert "<page_header" not in result
+    assert "<text" not in result
+    assert "Header title" not in result
+    assert "Body paragraph" not in result
+    assert "Footer line" not in result
+    assert "<thread" not in result
+    assert "<picture" in result
+    assert 'value="logo"' in result
+
+
+def test_suppress_content_filtered_table_shell():
+    """Table head-only shells are omitted when ``content_types`` excludes table body."""
+    doc = DoclingDocument(name="picture_only_with_table")
+    doc.add_page(page_no=1, size=Size(width=100, height=100), image=None)
+    prov = ProvenanceItem(
+        page_no=1,
+        bbox=BoundingBox.from_tuple((10, 10, 90, 90), origin=CoordOrigin.TOPLEFT),
+        charspan=(0, 0),
+    )
+    doc.add_table(data=TableData(), prov=prov)
+
+    params = DocLangParams(
+        include_version=False,
+        suppress_empty_elements=True,
+        add_location=True,
+        content_types={ContentType.PICTURE},
+    )
+    result = serialize_doclang(doc, params=params)
+    assert "<table" not in result
+    assert "<otsl" not in result
+
+
+def test_suppress_content_filtered_picture_shell():
+    """Picture shells are omitted when ``content_types`` excludes picture body."""
+    doc = DoclingDocument(name="ocr_only_with_picture")
+    doc.add_page(page_no=1, size=Size(width=820, height=500), image=None)
+    pic = doc.add_picture()
+    pic.meta = PictureMeta(
+        classification=PictureClassificationMetaField(
+            predictions=[
+                PictureClassificationPrediction(
+                    label=PictureClassificationLabel.LOGO,
+                    confidence=0.9,
+                )
+            ]
+        )
+    )
+    doc.add_text(label=DocItemLabel.TEXT, text="Body paragraph")
+
+    params = DocLangParams(
+        include_version=False,
+        suppress_empty_elements=True,
+        add_location=False,
+        label_mode=LabelMode.ALWAYS,
+        content_types={ContentType.TEXT_OTHER},
+    )
+    result = serialize_doclang(doc, params=params)
+    assert "<picture" not in result
+    assert "Body paragraph" in result
+
+
+def test_suppress_picture_on_layout_only():
+    """Layout-only serialization must not emit picture tags (only text/table boxes)."""
+    doc = DoclingDocument(name="layout_only_with_picture")
+    doc.add_page(page_no=1, size=Size(width=820, height=500), image=None)
+    pic_prov = ProvenanceItem(
+        page_no=1,
+        bbox=BoundingBox.from_tuple((10, 10, 200, 200), origin=CoordOrigin.TOPLEFT),
+        charspan=(0, 0),
+    )
+    pic = doc.add_picture(prov=pic_prov)
+    pic.meta = PictureMeta(
+        classification=PictureClassificationMetaField(
+            predictions=[
+                PictureClassificationPrediction(
+                    label=PictureClassificationLabel.LOGO,
+                    confidence=0.9,
+                )
+            ]
+        )
+    )
+    text_prov = ProvenanceItem(
+        page_no=1,
+        bbox=BoundingBox.from_tuple((10, 300, 400, 320), origin=CoordOrigin.TOPLEFT),
+        charspan=(0, 4),
+    )
+    doc.add_text(label=DocItemLabel.TEXT, text="Body", prov=text_prov)
+
+    params = DocLangParams(
+        include_version=False,
+        suppress_empty_elements=False,
+        add_location=True,
+        content_types=set(),
+        label_mode=LabelMode.ALWAYS,
+    )
+    result = serialize_doclang(doc, params=params)
+    assert "<picture" not in result
+    assert "<location" in result
+
+
+def test_picture_layout_boxes_without_classification():
+    """Layout + content tasks may emit picture boxes; labels require picture task."""
+    doc = DoclingDocument(name="layout_ocr_with_picture")
+    doc.add_page(page_no=1, size=Size(width=820, height=500), image=None)
+    pic_prov = ProvenanceItem(
+        page_no=1,
+        bbox=BoundingBox.from_tuple((10, 10, 200, 200), origin=CoordOrigin.TOPLEFT),
+        charspan=(0, 0),
+    )
+    pic = doc.add_picture(prov=pic_prov)
+    pic.meta = PictureMeta(
+        classification=PictureClassificationMetaField(
+            predictions=[
+                PictureClassificationPrediction(
+                    label=PictureClassificationLabel.LOGO,
+                    confidence=0.9,
+                )
+            ]
+        )
+    )
+    text_prov = ProvenanceItem(
+        page_no=1,
+        bbox=BoundingBox.from_tuple((10, 300, 400, 320), origin=CoordOrigin.TOPLEFT),
+        charspan=(0, 4),
+    )
+    doc.add_text(label=DocItemLabel.TEXT, text="Body", prov=text_prov)
+
+    params = DocLangParams(
+        include_version=False,
+        suppress_empty_elements=False,
+        add_location=True,
+        content_types={ContentType.TEXT_OTHER},
+        label_mode=LabelMode.ALWAYS,
+    )
+    result = serialize_doclang(doc, params=params)
+    assert "<picture" in result
+    assert "<label" not in result
+    assert "<location" in result
+    assert "Body" in result
+
+
+def test_picture_layer_can_be_disabled():
+    """Picture classification can be emitted without picture content-layer metadata."""
+    doc = DoclingDocument(name="picture_without_layer")
+    doc.add_page(page_no=1, size=Size(width=820, height=500), image=None)
+    pic = doc.add_picture()
+    pic.content_layer = ContentLayer.BACKGROUND
+    pic.meta = PictureMeta(
+        classification=PictureClassificationMetaField(
+            predictions=[
+                PictureClassificationPrediction(
+                    label=PictureClassificationLabel.LOGO,
+                    confidence=0.9,
+                )
+            ]
+        )
+    )
+
+    default_result = serialize_doclang(
+        doc,
+        params=DocLangParams(
+            include_version=False,
+            content_types={ContentType.PICTURE},
+            label_mode=LabelMode.ALWAYS,
+        ),
+    )
+    assert '<layer value="background"/>' in default_result
+
+    no_layer_result = serialize_doclang(
+        doc,
+        params=DocLangParams(
+            include_version=False,
+            content_types={ContentType.PICTURE},
+            label_mode=LabelMode.ALWAYS,
+            emit_picture_layer=False,
+        ),
+    )
+    assert '<label value="logo"/>' in no_layer_result
+    assert "<layer" not in no_layer_result
+
+
 def test_empty_picture_preserved_by_default():
     """Without suppress_empty_elements the empty picture is preserved."""
     doc = DoclingDocument(name="test")

--- a/test/test_serialization_doclang.py
+++ b/test/test_serialization_doclang.py
@@ -1458,7 +1458,7 @@ def test_suppress_content_filtered_text_shells():
 
 
 def test_suppress_content_filtered_table_shell():
-    """Table head-only shells are omitted when ``content_types`` excludes table body."""
+    """Table head-only shells are omitted on a picture-only prompt (no layout boxes)."""
     doc = DoclingDocument(name="picture_only_with_table")
     doc.add_page(page_no=1, size=Size(width=100, height=100), image=None)
     prov = ProvenanceItem(
@@ -1471,11 +1471,34 @@ def test_suppress_content_filtered_table_shell():
     params = DocLangParams(
         include_version=False,
         suppress_empty_elements=True,
-        add_location=True,
+        add_location=False,
         content_types={ContentType.PICTURE},
     )
     result = serialize_doclang(doc, params=params)
     assert "<table" not in result
+    assert "<otsl" not in result
+
+
+def test_table_box_kept_on_layout_with_suppression():
+    """A content-filtered table keeps its layout box when ``add_location`` is set."""
+    doc = DoclingDocument(name="layout_table_box")
+    doc.add_page(page_no=1, size=Size(width=100, height=100), image=None)
+    prov = ProvenanceItem(
+        page_no=1,
+        bbox=BoundingBox.from_tuple((10, 10, 90, 90), origin=CoordOrigin.TOPLEFT),
+        charspan=(0, 0),
+    )
+    doc.add_table(data=TableData(), prov=prov)
+
+    params = DocLangParams(
+        include_version=False,
+        suppress_empty_elements=True,
+        add_location=True,
+        content_types=set(),
+    )
+    result = serialize_doclang(doc, params=params)
+    assert "<table" in result
+    assert "<location" in result
     assert "<otsl" not in result
 
 
@@ -1527,8 +1550,8 @@ def test_suppress_unclassified_picture_with_always_label_mode():
     assert "Visible body text" in result
 
 
-def test_suppress_picture_on_layout_only():
-    """Layout-only serialization must not emit picture tags (only text/table boxes)."""
+def test_picture_box_on_layout_only_without_label():
+    """Layout-only (suppression on) keeps picture boxes but drops the classification label."""
     doc = DoclingDocument(name="layout_only_with_picture")
     doc.add_page(page_no=1, size=Size(width=820, height=500), image=None)
     pic_prov = ProvenanceItem(
@@ -1556,13 +1579,14 @@ def test_suppress_picture_on_layout_only():
 
     params = DocLangParams(
         include_version=False,
-        suppress_empty_elements=False,
+        suppress_empty_elements=True,
         add_location=True,
         content_types=set(),
         label_mode=LabelMode.ALWAYS,
     )
     result = serialize_doclang(doc, params=params)
-    assert "<picture" not in result
+    assert "<picture" in result
+    assert "<label" not in result
     assert "<location" in result
 
 
@@ -1595,7 +1619,7 @@ def test_picture_layout_boxes_without_classification():
 
     params = DocLangParams(
         include_version=False,
-        suppress_empty_elements=False,
+        suppress_empty_elements=True,
         add_location=True,
         content_types={ContentType.TEXT_OTHER},
         label_mode=LabelMode.ALWAYS,

--- a/test/test_serialization_doclang.py
+++ b/test/test_serialization_doclang.py
@@ -1508,6 +1508,25 @@ def test_suppress_content_filtered_picture_shell():
     assert "Body paragraph" in result
 
 
+def test_suppress_unclassified_picture_with_always_label_mode():
+    """Unclassified pictures are omitted for OCR-only even with ``label_mode=ALWAYS``."""
+    doc = DoclingDocument(name="ocr_with_icon_shell")
+    doc.add_picture()
+    doc.add_text(label=DocItemLabel.TEXT, text="Visible body text")
+
+    params = DocLangParams(
+        include_version=False,
+        suppress_empty_elements=True,
+        add_location=False,
+        label_mode=LabelMode.ALWAYS,
+        content_types={ContentType.TEXT_OTHER, ContentType.REF_CAPTION, ContentType.REF_FOOTNOTE},
+    )
+    result = serialize_doclang(doc, params=params)
+    assert "<picture" not in result
+    assert "<label" not in result
+    assert "Visible body text" in result
+
+
 def test_suppress_picture_on_layout_only():
     """Layout-only serialization must not emit picture tags (only text/table boxes)."""
     doc = DoclingDocument(name="layout_only_with_picture")


### PR DESCRIPTION
Problem When we serialize with narrow content_types (e.g. picture-only prompts like [<picture>]), the serializer was still emitting head-only shells — elements with metadata (<layer>, <thread>, <location>, <label>) but no actual supervised body content. That leaked spurious tags into WDS task-filtered training targets.

Fix (opt-in only — default behavior unchanged) All new logic is gated behind suppress_empty_elements=True (default remains False):

• Text / table / picture: if an element’s body type is filtered out and there’s no visible content, drop the element entirely instead of emitting an empty tag or metadata-only shell
• Layout exception: if add_location=True and the item has provenance, keep the element so layout supervision still gets boxes
• Picture labels: under suppression, <label> is only emitted when picture/chart/chemistry content is actually requested (layout-only prompts get boxes, no classification label)
• New param: emit_picture_layer (default True) — lets callers omit <layer> on pictures (we set this to False in granite for picture-classification prompts)