### PR TITLE
feat(document): add change_type field to TextItem

### DIFF
--- a/docling_core/types/doc/document.py
+++ b/docling_core/types/doc/document.py
@@ -1977,6 +1977,7 @@ class TextItem(DocItem):
 
     formatting: Optional[Formatting] = None
     hyperlink: Optional[Union[AnyUrl, Path]] = Field(union_mode="left_to_right", default=None)
+    change_type: Optional[typing.Literal["inserted", "deleted"]] = None
 
     @deprecated("Use export_to_doctags() instead.")
     def export_to_document_tokens(self, *args, **kwargs):
@@ -4210,6 +4211,7 @@ class DoclingDocument(BaseModel):
         hyperlink: Optional[Union[AnyUrl, Path]] = None,
         *,
         source: Optional[SourceType] = None,
+        change_type: Optional[typing.Literal["inserted", "deleted"]] = None,
         **kwargs: Any,
     ):
         """add_text.
@@ -4317,6 +4319,7 @@ class DoclingDocument(BaseModel):
                 parent=parent.get_ref(),
                 formatting=formatting,
                 hyperlink=hyperlink,
+                change_type=change_type,
             )
             if prov:
                 text_item.prov.append(prov)


### PR DESCRIPTION
Adds an optional change_type field to TextItem with values 'inserted' or 'deleted' (None means normal/final text). Also threads the parameter through DoclingDocument.add_text() so backends can set it at creation time.

Needed by the docling DOCX backend to represent tracked changes in 'raw' mode without hijacking underline/strikethrough formatting.