### PR TITLE
feat: add enable_chart_tables and traverse_pictures to save_as_markdown

### DIFF
--- a/docling_core/types/doc/document.py
+++ b/docling_core/types/doc/document.py
@@ -6322,10 +6322,7 @@ class DoclingDocument(BaseModel):
         compact_tables: bool = False,
         *,
         enable_chart_tables: bool = True,
-        mark_annotations: bool = False,
         traverse_pictures: bool = False,
-        allowed_meta_names: Optional[set[str]] = None,
-        blocked_meta_names: Optional[set[str]] = None,
         mark_meta: bool = False,
         use_legacy_annotations: Optional[bool] = None,  # deprecated
     ):
@@ -6356,12 +6353,9 @@ class DoclingDocument(BaseModel):
             included_content_layers=included_content_layers,
             page_break_placeholder=page_break_placeholder,
             include_annotations=include_annotations,
-            mark_annotations=mark_annotations,
             compact_tables=compact_tables,
             traverse_pictures=traverse_pictures,
             use_legacy_annotations=use_legacy_annotations,
-            allowed_meta_names=allowed_meta_names,
-            blocked_meta_names=blocked_meta_names,
             mark_meta=mark_meta,
         )
 

--- a/docling_core/types/doc/document.py
+++ b/docling_core/types/doc/document.py
@@ -6321,6 +6321,11 @@ class DoclingDocument(BaseModel):
         include_annotations: bool = True,
         compact_tables: bool = False,
         *,
+        enable_chart_tables: bool = True,
+        mark_annotations: bool = False,
+        traverse_pictures: bool = False,
+        allowed_meta_names: Optional[set[str]] = None,
+        blocked_meta_names: Optional[set[str]] = None,
         mark_meta: bool = False,
         use_legacy_annotations: Optional[bool] = None,  # deprecated
     ):
@@ -6343,6 +6348,7 @@ class DoclingDocument(BaseModel):
             escape_html=escape_html,
             escape_underscores=escaping_underscores,
             image_placeholder=image_placeholder,
+            enable_chart_tables=enable_chart_tables,
             image_mode=image_mode,
             indent=indent,
             text_width=text_width,
@@ -6350,8 +6356,12 @@ class DoclingDocument(BaseModel):
             included_content_layers=included_content_layers,
             page_break_placeholder=page_break_placeholder,
             include_annotations=include_annotations,
+            mark_annotations=mark_annotations,
             compact_tables=compact_tables,
+            traverse_pictures=traverse_pictures,
             use_legacy_annotations=use_legacy_annotations,
+            allowed_meta_names=allowed_meta_names,
+            blocked_meta_names=blocked_meta_names,
             mark_meta=mark_meta,
         )
 


### PR DESCRIPTION
### What

`save_as_markdown` already forwards most of `export_to_markdown`'s parameters, but five were missing, so callers using `save_as_markdown` silently got the defaults for them:

- `enable_chart_tables` (default `True`)
- ~`mark_annotations` (default `False`)~
- `traverse_pictures` (default `False`)
- ~`allowed_meta_names` (default `None`)~
- ~`blocked_meta_names` (default `None`)~

This adds them as keyword-only arguments with the same defaults as `export_to_markdown` and forwards them through.

Note: `mark_annotations`, `allowed_meta_names`, and `blocked_meta_names` are not propagated since they are either deprecated or legacy arguments from old implementations.

### Why

Fixes #619 — `save_as_markdown` should expose the same output options as `export_to_markdown` rather than dropping a subset to defaults.

### Notes

- Defaults are identical to `export_to_markdown`, so existing behavior is unchanged.
- New parameters are keyword-only (added after `*`), so no existing positional call to `save_as_markdown` is affected.
- The `escaping_underscores` → `escape_underscores` naming note from the earlier attempt (#629) is already handled on `main`, so it is intentionally left untouched here.
- Kept to a single-file, behavior-preserving change with no test-data changes; existing serialization/document tests pass locally (ruff, mypy, pytest, docs pre-commit hooks all green).