### PR TITLE
feat: add `ContentLayer.SHEET` and serialize Excel sheet groups in HTML and Markdown

### DIFF
--- a/docling_core/transforms/serializer/html.py
+++ b/docling_core/transforms/serializer/html.py
@@ -102,7 +102,7 @@ class HTMLParams(CommonParams):
     """HTML-specific serialization parameters."""
 
     # Default layers to use for HTML export
-    layers: set[ContentLayer] = {ContentLayer.BODY}
+    layers: set[ContentLayer] = {ContentLayer.BODY, ContentLayer.SHEET}
 
     # How to handle images
     image_mode: ImageRefMode = ImageRefMode.PLACEHOLDER
@@ -917,6 +917,8 @@ class HTMLFallbackSerializer(BaseFallbackSerializer):
         if isinstance(item, GroupItem):
             parts = doc_serializer.get_parts(item=item, **kwargs)
             text_res = "\n".join([p.text for p in parts if p.text])
+            if item.content_layer == ContentLayer.SHEET and item.name:
+                text_res = f'<section data-page-name="{item.name}">\n{text_res}\n</section>'
             return create_ser_result(text=text_res, span_source=parts)
         else:
             return create_ser_result(

--- a/docling_core/transforms/serializer/markdown.py
+++ b/docling_core/transforms/serializer/markdown.py
@@ -147,7 +147,7 @@ class OrigListItemMarkerMode(str, Enum):
 class MarkdownParams(CommonParams):
     """Markdown-specific serialization parameters."""
 
-    layers: set[ContentLayer] = {ContentLayer.BODY}
+    layers: set[ContentLayer] = {ContentLayer.BODY, ContentLayer.SHEET}
     image_mode: ImageRefMode = ImageRefMode.PLACEHOLDER
     image_placeholder: str = "<!-- image -->"
     enable_chart_tables: bool = True

--- a/docling_core/transforms/serializer/markdown_excel.py
+++ b/docling_core/transforms/serializer/markdown_excel.py
@@ -14,17 +14,20 @@ from docling_core.transforms.serializer.markdown import (
     MarkdownDocSerializer,
     MarkdownFallbackSerializer,
 )
-from docling_core.types.doc.document import DoclingDocument, GroupItem, NodeItem
-from docling_core.types.doc.labels import GroupLabel
+from docling_core.types.doc.document import (
+    ContentLayer,
+    DoclingDocument,
+    GroupItem,
+    NodeItem,
+)
 
 
 class MsExcelMarkdownFallbackSerializer(MarkdownFallbackSerializer):
-    """Fallback serializer that renders ``GroupLabel.SHEET`` groups as headings.
+    """Fallback serializer that renders sheet groups as Markdown headings.
 
-    When a ``GroupItem`` with ``label=GroupLabel.SHEET`` is encountered the
-    group's ``name`` is emitted as a level-2 Markdown heading (``##``) before
-    the group's children, matching the visual structure of the original
-    workbook where each worksheet has a name.
+    When a ``GroupItem`` with ``content_layer=ContentLayer.SHEET`` is encountered
+    the group's ``name`` is emitted as a level-2 Markdown heading (``##``) before
+    the group's children, matching the visual structure of the original workbook.
     """
 
     @override
@@ -36,7 +39,7 @@ class MsExcelMarkdownFallbackSerializer(MarkdownFallbackSerializer):
         doc: DoclingDocument,
         **kwargs: Any,
     ) -> SerializationResult:
-        if isinstance(item, GroupItem) and item.label == GroupLabel.SHEET:
+        if isinstance(item, GroupItem) and item.content_layer == ContentLayer.SHEET:
             parts = doc_serializer.get_parts(item=item, **kwargs)
             content = "\n\n".join(p.text for p in parts if p.text)
             heading = f"## {item.name}"
@@ -49,7 +52,7 @@ class MsExcelMarkdownDocSerializer(MarkdownDocSerializer):
     r"""``MarkdownDocSerializer`` variant for Excel-sourced ``DoclingDocument``\\s.
 
     Swap in :class:`MsExcelMarkdownFallbackSerializer` so that worksheet
-    groups (``GroupLabel.SHEET``) are rendered with their name as a Markdown
+    groups (``ContentLayer.SHEET``) are rendered with their name as a Markdown
     heading without requiring heading nodes to be injected into the document
     model by the backend.
 

--- a/docling_core/types/doc/document.py
+++ b/docling_core/types/doc/document.py
@@ -1396,9 +1396,10 @@ class ContentLayer(str, Enum):
     BACKGROUND = "background"  # eg watermarks
     INVISIBLE = "invisible"  # hidden or invisible text
     NOTES = "notes"  # author/speaker notes, corrections, etc
+    SHEET = "sheet"  # spreadsheet worksheet content (Excel sheets)
 
 
-DEFAULT_CONTENT_LAYERS = {ContentLayer.BODY}
+DEFAULT_CONTENT_LAYERS = {ContentLayer.BODY, ContentLayer.SHEET}
 
 
 class _ExtraAllowingModel(BaseModel):

--- a/docs/DoclingDocument.json
+++ b/docs/DoclingDocument.json
@@ -576,7 +576,8 @@
         "furniture",
         "background",
         "invisible",
-        "notes"
+        "notes",
+        "sheet"
       ],
       "title": "ContentLayer",
       "type": "string"

