### PR TITLE
feat(md): implement key-value table serialization in MarkdownKeyValueSerializer

### DIFF
--- a/docling_core/transforms/serializer/markdown.py
+++ b/docling_core/transforms/serializer/markdown.py
@@ -70,6 +70,7 @@ from docling_core.types.doc.document import (
     TitleItem,
     TopicsMetaField,
 )
+from docling_core.types.doc.labels import GraphCellLabel, GraphLinkLabel
 
 _logger = logging.getLogger(__name__)
 
@@ -698,15 +699,42 @@ class MarkdownKeyValueSerializer(BaseKeyValueSerializer):
         doc: DoclingDocument,
         **kwargs: Any,
     ) -> SerializationResult:
-        """Serializes the passed item."""
-        # TODO add actual implementation
-        if item.self_ref not in doc_serializer.get_excluded_refs():
-            return create_ser_result(
-                text="<!-- missing-key-value-item -->",
-                span_source=item,
-            )
-        else:
+        """Serializes the passed item as a Markdown table of key/value pairs."""
+        if item.self_ref in doc_serializer.get_excluded_refs(**kwargs):
             return create_ser_result()
+
+        cells_by_id = {cell.cell_id: cell for cell in item.graph.cells}
+        value_ids_by_key_id: dict[int, list[int]] = {}
+        for link in item.graph.links:
+            if link.label != GraphLinkLabel.TO_VALUE:
+                continue
+            value_ids_by_key_id.setdefault(link.source_cell_id, []).append(link.target_cell_id)
+
+        rows: list[tuple[str, str]] = []
+        linked_value_ids: set[int] = set()
+        for cell in item.graph.cells:
+            if cell.label != GraphCellLabel.KEY:
+                continue
+            value_ids = value_ids_by_key_id.get(cell.cell_id, [])
+            linked_value_ids.update(value_ids)
+            values = [cells_by_id[vid].text for vid in value_ids if vid in cells_by_id]
+            rows.append((cell.text, "; ".join(values)))
+
+        # Include values that aren't linked to any key (orphan values).
+        for cell in item.graph.cells:
+            if cell.label == GraphCellLabel.VALUE and cell.cell_id not in linked_value_ids:
+                rows.append(("", cell.text))
+
+        if not rows:
+            return create_ser_result()
+
+        def esc(text: str) -> str:
+            return text.replace("|", "\\|").replace("\n", " ")
+
+        lines = ["| Key | Value |", "| --- | --- |"]
+        lines.extend(f"| {esc(key)} | {esc(value)} |" for key, value in rows)
+
+        return create_ser_result(text="\n".join(lines), span_source=item)
 
 
 class MarkdownFormSerializer(BaseFormSerializer):

--- a/test/data/doc/constructed.gt.txt
+++ b/test/data/doc/constructed.gt.txt
@@ -51,7 +51,9 @@ Here a formula block:
 
 $$E=mc^2$$
 
-<!-- missing-key-value-item -->
+| Key | Value |
+| --- | --- |
+| number | 1 |
 
 <!-- missing-form-item -->
 

--- a/test/data/doc/constructed_legacy_annot_mark_false.gt.md
+++ b/test/data/doc/constructed_legacy_annot_mark_false.gt.md
@@ -59,7 +59,9 @@ Here a formula block:
 
 $$E=mc^2$$
 
-<!-- missing-key-value-item -->
+| Key | Value |
+| --- | --- |
+| number | 1 |
 
 <!-- missing-form-item -->
 

--- a/test/data/doc/constructed_legacy_annot_mark_true.gt.md
+++ b/test/data/doc/constructed_legacy_annot_mark_true.gt.md
@@ -59,7 +59,9 @@ Here a formula block:
 
 $$E=mc^2$$
 
-<!-- missing-key-value-item -->
+| Key | Value |
+| --- | --- |
+| number | 1 |
 
 <!-- missing-form-item -->
 

--- a/test/data/doc/constructed_mode_always_valid_false.gt.md
+++ b/test/data/doc/constructed_mode_always_valid_false.gt.md
@@ -57,7 +57,9 @@ Here a formula block:
 
 $$E=mc^2$$
 
-<!-- missing-key-value-item -->
+| Key | Value |
+| --- | --- |
+| number | 1 |
 
 <!-- missing-form-item -->
 

--- a/test/data/doc/constructed_mode_always_valid_true.gt.md
+++ b/test/data/doc/constructed_mode_always_valid_true.gt.md
@@ -57,7 +57,9 @@ Here a formula block:
 
 $$E=mc^2$$
 
-<!-- missing-key-value-item -->
+| Key | Value |
+| --- | --- |
+| number | 1 |
 
 <!-- missing-form-item -->
 

--- a/test/data/doc/constructed_mode_auto_valid_false.gt.md
+++ b/test/data/doc/constructed_mode_auto_valid_false.gt.md
@@ -57,7 +57,9 @@ Here a formula block:
 
 $$E=mc^2$$
 
-<!-- missing-key-value-item -->
+| Key | Value |
+| --- | --- |
+| number | 1 |
 
 <!-- missing-form-item -->
 

