### PR TITLE
fix: normalize image reference paths to POSIX format

### DIFF
--- a/docling_core/types/doc/document.py
+++ b/docling_core/types/doc/document.py
@@ -5918,7 +5918,7 @@ class DoclingDocument(BaseModel):
                                 scale = img.size[0] / item.prov[0].bbox.width
                                 item.image = ImageRef.from_pil(image=img, dpi=round(72 * scale))
                             elif item.image is not None:
-                                item.image.uri = Path(obj_path)
+                                item.image.uri = Path(obj_path).as_posix()
 
                         # if item.image._pil is not None:
                         #    item.image._pil.close()


### PR DESCRIPTION
## Summary

This PR fixes Windows-specific image reference paths when exporting documents with referenced images.

Currently, image URIs are stored using the platform-specific path separator. On Windows this results in backslashes (`\`), which are URL-encoded as `%5C` in HTML output and also appear in Markdown image references.

This change normalizes the generated image URI to POSIX format using `Path(...).as_posix()`, ensuring consistent forward-slash (`/`) separators across platforms.

## Changes

* Normalize referenced image paths using `Path(obj_path).as_posix()`.
* Preserve cross-platform compatibility for HTML and Markdown image references.

## Testing

* Verified the implementation on Windows.
* Confirmed that generated image references use `/` instead of `\` (or `%5C` in HTML).
* Ran formatting and lint checks locally.
