### PR TITLE
feat: serialize subscript and superscript in Markdown export

### DIFF
--- a/docling_core/transforms/serializer/markdown.py
+++ b/docling_core/transforms/serializer/markdown.py
@@ -868,6 +868,16 @@ class MarkdownDocSerializer(DocSerializer):
         return f"~~{text}~~"
 
     @override
+    def serialize_subscript(self, text: str, **kwargs: Any):
+        """Apply Markdown-specific subscript serialization."""
+        return f"<sub>{text}</sub>"
+
+    @override
+    def serialize_superscript(self, text: str, **kwargs: Any):
+        """Apply Markdown-specific superscript serialization."""
+        return f"<sup>{text}</sup>"
+
+    @override
     def serialize_hyperlink(
         self,
         text: str,

--- a/docling_core/transforms/serializer/plain_text.py
+++ b/docling_core/transforms/serializer/plain_text.py
@@ -43,8 +43,9 @@ class PlainTextDocSerializer(MarkdownDocSerializer):
     """Document serializer that produces clean plain text.
 
     Strips all Markdown decoration — heading markers, bold/italic/strikethrough
-    markers, and hyperlink syntax — while keeping list bullets (``-``), ordered
-    list numbers, and table-cell separators (``|``) intact.
+    markers, sub/superscript tags, and hyperlink syntax — while keeping list
+    bullets (``-``), ordered list numbers, and table-cell separators (``|``)
+    intact.
     """
 
     text_serializer: BaseTextSerializer = PlainTextTextSerializer()
@@ -63,6 +64,16 @@ class PlainTextDocSerializer(MarkdownDocSerializer):
     @override
     def serialize_strikethrough(self, text: str, **kwargs: Any) -> str:
         """Apply plain-text strikethrough serialization."""
+        return text
+
+    @override
+    def serialize_subscript(self, text: str, **kwargs: Any) -> str:
+        """Apply plain-text subscript serialization."""
+        return text
+
+    @override
+    def serialize_superscript(self, text: str, **kwargs: Any) -> str:
+        """Apply plain-text superscript serialization."""
         return text
 
     @override

--- a/test/data/doc/constructed_doc.embedded.md.gt
+++ b/test/data/doc/constructed_doc.embedded.md.gt
@@ -61,7 +61,7 @@ $$E=mc^2$$
 
 <!-- missing-form-item -->
 
-Some formatting chops: **bold** *italic* underline ~~strikethrough~~ subscript superscript [hyperlink](.) &amp; [~~***everything at the same time.***~~](https://github.com/DS4SD/docling)
+Some formatting chops: **bold** *italic* underline ~~strikethrough~~ <sub>subscript</sub> <sup>superscript</sup> [hyperlink](.) &amp; [~~***everything at the same time.***~~](https://github.com/DS4SD/docling)
 
 - (i) Item 1 in A
 - (ii) Item 2 in A

--- a/test/data/doc/constructed_doc.placeholder.md.gt
+++ b/test/data/doc/constructed_doc.placeholder.md.gt
@@ -61,7 +61,7 @@ $$E=mc^2$$
 
 <!-- missing-form-item -->
 
-Some formatting chops: **bold** *italic* underline ~~strikethrough~~ subscript superscript [hyperlink](.) &amp; [~~***everything at the same time.***~~](https://github.com/DS4SD/docling)
+Some formatting chops: **bold** *italic* underline ~~strikethrough~~ <sub>subscript</sub> <sup>superscript</sup> [hyperlink](.) &amp; [~~***everything at the same time.***~~](https://github.com/DS4SD/docling)
 
 - (i) Item 1 in A
 - (ii) Item 2 in A

--- a/test/data/doc/constructed_doc.referenced.md.gt
+++ b/test/data/doc/constructed_doc.referenced.md.gt
@@ -61,7 +61,7 @@ $$E=mc^2$$
 
 <!-- missing-form-item -->
 
-Some formatting chops: **bold** *italic* underline ~~strikethrough~~ subscript superscript [hyperlink](.) &amp; [~~***everything at the same time.***~~](https://github.com/DS4SD/docling)
+Some formatting chops: **bold** *italic* underline ~~strikethrough~~ <sub>subscript</sub> <sup>superscript</sup> [hyperlink](.) &amp; [~~***everything at the same time.***~~](https://github.com/DS4SD/docling)
 
 - (i) Item 1 in A
 - (ii) Item 2 in A

--- a/test/data/doc/constructed_document.yaml.md
+++ b/test/data/doc/constructed_document.yaml.md
@@ -61,7 +61,7 @@ $$E=mc^2$$
 
 <!-- missing-form-item -->
 
-Some formatting chops: **bold** *italic* underline ~~strikethrough~~ subscript superscript [hyperlink](.) &amp; [~~***everything at the same time.***~~](https://github.com/DS4SD/docling)
+Some formatting chops: **bold** *italic* underline ~~strikethrough~~ <sub>subscript</sub> <sup>superscript</sup> [hyperlink](.) &amp; [~~***everything at the same time.***~~](https://github.com/DS4SD/docling)
 
 - (i) Item 1 in A
 - (ii) Item 2 in A

--- a/test/data/doc/constructed_legacy_annot_mark_false.gt.md
+++ b/test/data/doc/constructed_legacy_annot_mark_false.gt.md
@@ -63,7 +63,7 @@ $$E=mc^2$$
 
 <!-- missing-form-item -->
 
-Some formatting chops: **bold** *italic* underline ~~strikethrough~~ subscript superscript [hyperlink](.) &amp; [~~***everything at the same time.***~~](https://github.com/DS4SD/docling)
+Some formatting chops: **bold** *italic* underline ~~strikethrough~~ <sub>subscript</sub> <sup>superscript</sup> [hyperlink](.) &amp; [~~***everything at the same time.***~~](https://github.com/DS4SD/docling)
 
 - (i) Item 1 in A
 - (ii) Item 2 in A

--- a/test/data/doc/constructed_legacy_annot_mark_true.gt.md
+++ b/test/data/doc/constructed_legacy_annot_mark_true.gt.md
@@ -63,7 +63,7 @@ $$E=mc^2$$
 
 <!-- missing-form-item -->
 
-Some formatting chops: **bold** *italic* underline ~~strikethrough~~ subscript superscript [hyperlink](.) &amp; [~~***everything at the same time.***~~](https://github.com/DS4SD/docling)
+Some formatting chops: **bold** *italic* underline ~~strikethrough~~ <sub>subscript</sub> <sup>superscript</sup> [hyperlink](.) &amp; [~~***everything at the same time.***~~](https://github.com/DS4SD/docling)
 
 - (i) Item 1 in A
 - (ii) Item 2 in A

--- a/test/data/doc/constructed_mode_always_valid_false.gt.md
+++ b/test/data/doc/constructed_mode_always_valid_false.gt.md
@@ -61,7 +61,7 @@ $$E=mc^2$$
 
 <!-- missing-form-item -->
 
-Some formatting chops: **bold** *italic* underline ~~strikethrough~~ subscript superscript [hyperlink](.) &amp; [~~***everything at the same time.***~~](https://github.com/DS4SD/docling)
+Some formatting chops: **bold** *italic* underline ~~strikethrough~~ <sub>subscript</sub> <sup>superscript</sup> [hyperlink](.) &amp; [~~***everything at the same time.***~~](https://github.com/DS4SD/docling)
 
 (i) Item 1 in A
 (ii) Item 2 in A

--- a/test/data/doc/constructed_mode_always_valid_true.gt.md
+++ b/test/data/doc/constructed_mode_always_valid_true.gt.md
@@ -61,7 +61,7 @@ $$E=mc^2$$
 
 <!-- missing-form-item -->
 
-Some formatting chops: **bold** *italic* underline ~~strikethrough~~ subscript superscript [hyperlink](.) &amp; [~~***everything at the same time.***~~](https://github.com/DS4SD/docling)
+Some formatting chops: **bold** *italic* underline ~~strikethrough~~ <sub>subscript</sub> <sup>superscript</sup> [hyperlink](.) &amp; [~~***everything at the same time.***~~](https://github.com/DS4SD/docling)
 
 1. (i) Item 1 in A
 2. (ii) Item 2 in A

--- a/test/data/doc/constructed_mode_auto_valid_false.gt.md
+++ b/test/data/doc/constructed_mode_auto_valid_false.gt.md
@@ -61,7 +61,7 @@ $$E=mc^2$$
 
 <!-- missing-form-item -->
 
-Some formatting chops: **bold** *italic* underline ~~strikethrough~~ subscript superscript [hyperlink](.) &amp; [~~***everything at the same time.***~~](https://github.com/DS4SD/docling)
+Some formatting chops: **bold** *italic* underline ~~strikethrough~~ <sub>subscript</sub> <sup>superscript</sup> [hyperlink](.) &amp; [~~***everything at the same time.***~~](https://github.com/DS4SD/docling)
 
 (i) Item 1 in A
 (ii) Item 2 in A

--- a/test/data/doc/constructed_mode_auto_valid_true.gt.md
+++ b/test/data/doc/constructed_mode_auto_valid_true.gt.md
@@ -61,7 +61,7 @@ $$E=mc^2$$
 
 <!-- missing-form-item -->
 
-Some formatting chops: **bold** *italic* underline ~~strikethrough~~ subscript superscript [hyperlink](.) &amp; [~~***everything at the same time.***~~](https://github.com/DS4SD/docling)
+Some formatting chops: **bold** *italic* underline ~~strikethrough~~ <sub>subscript</sub> <sup>superscript</sup> [hyperlink](.) &amp; [~~***everything at the same time.***~~](https://github.com/DS4SD/docling)
 
 - (i) Item 1 in A
 - (ii) Item 2 in A

--- a/test/data/doc/constructed_mode_never_valid_false.gt.md
+++ b/test/data/doc/constructed_mode_never_valid_false.gt.md
@@ -61,7 +61,7 @@ $$E=mc^2$$
 
 <!-- missing-form-item -->
 
-Some formatting chops: **bold** *italic* underline ~~strikethrough~~ subscript superscript [hyperlink](.) &amp; [~~***everything at the same time.***~~](https://github.com/DS4SD/docling)
+Some formatting chops: **bold** *italic* underline ~~strikethrough~~ <sub>subscript</sub> <sup>superscript</sup> [hyperlink](.) &amp; [~~***everything at the same time.***~~](https://github.com/DS4SD/docling)
 
 Item 1 in A
 Item 2 in A

--- a/test/data/doc/constructed_mode_never_valid_true.gt.md
+++ b/test/data/doc/constructed_mode_never_valid_true.gt.md
@@ -61,7 +61,7 @@ $$E=mc^2$$
 
 <!-- missing-form-item -->
 
-Some formatting chops: **bold** *italic* underline ~~strikethrough~~ subscript superscript [hyperlink](.) &amp; [~~***everything at the same time.***~~](https://github.com/DS4SD/docling)
+Some formatting chops: **bold** *italic* underline ~~strikethrough~~ <sub>subscript</sub> <sup>superscript</sup> [hyperlink](.) &amp; [~~***everything at the same time.***~~](https://github.com/DS4SD/docling)
 
 1. Item 1 in A
 2. Item 2 in A

--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -24,7 +24,7 @@ from docling_core.transforms.serializer.markdown import (
 )
 from docling_core.transforms.serializer.webvtt import WebVTTDocSerializer, WebVTTParams
 from docling_core.transforms.visualizer.layout_visualizer import LayoutVisualizer
-from docling_core.types.doc import DoclingDocument
+from docling_core.types.doc import DoclingDocument, Formatting, Script
 from docling_core.types.doc.base import ImageRefMode
 from docling_core.types.doc.document import (
     BaseMeta,
@@ -202,6 +202,32 @@ def test_md_inline_and_formatting():
     )
     actual = ser.serialize().text
     verify(exp_file=src.with_suffix(".gt.md"), actual=actual)
+
+
+def test_md_subscript_formatting():
+    """Subscript spans are exported as inline <sub> HTML in Markdown."""
+    doc = DoclingDocument(name="test")
+    doc.add_text(
+        label=DocItemLabel.TEXT,
+        text="H2O",
+        formatting=Formatting(script=Script.SUB),
+    )
+
+    actual = MarkdownDocSerializer(doc=doc).serialize().text
+    assert "<sub>H2O</sub>" in actual
+
+
+def test_md_superscript_formatting():
+    """Superscript spans are exported as inline <sup> HTML in Markdown."""
+    doc = DoclingDocument(name="test")
+    doc.add_text(
+        label=DocItemLabel.TEXT,
+        text="2",
+        formatting=Formatting(script=Script.SUPER),
+    )
+
+    actual = MarkdownDocSerializer(doc=doc).serialize().text
+    assert "<sup>2</sup>" in actual
 
 
 def test_md_pb_placeholder_and_page_filter():


### PR DESCRIPTION
## Summary

The Markdown serializer drops subscript and superscript formatting. A text span marked `Formatting(script=Script.SUB)` or `Script.SUPER` is written out as plain text, so a subscript like the 2 in `H2O` or an exponent like `E=mc2` becomes an ordinary digit with no way to recover it. The HTML serializer already preserves these as `<sub>`/`<sup>`; the Markdown serializer never implemented the hooks.

This adds them. #319 introduced the sub/superscript model and the HTML support but intentionally left Markdown out, since the Pandoc `~x~`/`^x^` syntax is uncommon and does not render in editors like VS Code. Emitting inline `<sub>`/`<sup>` avoids that: it renders on GitHub and in any CommonMark viewer, and it matches what the HTML serializer already produces, so Markdown and HTML stay in sync.

Addresses docling-project/docling#520.

## Changes

- `docling_core/transforms/serializer/markdown.py`: implement `serialize_subscript` and `serialize_superscript`, returning `<sub>{text}</sub>` and `<sup>{text}</sup>`. They run in `post_process` after the content is HTML-escaped, like the existing bold/italic/strikethrough hooks, so only the wrapping tags are literal.
- `docling_core/transforms/serializer/plain_text.py`: `PlainTextDocSerializer` subclasses the Markdown serializer, so it would otherwise inherit the new tags. Override both hooks to return the text unchanged, consistent with how it already strips bold/italic/strikethrough.
- `test/test_serialization.py`: add `test_md_subscript_formatting` and `test_md_superscript_formatting`.
- Regenerated the Markdown reference data under `test/data/doc/`. The shared test fixture already contains sub/superscript spans, so their Markdown ground truth now renders `<sub>`/`<sup>` (one changed line per file). Note: this updates reference test data, which requires a double review per CONTRIBUTING.

## Example

```python
doc.add_text(label=DocItemLabel.TEXT, text="H2O", formatting=Formatting(script=Script.SUB))
doc.export_to_markdown()
```

Before: `H2O`
After: `<sub>H2O</sub>`

I also checked this directly by exporting the same document with and without the change and rendering both outputs. The subscript and superscript text now displays as actual sub/superscript instead of flat text.

## Testing

All run locally and passing:

- `uv run pytest`: 544 passed, 6 skipped
- `uv run ruff check` and `uv run ruff format --check`: clean
- `uv run mypy docling_core test`: clean
- New unit tests assert `<sub>`/`<sup>` in the Markdown output; the plain-text serializer test confirms the tags are stripped there
