### PR TITLE
feat(HybridChunker): add table_serialization parameter for markdown table format

### DIFF
--- a/docling_core/transforms/chunker/__init__.py
+++ b/docling_core/transforms/chunker/__init__.py
@@ -14,6 +14,6 @@ from docling_core.transforms.chunker.code_chunking.standard_code_chunking_strate
 )
 from docling_core.transforms.chunker.doc_chunk import DocChunk, DocMeta
 from docling_core.transforms.chunker.hierarchical_chunker import HierarchicalChunker
-from docling_core.transforms.chunker.hybrid_chunker import HybridChunker
+from docling_core.transforms.chunker.hybrid_chunker import HybridChunker, TableSerializationFormat
 from docling_core.transforms.chunker.page_chunker import PageChunker
 from docling_core.types.doc.labels import CodeLanguageLabel

--- a/docling_core/transforms/chunker/hybrid_chunker.py
+++ b/docling_core/transforms/chunker/hybrid_chunker.py
@@ -2,10 +2,12 @@
 
 import warnings
 from collections.abc import Iterable, Iterator
+from enum import Enum
 from functools import cached_property
 from typing import Any, Optional, Union, cast
 
 from pydantic import BaseModel, ConfigDict, Field, computed_field, model_validator
+from typing_extensions import override
 
 from docling_core.transforms.chunker.hierarchical_chunker import (
     ChunkingDocSerializer,
@@ -15,6 +17,11 @@ from docling_core.transforms.chunker.line_chunker import LineBasedTokenChunker
 from docling_core.transforms.chunker.tokenizer.base import BaseTokenizer
 from docling_core.transforms.chunker.tokenizer.huggingface import get_default_tokenizer
 from docling_core.transforms.serializer.base import BaseDocSerializer
+from docling_core.transforms.serializer.markdown import (
+    MarkdownParams,
+    MarkdownTableSerializer,
+)
+from docling_core.types.doc.base import ImageRefMode
 from docling_core.types.doc.document import SectionHeaderItem, TableItem, TitleItem
 
 try:
@@ -41,6 +48,13 @@ from docling_core.transforms.serializer.base import (
 from docling_core.types import DoclingDocument
 
 
+class TableSerializationFormat(str, Enum):
+    """Serialization format for table chunks."""
+
+    TRIPLET = "triplet"
+    MARKDOWN = "markdown"
+
+
 class HybridChunker(BaseChunker):
     r"""Chunker doing tokenization-aware refinements on top of document layout chunking.
 
@@ -49,6 +63,11 @@ class HybridChunker(BaseChunker):
             respective pretrained model
         max_tokens: The maximum number of tokens per chunk. If not set, limit is
             resolved from the tokenizer
+        table_serialization: Format for table chunk text. "triplet" (default) produces
+            'row, column = value' flat text; "markdown" produces pipe-table format
+            preserving column structure.
+        compact_tables: When True and table_serialization="markdown", removes column
+            padding for minimal whitespace. Reduces token count for large tables.
         repeat_table_headers: Whether to repeat a table header if the table is chunked
         merge_peers: Whether to merge undersized chunks sharing same relevant metadata
         always_emit_headings: Whether to emit headings even for empty sections
@@ -59,11 +78,13 @@ class HybridChunker(BaseChunker):
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
     tokenizer: BaseTokenizer = Field(default_factory=get_default_tokenizer)
+    table_serialization: TableSerializationFormat = TableSerializationFormat.TRIPLET
+    compact_tables: bool = False
     repeat_table_header: bool = True
     merge_peers: bool = True
     omit_header_on_overflow: bool = False
 
-    serializer_provider: BaseSerializerProvider = ChunkingSerializerProvider()
+    serializer_provider: BaseSerializerProvider = Field(default_factory=ChunkingSerializerProvider)
     always_emit_headings: bool = False
 
     @model_validator(mode="before")
@@ -97,6 +118,29 @@ class HybridChunker(BaseChunker):
                     if max_tokens is not None:
                         kwargs["max_tokens"] = max_tokens
                     data["tokenizer"] = HuggingFaceTokenizer(**kwargs)
+
+            # Resolve serializer_provider from table_serialization if not explicitly set
+            if "serializer_provider" not in data or data["serializer_provider"] is None:
+                table_ser = data.get("table_serialization", TableSerializationFormat.TRIPLET)
+                if table_ser == TableSerializationFormat.MARKDOWN or table_ser == "markdown":
+                    compact = data.get("compact_tables", False)
+
+                    class _MarkdownChunkingSerializerProvider(ChunkingSerializerProvider):
+                        @override
+                        def get_serializer(self, doc: DoclingDocument) -> BaseDocSerializer:
+                            return ChunkingDocSerializer(
+                                doc=doc,
+                                table_serializer=MarkdownTableSerializer(),
+                                params=MarkdownParams(
+                                    image_mode=ImageRefMode.PLACEHOLDER,
+                                    image_placeholder="",
+                                    escape_underscores=False,
+                                    escape_html=False,
+                                    compact_tables=compact,
+                                ),
+                            )
+
+                    data["serializer_provider"] = _MarkdownChunkingSerializerProvider()
         return data
 
     @property

--- a/test/test_hybrid_chunker.py
+++ b/test/test_hybrid_chunker.py
@@ -286,6 +286,32 @@ def test_chunk_custom_serializer():
     )
 
 
+def test_chunk_table_serialization_markdown():
+    """Test that table_serialization='markdown' produces same output as custom serializer."""
+    EXPECTED_OUT_FILE = "test/data/chunker/2e_out_chunks.json"
+
+    with open(INPUT_FILE, encoding="utf-8") as f:
+        data_json = f.read()
+    dl_doc = DLDocument.model_validate_json(data_json)
+
+    chunker = HybridChunker(
+        tokenizer=HuggingFaceTokenizer(
+            tokenizer=INNER_TOKENIZER,
+            max_tokens=MAX_TOKENS,
+        ),
+        merge_peers=True,
+        table_serialization="markdown",
+    )
+
+    chunk_iter = chunker.chunk(dl_doc=dl_doc)
+    chunks = list(chunk_iter)
+    act_data = dict(root=[DocChunk.model_validate(n).export_json_dict() for n in chunks])
+    assert_or_generate_json_ground_truth(
+        act_data,
+        EXPECTED_OUT_FILE,
+    )
+
+
 def test_chunk_openai():
     EXPECTED_OUT_FILE = "test/data/chunker/2f_out_chunks.json"
 


### PR DESCRIPTION
Closes docling-project/docling#3645

## Summary

Adds a `table_serialization` parameter to `HybridChunker` allowing users to choose between the existing flat "triplet" format and a new "markdown" pipe-table format for table chunks.

## Usage

```python
from docling_core.transforms.chunker import HybridChunker

# Existing behavior (default, unchanged)
chunker = HybridChunker(tokenizer=tokenizer, table_serialization="triplet")

# New: markdown pipe-table format
chunker = HybridChunker(tokenizer=tokenizer, table_serialization="markdown")

# New: markdown + compact (no column padding, saves tokens)
chunker = HybridChunker(tokenizer=tokenizer, table_serialization="markdown", compact_tables=True)
```

## Before — `triplet` (default, unchanged)

```
Apple M3 Max, Thread budget. = 4. Apple M3 Max, native backend.TTS = 177 s 167 s.
Apple M3 Max, native backend.Pages/s = 1.27 1.34. Apple M3 Max, native backend.Mem = 6.20 GB.
```

## After — `markdown` + `compact_tables=True`

```
| CPU | Thread budget | native backend | native backend | native backend |
| - | - | - | - | - |
|  |  | TTS | Pages/s | Mem |
| Apple M3 Max | 4 | 177 s 167 s | 1.27 1.34 | 6.20 GB |
```

## Changes

- `hybrid_chunker.py`: Added `TableSerializationFormat` enum, `table_serialization` and `compact_tables` params, wires up `MarkdownTableSerializer` in model_validator
- `__init__.py`: Export `TableSerializationFormat`
- `test_hybrid_chunker.py`: Added `test_chunk_table_serialization_markdown` test
- Changed `serializer_provider` default to `Field(default_factory=...)` for proper per-instance defaults

## Testing

- All 19 existing hybrid chunker tests pass
- New test validates markdown mode produces identical output to manual `ChunkingSerializerProvider` with `MarkdownTableSerializer`
- Ruff + mypy clean
