### PR TITLE
fix(serializer): serialize table footnotes in Markdown and HTML

### DIFF
--- a/docling_core/transforms/serializer/html.py
+++ b/docling_core/transforms/serializer/html.py
@@ -443,6 +443,11 @@ class HTMLTableSerializer(BaseTableSerializer):
         text_res = "".join([r.text for r in res_parts])
         text_res = f"<table>{text_res}</table>" if text_res else ""
 
+        ftn_res = doc_serializer.serialize_footnotes(item=item, **kwargs)
+        if ftn_res.text:
+            text_res = f"{text_res}{ftn_res.text}" if text_res else ftn_res.text
+            res_parts.append(ftn_res)
+
         return create_ser_result(text=text_res, span_source=res_parts)
 
     @override
@@ -1274,6 +1279,33 @@ class HTMLDocSerializer(DocSerializer):
         text_res = params.caption_delim.join([r.text for r in results])
         if text_res:
             text_res = f"<{tag}>{text_res}</{tag}>"
+        return create_ser_result(text=text_res, span_source=results)
+
+    @override
+    def serialize_footnotes(
+        self,
+        item: FloatingItem,
+        **kwargs: Any,
+    ) -> SerializationResult:
+        """Serialize the item's footnotes."""
+        params = self.params.merge_with_patch(patch=kwargs)
+        results: list[SerializationResult] = []
+        excluded_refs = self.get_excluded_refs(**kwargs)
+
+        if DocItemLabel.FOOTNOTE in params.labels:
+            for ftn in item.footnotes:
+                if isinstance(it := ftn.resolve(self.doc), TextItem) and it.self_ref not in excluded_refs:
+                    text_ftn = it.text
+                    text_dir = get_text_direction(text_ftn)
+                    dir_str = f' dir="{text_dir}"' if text_dir == "rtl" else ""
+                    results.append(
+                        create_ser_result(
+                            text=(f'<div class="footnote"{dir_str}>{html.escape(text_ftn)}</div>'),
+                            span_source=it,
+                        )
+                    )
+
+        text_res = params.caption_delim.join([r.text for r in results])
         return create_ser_result(text=text_res, span_source=results)
 
     def _generate_head(self) -> str:

--- a/docling_core/transforms/serializer/markdown.py
+++ b/docling_core/transforms/serializer/markdown.py
@@ -576,6 +576,10 @@ class MarkdownTableSerializer(BaseTableSerializer):
             if table_text:
                 res_parts.append(create_ser_result(text=table_text, span_source=item))
 
+            ftn_res = doc_serializer.serialize_footnotes(item=item, **kwargs)
+            if ftn_res.text:
+                res_parts.append(ftn_res)
+
         text_res = "\n\n".join([r.text for r in res_parts])
 
         return create_ser_result(text=text_res, span_source=res_parts)

--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -1103,3 +1103,36 @@ def test_html_meta_emits_xhtml_compatible_attributes():
     assert 'data-meta-name="entities"' in html_out
     # Output must be parseable by a strict XML parser.
     ET.fromstring(html_out)
+
+
+def test_table_footnotes_serialized_to_markdown_and_html():
+    """Regression test for #496: table footnotes must not be dropped by the
+    Markdown and HTML serializers (they are delegated to the parent TableItem)."""
+    doc = DoclingDocument(name="t")
+
+    td = TableData(num_rows=0, num_cols=2)
+    td.add_row(["Header 1", "Header 2"])
+    td.add_row(["Data 1", "Data 2"])
+    table = doc.add_table(data=td)
+
+    fn1 = doc.add_text(label=DocItemLabel.FOOTNOTE, text="First footnote.")
+    fn2 = doc.add_text(label=DocItemLabel.FOOTNOTE, text="Second footnote.")
+    table.footnotes.append(fn1.get_ref())
+    table.footnotes.append(fn2.get_ref())
+
+    # footnotes are stored on the table in the document model ...
+    assert [fn.resolve(doc).text for fn in table.footnotes] == [
+        "First footnote.",
+        "Second footnote.",
+    ]
+
+    # ... and must survive Markdown serialization
+    md_out = doc.export_to_markdown()
+    assert "First footnote." in md_out
+    assert "Second footnote." in md_out
+
+    # ... and HTML serialization (as escaped footnote divs after the table)
+    html_out = doc.export_to_html()
+    assert "First footnote." in html_out
+    assert "Second footnote." in html_out
+    assert '<div class="footnote">First footnote.</div>' in html_out


### PR DESCRIPTION
Fixes #496

## Problem

Table footnotes are silently dropped from **Markdown and HTML** output. The footnotes are correctly stored on `TableItem.footnotes` in the document model (they appear in the JSON), but never make it into the serialized text — so a table renders with dangling `*` / `**` markers whose definitions have vanished. As #496 notes, this also affects chunking, which relies on serialization.

## Root cause

After footnote handling was delegated to the parent `FloatingItem`, the `serialize_footnotes` hook was added to the doc serializer — but the table serializers were never wired to call it. They call `serialize_captions` (so captions appear) but not `serialize_footnotes`, so the method was effectively dead code and the footnotes had nowhere to go.

## Fix

- **`MarkdownTableSerializer`** — emit the table's footnotes after the table body, mirroring the existing caption handling.
- **`HTMLTableSerializer`** — emit the footnotes after the closing `</table>`.
- **`HTMLDocSerializer`** — add a `serialize_footnotes` override so footnotes are HTML-escaped and wrapped in `<div class="footnote">`, matching the existing `serialize_captions` override (the base method returns raw text, which is unsafe for HTML).

## Evidence

Using the `table_parsing_test.pdf` attached to #496 (digital PDF, standard pipeline). The table has two footnotes assigned; before the fix both are missing from the Markdown, after the fix both are present:

**Before** (`export_to_markdown()`):
```
| 442-D | Legacy Support | 1 | Archived** |

This final paragraph provides a clear end-of-section marker. ...
```

**After**:
```
| 442-D | Legacy Support | 1 | Archived** |

*Note: The 'Pending' status indicates that the asset is awaiting final security validation. **Note: 'Archived' items are scheduled for decommissioning at the end of the current fiscal year.

This final paragraph provides a clear end-of-section marker. ...
```

HTML output, after the fix, now emits (escaped):
```html
<table>...</table><div class="footnote">*Note: The 'Pending' status ...</div><div class="footnote">**Note: 'Archived' items ...</div>
```

> Note: #496 only mentions Markdown, but **HTML was affected too** — this PR fixes both.

## Testing

- Added a regression test (`test_table_footnotes_serialized_to_markdown_and_html`) that builds an in-memory `DoclingDocument` with a table + two footnotes and asserts they survive both `export_to_markdown()` and `export_to_html()`.
- Full existing suites pass with no regressions: serialization (`test_serialization.py`, `test_serialization_doctag.py`, `test_latex_serialization.py`, `test_azure_serializer.py`) and chunking (`test_hierarchical_chunker.py`).
- `ruff check` and `ruff format --check` clean.
