### PR TITLE
feat(document): register the Box Note mime type

### DIFF
--- a/docling_core/types/doc/document.py
+++ b/docling_core/types/doc/document.py
@@ -1074,22 +1074,23 @@ class DocumentOrigin(BaseModel):
     )
 
     _extra_mimetypes: typing.ClassVar[list[str]] = [
+        "application/vnd.box.boxnote",
+        "application/vnd.oasis.opendocument.presentation",
+        "application/vnd.oasis.opendocument.spreadsheet",
+        "application/vnd.oasis.opendocument.text",
+        "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+        "application/vnd.openxmlformats-officedocument.presentationml.slideshow",
+        "application/vnd.openxmlformats-officedocument.presentationml.template",
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
         "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
         "application/vnd.openxmlformats-officedocument.wordprocessingml.template",
-        "application/vnd.openxmlformats-officedocument.presentationml.template",
-        "application/vnd.openxmlformats-officedocument.presentationml.slideshow",
-        "application/vnd.openxmlformats-officedocument.presentationml.presentation",
-        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-        "application/vnd.oasis.opendocument.text",
-        "application/vnd.oasis.opendocument.spreadsheet",
-        "application/vnd.oasis.opendocument.presentation",
-        "text/asciidoc",
-        "text/markdown",
-        "text/csv",
-        "text/vtt",
-        "audio/x-wav",
-        "audio/wav",
         "audio/mp3",
+        "audio/wav",
+        "audio/x-wav",
+        "text/asciidoc",
+        "text/csv",
+        "text/markdown",
+        "text/vtt",
     ]
 
     @field_validator("binary_hash", mode="before")


### PR DESCRIPTION
`DocumentOrigin` rejects `application/vnd.box.boxnote` because it isn't in Python's `mimetypes` registry, so the Box Note backend in docling (docling-project/docling#3722) falls back to `application/json`. This registers it in `_extra_mimetypes`, alongside the other vendor types, so the backend can use the correct mime.

Per @ceberam's review on that PR.