### PR TITLE
perf: added simpler table cell representation for high volume parsing

### DIFF
--- a/docling_core/types/doc/document.py
+++ b/docling_core/types/doc/document.py
@@ -324,6 +324,17 @@ class PictureScatterChartData(PictureChartData):
     y_axis_label: str
     points: list[ChartPoint]
 
+@dataclass(slots=True)
+class FastTableCell:
+    text: str
+    row_span: int
+    col_span: int
+    start_row_offset_idx: int
+    end_row_offset_idx: int
+    start_col_offset_idx: int
+    end_col_offset_idx: int
+    column_header: bool = False
+    row_header: bool = False
 
 class TableCell(BaseModel):
     """TableCell."""
@@ -386,7 +397,7 @@ class RichTableCell(TableCell):
 
 
 AnyTableCell = Annotated[
-    Union[RichTableCell, TableCell],
+    Union[RichTableCell, TableCell, FastTableCell],
     Field(union_mode="left_to_right"),
 ]
 


### PR DESCRIPTION
This PR follows issue number [3328](https://github.com/docling-project/docling/issues/3328) and the proposed solution at PR [3692](https://github.com/docling-project/docling/pull/3692) at the docling project for high-volume XLSX parsing. 

TODO:
- Check schema/backward compatibility issues between dataclass and pydantic models