### PR TITLE
feat(doclang): add support for `<description>` and `<summary>`

### DIFF
--- a/docling_core/transforms/deserializer/doclang.py
+++ b/docling_core/transforms/deserializer/doclang.py
@@ -1533,9 +1533,9 @@ class DocLangDocDeserializer(BaseDocDeserializer, BaseModel):
         )
 
     def _apply_custom_meta_from_element(self, *, item: NodeItem, el: Element) -> None:
-        """Restore item meta from ``<custom>`` children in the element head."""
+        """Restore item meta from element-head property elements."""
         head_nodes, _ = self._split_element_children_head_body(el)
-        self._apply_custom_meta_from_head_nodes(item=item, head_nodes=head_nodes)
+        self._apply_meta_from_head_nodes(item=item, head_nodes=head_nodes)
 
     def _ensure_item_meta(self, item: DocItem) -> BaseMeta:
         """Return ``item.meta``, creating the appropriate meta model when absent."""
@@ -1578,16 +1578,25 @@ class DocLangDocDeserializer(BaseDocDeserializer, BaseModel):
             namespace, name = parsed
             meta.set_custom_field(namespace=namespace, name=name, value=value)
 
-    def _apply_custom_meta_from_head_nodes(self, *, item: NodeItem, head_nodes: Sequence[Node]) -> None:
-        """Restore item meta from ``<custom>`` children in the element head."""
+    def _apply_meta_from_head_nodes(self, *, item: NodeItem, head_nodes: Sequence[Node]) -> None:
+        """Restore item meta from element-head property elements."""
         if not isinstance(item, DocItem):
             return
         for node in head_nodes:
-            if not isinstance(node, Element) or node.tagName != DocLangToken.CUSTOM.value:
+            if not isinstance(node, Element):
                 continue
-            for child in node.childNodes:
-                if isinstance(child, Element):
-                    self._apply_custom_meta_field_element(item=item, field_el=child)
+            tag = node.tagName
+            if tag == DocLangToken.DESCRIPTION.value:
+                if isinstance(item, FloatingItem) and (text := self._get_text(node).strip()):
+                    meta = cast(FloatingMeta, self._ensure_item_meta(item))
+                    meta.description = DescriptionMetaField(text=text)
+            elif tag == DocLangToken.SUMMARY.value:
+                if text := self._get_text(node).strip():
+                    self._ensure_item_meta(item).summary = SummaryMetaField(text=text)
+            elif tag == DocLangToken.CUSTOM.value:
+                for child in node.childNodes:
+                    if isinstance(child, Element):
+                        self._apply_custom_meta_field_element(item=item, field_el=child)
 
     # ------------- Helpers -------------
     def _extract_caption(self, *, doc: DoclingDocument, el: Element) -> Optional[TextItem]:

--- a/docling_core/transforms/serializer/_doclang_utils.py
+++ b/docling_core/transforms/serializer/_doclang_utils.py
@@ -291,6 +291,8 @@ class DocLangToken(str, Enum):
     HEADING = "heading"
     TEXT = "text"
     CAPTION = "caption"
+    DESCRIPTION = "description"
+    SUMMARY = "summary"
     FOOTNOTE = "footnote"
     PAGE_HEADER = "page_header"
     PAGE_FOOTER = "page_footer"