--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -22,6 +22,9 @@ from docling_core.transforms.serializer.markdown import (
     OrigListItemMarkerMode,
     _cell_content_has_table,
 )
+from docling_core.transforms.serializer.markdown_excel import (
+    MsExcelMarkdownDocSerializer,
+)
 from docling_core.transforms.serializer.webvtt import WebVTTDocSerializer, WebVTTParams
 from docling_core.transforms.visualizer.layout_visualizer import LayoutVisualizer
 from docling_core.types.doc import DoclingDocument
@@ -29,6 +32,7 @@ from docling_core.types.doc.base import ImageRefMode
 from docling_core.types.doc.document import (
     BaseMeta,
     CharSpan,
+    ContentLayer,
     DescriptionAnnotation,
     EntitiesMetaField,
     EntityMention,
@@ -43,7 +47,7 @@ from docling_core.types.doc.document import (
     TableData,
     TextItem,
 )
-from docling_core.types.doc.labels import DocItemLabel
+from docling_core.types.doc.labels import DocItemLabel, GroupLabel
 
 from .test_data_gen_flag import GEN_TEST_DATA
 
@@ -1103,3 +1107,31 @@ def test_html_meta_emits_xhtml_compatible_attributes():
     assert 'data-meta-name="entities"' in html_out
     # Output must be parseable by a strict XML parser.
     ET.fromstring(html_out)
+
+
+def _build_two_sheet_doc() -> DoclingDocument:
+    doc = DoclingDocument(name="workbook")
+    for sheet_name in ("Sales", "Costs"):
+        sheet = doc.add_group(
+            label=GroupLabel.SHEET,
+            name=sheet_name,
+            content_layer=ContentLayer.SHEET,
+        )
+        doc.add_text(label=DocItemLabel.TEXT, text=f"Data from {sheet_name}", parent=sheet)
+    return doc
+
+
+def test_sheet_html_section_wrapping():
+    """HTMLFallbackSerializer wraps ContentLayer.SHEET groups in <section>."""
+    doc = _build_two_sheet_doc()
+    html = HTMLDocSerializer(doc=doc).serialize().text
+    assert '<section data-page-name="Sales">' in html
+    assert '<section data-page-name="Costs">' in html
+
+
+def test_sheet_markdown_heading():
+    """MsExcelMarkdownFallbackSerializer emits ## headings for sheet groups."""
+    doc = _build_two_sheet_doc()
+    md = MsExcelMarkdownDocSerializer(doc=doc).serialize().text
+    assert "## Sales" in md
+    assert "## Costs" in md


### PR DESCRIPTION
When converting a multi-sheet Excel file, there was no way to tell which table or piece of content belonged to which worksheet in the HTML or Markdown output. This PR fixes that by tagging visible worksheet groups with a dedicated content layer, so the HTML serializer can wrap each sheet's content in a labeled `<section>` element and the Markdown serializer can emit a heading for each sheet.