--- a/test/data/doc/constructed_mode_auto_valid_true.gt.md
+++ b/test/data/doc/constructed_mode_auto_valid_true.gt.md
@@ -57,7 +57,9 @@ Here a formula block:
 
 $$E=mc^2$$
 
-<!-- missing-key-value-item -->
+| Key | Value |
+| --- | --- |
+| number | 1 |
 
 <!-- missing-form-item -->
 

--- a/test/data/doc/constructed_mode_never_valid_false.gt.md
+++ b/test/data/doc/constructed_mode_never_valid_false.gt.md
@@ -57,7 +57,9 @@ Here a formula block:
 
 $$E=mc^2$$
 
-<!-- missing-key-value-item -->
+| Key | Value |
+| --- | --- |
+| number | 1 |
 
 <!-- missing-form-item -->
 

--- a/test/data/doc/constructed_mode_never_valid_true.gt.md
+++ b/test/data/doc/constructed_mode_never_valid_true.gt.md
@@ -57,7 +57,9 @@ Here a formula block:
 
 $$E=mc^2$$
 
-<!-- missing-key-value-item -->
+| Key | Value |
+| --- | --- |
+| number | 1 |
 
 <!-- missing-form-item -->
 

--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -32,6 +32,9 @@ from docling_core.types.doc.document import (
     DescriptionAnnotation,
     EntitiesMetaField,
     EntityMention,
+    GraphCell,
+    GraphData,
+    GraphLink,
     LanguageMetaField,
     PictureClassificationMetaField,
     PictureClassificationPrediction,
@@ -43,7 +46,7 @@ from docling_core.types.doc.document import (
     TableData,
     TextItem,
 )
-from docling_core.types.doc.labels import DocItemLabel
+from docling_core.types.doc.labels import DocItemLabel, GraphCellLabel, GraphLinkLabel
 
 from .test_data_gen_flag import GEN_TEST_DATA
 
@@ -1103,3 +1106,46 @@ def test_html_meta_emits_xhtml_compatible_attributes():
     assert 'data-meta-name="entities"' in html_out
     # Output must be parseable by a strict XML parser.
     ET.fromstring(html_out)
+
+
+def test_markdown_key_value_serializer():
+    """Test that key-value items are rendered as a Markdown table."""
+    doc = DoclingDocument(name="x")
+
+    graph = GraphData(
+        cells=[
+            GraphCell(label=GraphCellLabel.KEY, cell_id=0, text="Name", orig="Name"),
+            GraphCell(label=GraphCellLabel.VALUE, cell_id=1, text="Alice", orig="Alice"),
+            GraphCell(label=GraphCellLabel.KEY, cell_id=2, text="Tags", orig="Tags"),
+            GraphCell(label=GraphCellLabel.VALUE, cell_id=3, text="a|b", orig="a|b"),
+            GraphCell(label=GraphCellLabel.VALUE, cell_id=4, text="c\nd", orig="c\nd"),
+            GraphCell(label=GraphCellLabel.VALUE, cell_id=5, text="Orphan", orig="Orphan"),
+        ],
+        links=[
+            GraphLink(label=GraphLinkLabel.TO_VALUE, source_cell_id=0, target_cell_id=1),
+            GraphLink(label=GraphLinkLabel.TO_VALUE, source_cell_id=2, target_cell_id=3),
+            GraphLink(label=GraphLinkLabel.TO_VALUE, source_cell_id=2, target_cell_id=4),
+        ],
+    )
+    doc.add_key_values(graph=graph)
+
+    text = MarkdownDocSerializer(doc=doc).serialize().text
+
+    assert "<!-- missing-key-value-item -->" not in text
+    lines = text.splitlines()
+    assert "| Key | Value |" in lines
+    assert "| --- | --- |" in lines
+    assert "| Name | Alice |" in lines
+    assert "| Tags | a\\|b; c d |" in lines
+    assert "|  | Orphan |" in lines
+
+
+def test_markdown_key_value_serializer_empty_graph_omitted():
+    """Test that a key-value item with no cells produces no output."""
+    doc = DoclingDocument(name="x")
+    doc.add_key_values(graph=GraphData())
+
+    text = MarkdownDocSerializer(doc=doc).serialize().text
+
+    assert "<!-- missing-key-value-item -->" not in text
+    assert "Key" not in text


### PR DESCRIPTION
## Summary
- `MarkdownKeyValueSerializer.serialize` was a stub that always emitted `<!-- missing-key-value-item -->`.
- Implements the real behavior: renders `KeyValueItem` graphs as a Markdown table of key/value pairs, joining multi-value keys with `; `, including orphan (unlinked) values, and escaping `|`/newlines for table safety.

## Test plan
- [x] Added `test_markdown_key_value_serializer` and `test_markdown_key_value_serializer_empty_graph_omitted` in `test/test_serialization.py`
- [x] Regenerated affected golden files (`constructed*.gt.md`, `constructed.gt.txt`) via `DOCLING_GEN_TEST_DATA=1`
- [x] `ruff format`/`ruff check`/`mypy` clean on touched files
- [x] `pytest test/test_serialization.py test/test_plain_text_serialization.py test/test_latex_serialization.py` passing