@@ -1035,6 +1037,8 @@ _ELEMENT_HEAD_TAGS: Final[frozenset[str]] = frozenset(
         DocLangToken.HREF.value,
         DocLangToken.LOCATION.value,
         DocLangToken.CAPTION.value,
+        DocLangToken.DESCRIPTION.value,
+        DocLangToken.SUMMARY.value,
         DocLangToken.CUSTOM.value,
         DocLangToken.THREAD.value,
         DocLangToken.XREF.value,

--- a/docling_core/transforms/serializer/doclang.py
+++ b/docling_core/transforms/serializer/doclang.py
@@ -21,9 +21,7 @@ from typing_extensions import override
 
 from docling_core.transforms.serializer._doclang_utils import (
     _DOCLANG_LABEL_UNDEFINED,
-    _DOCLANG_META_TAG_DESCRIPTION,
     _DOCLANG_META_TAG_SMILES,
-    _DOCLANG_META_TAG_SUMMARY,
     _DOCLANG_VERSION,
     DOCLANG_DFLT_RESOLUTION,
     DOCLANG_NAMESPACE,
@@ -73,7 +71,6 @@ from docling_core.types.doc import (
     BoundingBox,
     CodeItem,
     ContentLayer,
-    DescriptionMetaField,
     DocItem,
     DoclingDocument,
     FloatingItem,
@@ -94,7 +91,6 @@ from docling_core.types.doc import (
     Script,
     SectionHeaderItem,
     Size,
-    SummaryMetaField,
     TableCell,
     TableData,
     TableItem,
@@ -324,6 +320,12 @@ def _text_item_hyperlink_uri(item: DocItem) -> Optional[str]:
     return None
 
 
+def _meta_field_serialization_allowed(name: str, params: DocLangParams) -> bool:
+    return (params.allowed_meta_names is None or name in params.allowed_meta_names) and (
+        name not in params.blocked_meta_names
+    )
+
+
 def _element_head_prefix(
     *,
     item: DocItem,
@@ -333,9 +335,10 @@ def _element_head_prefix(
     caption_text: Optional[str] = None,
     custom_text: Optional[str] = None,
     include_href: bool = True,
+    include_item_meta_head: bool = True,
     thread_id: Optional[str] = None,
 ) -> str:
-    """Emit element-head property elements in XSD order (label → thread → href → layer → location → caption → custom)."""
+    """Emit element-head property elements in XSD order (label → thread → href → layer → location → caption → description → summary → custom)."""
     parts: list[str] = []
     if label_value:
         parts.append(_create_label_token(value=label_value))
@@ -350,6 +353,26 @@ def _element_head_prefix(
             parts.append(loc)
     if caption_text:
         parts.append(caption_text)
+    if include_item_meta_head:
+        if (
+            isinstance(item, FloatingItem)
+            and item.meta
+            and item.meta.description
+            and _meta_field_serialization_allowed(MetaFieldName.DESCRIPTION, params)
+        ):
+            parts.append(
+                _wrap(
+                    text=_escape_text(item.meta.description.text, params),
+                    wrap_tag=DocLangToken.DESCRIPTION.value,
+                )
+            )
+        if item.meta and item.meta.summary and _meta_field_serialization_allowed(MetaFieldName.SUMMARY, params):
+            parts.append(
+                _wrap(
+                    text=_escape_text(item.meta.summary.text, params),
+                    wrap_tag=DocLangToken.SUMMARY.value,
+                )
+            )
     if custom_text:
         parts.append(custom_text)
     return "".join(parts)
@@ -1038,10 +1061,9 @@ class DocLangMetaSerializer(BaseModel, BaseMetaSerializer):
 
     def _serialize_meta_field(self, meta: BaseMeta, name: str, params: DocLangParams) -> Optional[str]:
         if (field_val := getattr(meta, name)) is not None:
-            if name == MetaFieldName.SUMMARY and isinstance(field_val, SummaryMetaField):
-                txt = _wrap(text=_escape_text(field_val.text, params), wrap_tag=_DOCLANG_META_TAG_SUMMARY)
-            elif name == MetaFieldName.DESCRIPTION and isinstance(field_val, DescriptionMetaField):
-                txt = _wrap(text=_escape_text(field_val.text, params), wrap_tag=_DOCLANG_META_TAG_DESCRIPTION)
+            if name in {MetaFieldName.SUMMARY, MetaFieldName.DESCRIPTION}:
+                # Emitted as native element-head ``<summary>`` / ``<description>``.
+                return None
             elif name == MetaFieldName.CLASSIFICATION:
                 # Picture classification is emitted as <label value="..."/> in element head.
                 return None
@@ -1197,6 +1219,7 @@ class DocLangPictureSerializer(BasePictureSerializer):
             label_value=picture_label,
             caption_text=caption_head or None,
             custom_text=custom_head or None,
+            include_item_meta_head=any_match,
         )
         inner = head + "".join(picture_body_parts)
         picture_open = f"<{DocLangToken.PICTURE.value}"

--- a/test/data/doc/cdata_always.gt.dclg.xml
+++ b/test/data/doc/cdata_always.gt.dclg.xml
@@ -182,11 +182,11 @@ Affiliation 2]]></content>
   <text><![CDATA[Some 'single' quotes]]></text>
   <text><![CDATA[Some "double" quotes]]></text>
   <text>
-    <custom>
-      <docling__summary><![CDATA[Summary with <tags> & ampersands]]></docling__summary>
-      <docling__description><![CDATA[Description content]]></docling__description>
-    </custom>
+    <summary><![CDATA[Summary with <tags> & ampersands]]></summary>
 <![CDATA[An ampersand: &]]>  </text>
+  <picture>
+    <description><![CDATA[Description content]]></description>
+  </picture>
   <code><![CDATA[0 == 0]]></code>
   <code>
     <content><![CDATA[ 1 leading space, 4 trailing    ]]></content>

--- a/test/data/doc/cdata_when_needed.gt.dclg.xml
+++ b/test/data/doc/cdata_when_needed.gt.dclg.xml
@@ -189,11 +189,11 @@ hyperlink
   <text><![CDATA[Some 'single' quotes]]></text>
   <text><![CDATA[Some "double" quotes]]></text>
   <text>
-    <custom>
-      <docling__summary><![CDATA[Summary with <tags> & ampersands]]></docling__summary>
-      <docling__description>Description content</docling__description>
-    </custom>
+    <summary><![CDATA[Summary with <tags> & ampersands]]></summary>
 <![CDATA[An ampersand: &]]>  </text>
+  <picture>
+    <description>Description content</description>
+  </picture>
   <code>0 == 0</code>
   <code>
     <content> 1 leading space, 4 trailing    </content>

--- a/test/data/doc/content_all.gt.dclg.xml
+++ b/test/data/doc/content_all.gt.dclg.xml
@@ -188,10 +188,8 @@ hyperlink
     <location value="15"/>
     <location value="502"/>
     <caption>Picture Caption</caption>
-    <custom>
-      <docling__summary>Picture Summary</docling__summary>
-      <docling__description>Picture Description</docling__description>
-    </custom>
+    <description>Picture Description</description>
+    <summary>Picture Summary</summary>
   </picture>
   <picture class="chart">
     <label value="pie_chart"/>
@@ -200,10 +198,8 @@ hyperlink
     <location value="15"/>
     <location value="502"/>
     <caption>Picture Caption</caption>
-    <custom>
-      <docling__summary>Picture Summary</docling__summary>
-      <docling__description>Picture Description</docling__description>
-    </custom>
+    <description>Picture Description</description>
+    <summary>Picture Summary</summary>
     <tabular>
       <fcel/>
       Foo

--- a/test/data/doc/content_block_specific.gt.dclg.xml
+++ b/test/data/doc/content_block_specific.gt.dclg.xml
@@ -169,10 +169,8 @@ hyperlink
     <location value="15"/>
     <location value="502"/>
     <caption>Picture Caption</caption>
-    <custom>
-      <docling__summary>Picture Summary</docling__summary>
-      <docling__description>Picture Description</docling__description>
-    </custom>
+    <description>Picture Description</description>
+    <summary>Picture Summary</summary>
   </picture>
   <picture class="chart">
     <label value="pie_chart"/>
@@ -181,10 +179,8 @@ hyperlink
     <location value="15"/>
     <location value="502"/>
     <caption>Picture Caption</caption>
-    <custom>
-      <docling__summary>Picture Summary</docling__summary>
-      <docling__description>Picture Description</docling__description>
-    </custom>
+    <description>Picture Description</description>
+    <summary>Picture Summary</summary>
     <tabular>
       <fcel/>
       Foo

--- a/test/data/doc/content_specific.gt.dclg.xml
+++ b/test/data/doc/content_specific.gt.dclg.xml
@@ -141,10 +141,8 @@
     <location value="15"/>
     <location value="502"/>
     <caption>Picture Caption</caption>
-    <custom>
-      <docling__summary>Picture Summary</docling__summary>
-      <docling__description>Picture Description</docling__description>
-    </custom>
+    <description>Picture Description</description>
+    <summary>Picture Summary</summary>
   </picture>
   <picture>
     <label value="pie_chart"/>
@@ -153,10 +151,8 @@
     <location value="15"/>
     <location value="502"/>
     <caption>Picture Caption</caption>
-    <custom>
-      <docling__summary>Picture Summary</docling__summary>
-      <docling__description>Picture Description</docling__description>
-    </custom>
+    <description>Picture Description</description>
+    <summary>Picture Summary</summary>
   </picture>
   <code>0 == 0</code>
   <code>

--- a/test/data/doc/dummy_doc_with_meta.gt.dclg.xml
+++ b/test/data/doc/dummy_doc_with_meta.gt.dclg.xml
@@ -4,8 +4,8 @@
     <location value="26"/>
     <location value="415"/>
     <location value="47"/>
+    <summary>This is a title.</summary>
     <custom>
-      <docling__summary>This is a title.</docling__summary>
       <my_corp__foo>More stuff here.</my_corp__foo>
     </custom>
     DocLayNet: A Large Human-Annotated Dataset for Document-Layout Analysis
@@ -23,8 +23,8 @@
       <location value="218"/>
       Figure 1: Four examples of complex page layouts across different document categories
     </caption>
+    <description>...</description>
     <custom>
-      <docling__description>...</docling__description>
       <docling__smiles>CC1=NNC(C2=CN3C=CN=C3C(CC3=CC(F)=CC(F)=C3)=N2)=N1</docling__smiles>
       <docling_legacy__misc><![CDATA[{'myanalysis': {'prediction': 'abc'}, 'something_else': {'text': 'aaa'}}]]></docling_legacy__misc>
     </custom>
@@ -34,9 +34,7 @@
       <location value="201"/>
       <location value="251"/>
       <location value="218"/>
-      <custom>
-        <docling__summary>This is a section header.</docling__summary>
-      </custom>
+      <summary>This is a section header.</summary>
       OPERATION (cont.)
     </heading>
   </picture>
@@ -45,5 +43,6 @@
     <location value="201"/>
     <location value="251"/>
     <location value="218"/>
+    <description>A description annotation for this table.</description>
   </table>
 </doclang>

--- a/test/data/doc/picture_molecule_meta/reserialized.dclg.xml
+++ b/test/data/doc/picture_molecule_meta/reserialized.dclg.xml
@@ -1,9 +1,9 @@
 <doclang>
   <picture class="chart">
     <label value="pie_chart"/>
+    <description>Picture meta description</description>
+    <summary>Picture meta summary</summary>
     <custom>
-      <docling__summary>Picture meta summary</docling__summary>
-      <docling__description>Picture meta description</docling__description>
       <docling__smiles>CC1=NNC(C2=CN3C=CN=C3C(CC3=CC(F)=CC(F)=C3)=N2)=N1</docling__smiles>
       <my_corp__note>custom field on picture meta</my_corp__note>
     </custom>

--- a/test/data/doc/picture_molecule_meta/serialized.dclg.xml
+++ b/test/data/doc/picture_molecule_meta/serialized.dclg.xml
@@ -1,9 +1,9 @@
 <doclang>
   <picture class="chart">
     <label value="pie_chart"/>
+    <description>Picture meta description</description>
+    <summary>Picture meta summary</summary>
     <custom>
-      <docling__summary>Picture meta summary</docling__summary>
-      <docling__description>Picture meta description</docling__description>
       <docling__smiles>CC1=NNC(C2=CN3C=CN=C3C(CC3=CC(F)=CC(F)=C3)=N2)=N1</docling__smiles>
       <my_corp__note>custom field on picture meta</my_corp__note>
     </custom>

--- a/test/test_deserializer_doclang.py
+++ b/test/test_deserializer_doclang.py
@@ -1993,8 +1993,8 @@ def test_picture_molecule_meta_roundtrip():
 
     dt = _serialize(doc)
     verify(serialized_dclg, dt)
-    assert f"<docling__summary>{_PICTURE_META_SUMMARY}</docling__summary>" in dt
-    assert f"<docling__description>{_PICTURE_META_DESCRIPTION}</docling__description>" in dt
+    assert f"<summary>{_PICTURE_META_SUMMARY}</summary>" in dt
+    assert f"<description>{_PICTURE_META_DESCRIPTION}</description>" in dt
     assert f"<docling__smiles>{_EXAMPLE_MOLECULE_SMILES}</docling__smiles>" in dt
     assert f"<my_corp__note>{_PICTURE_META_CUSTOM_VALUE}</my_corp__note>" in dt
     assert 'class="chart"' in dt

--- a/test/test_serialization_doclang.py
+++ b/test/test_serialization_doclang.py
@@ -22,6 +22,7 @@ from docling_core.transforms.serializer.doclang import (
     WrapMode,
 )
 from docling_core.types.doc import (
+    BaseMeta,
     BoundingBox,
     CodeLanguageLabel,
     CoordOrigin,
@@ -296,8 +297,11 @@ def _create_escape_test_doc(inp_doc: DoclingDocument):
     doc.add_text(label=DocItemLabel.TEXT, text="Some 'single' quotes")
     doc.add_text(label=DocItemLabel.TEXT, text='Some "double" quotes')
     text_item = doc.add_text(label=DocItemLabel.TEXT, text="An ampersand: &")
-    text_item.meta = PictureMeta(
+    text_item.meta = BaseMeta(
         summary=SummaryMetaField(text="Summary with <tags> & ampersands"),
+    )
+    pic = doc.add_picture()
+    pic.meta = PictureMeta(
         description=DescriptionMetaField(text="Description content"),
     )
     doc.add_code(text="0 == 0")


### PR DESCRIPTION
- Map `FloatingItem.meta.description` and `NodeItem.meta.summary` to native DocLang 0.7 element-head `<description>` and `<summary>` instead of `<custom><docling__…>` tags
- Deserialize the new head elements while keeping backward compatibility with legacy `docling__summary` / `docling__description` under `<custom>`
- Gate picture meta head emission on `content_types` via `include_item_meta_head`, preserving prior behavior when content filtering is enabled
- Update golden files and CDATA fixtures to use correct meta types (`BaseMeta` on `TextItem`, `PictureMeta` on `PictureItem`)