### PR TITLE
fix(tokens): normalize inverted bbox in get_location instead of asserting

### DIFF
--- a/docling_core/types/doc/tokens.py
+++ b/docling_core/types/doc/tokens.py
@@ -302,7 +302,7 @@ class DocumentToken(str, Enum):
         ysize: int = 500,  # TODO review
         self_closing: bool = False,
     ):
-        """Get the location string give bbox and page-dim."""
+        """Get the location string given bbox and page-dim."""
         # Normalize potentially inverted coordinates instead of asserting on
         # them. Near-degenerate elements (e.g. a thin rule whose layout-model
         # regression produced a slightly inverted bbox) can arrive with

--- a/docling_core/types/doc/tokens.py
+++ b/docling_core/types/doc/tokens.py
@@ -303,13 +303,19 @@ class DocumentToken(str, Enum):
         self_closing: bool = False,
     ):
         """Get the location string give bbox and page-dim."""
-        assert bbox[0] <= bbox[2], f"bbox[0]<=bbox[2] => {bbox[0]}<={bbox[2]}"
-        assert bbox[1] <= bbox[3], f"bbox[1]<=bbox[3] => {bbox[1]}<={bbox[3]}"
+        # Normalize potentially inverted coordinates instead of asserting on
+        # them. Near-degenerate elements (e.g. a thin rule whose layout-model
+        # regression produced a slightly inverted bbox) can arrive with
+        # bbox[0] > bbox[2] or bbox[1] > bbox[3]. The min()/max() calls below
+        # already emit correctly-ordered tokens, so sorting here mirrors that
+        # normalization and avoids crashing export_to_doctags on valid output.
+        left, right = sorted((bbox[0], bbox[2]))
+        top, bottom = sorted((bbox[1], bbox[3]))
 
-        x0 = bbox[0] / page_w
-        y0 = bbox[1] / page_h
-        x1 = bbox[2] / page_w
-        y1 = bbox[3] / page_h
+        x0 = left / page_w
+        y0 = top / page_h
+        x1 = right / page_w
+        y1 = bottom / page_h
 
         x0_tok = DocumentToken.get_location_token(val=min(x0, x1), rnorm=xsize, self_closing=self_closing)
         y0_tok = DocumentToken.get_location_token(val=min(y0, y1), rnorm=ysize, self_closing=self_closing)

--- a/docling_core/types/doc/tokens.py
+++ b/docling_core/types/doc/tokens.py
@@ -303,12 +303,11 @@ class DocumentToken(str, Enum):
         self_closing: bool = False,
     ):
         """Get the location string given bbox and page-dim."""
-        # Normalize potentially inverted coordinates instead of asserting on
-        # them. Near-degenerate elements (e.g. a thin rule whose layout-model
-        # regression produced a slightly inverted bbox) can arrive with
-        # bbox[0] > bbox[2] or bbox[1] > bbox[3]. The min()/max() calls below
-        # already emit correctly-ordered tokens, so sorting here mirrors that
-        # normalization and avoids crashing export_to_doctags on valid output.
+        # Normalize potentially inverted coordinates: near-degenerate elements
+        # (e.g. a thin rule whose layout-model regression produced a slightly
+        # inverted bbox) can arrive with bbox[0] > bbox[2] or bbox[1] > bbox[3].
+        # After sorting, left <= right and top <= bottom is guaranteed, so the
+        # ratios x0 <= x1 and y0 <= y1 follow directly from positive page dims.
         left, right = sorted((bbox[0], bbox[2]))
         top, bottom = sorted((bbox[1], bbox[3]))
 
@@ -317,10 +316,10 @@ class DocumentToken(str, Enum):
         x1 = right / page_w
         y1 = bottom / page_h
 
-        x0_tok = DocumentToken.get_location_token(val=min(x0, x1), rnorm=xsize, self_closing=self_closing)
-        y0_tok = DocumentToken.get_location_token(val=min(y0, y1), rnorm=ysize, self_closing=self_closing)
-        x1_tok = DocumentToken.get_location_token(val=max(x0, x1), rnorm=xsize, self_closing=self_closing)
-        y1_tok = DocumentToken.get_location_token(val=max(y0, y1), rnorm=ysize, self_closing=self_closing)
+        x0_tok = DocumentToken.get_location_token(val=x0, rnorm=xsize, self_closing=self_closing)
+        y0_tok = DocumentToken.get_location_token(val=y0, rnorm=ysize, self_closing=self_closing)
+        x1_tok = DocumentToken.get_location_token(val=x1, rnorm=xsize, self_closing=self_closing)
+        y1_tok = DocumentToken.get_location_token(val=y1, rnorm=ysize, self_closing=self_closing)
 
         loc_str = f"{x0_tok}{y0_tok}{x1_tok}{y1_tok}"
 

--- a/docling_core/types/doc/tokens.py
+++ b/docling_core/types/doc/tokens.py
@@ -302,12 +302,15 @@ class DocumentToken(str, Enum):
         ysize: int = 500,  # TODO review
         self_closing: bool = False,
     ):
-        """Get the location string given bbox and page-dim."""
-        # Normalize potentially inverted coordinates: near-degenerate elements
-        # (e.g. a thin rule whose layout-model regression produced a slightly
-        # inverted bbox) can arrive with bbox[0] > bbox[2] or bbox[1] > bbox[3].
-        # After sorting, left <= right and top <= bottom is guaranteed, so the
-        # ratios x0 <= x1 and y0 <= y1 follow directly from positive page dims.
+        """Get the location string given bbox and page-dim.
+
+        Inverted coordinates are normalized silently: near-degenerate elements
+        (e.g. a thin rule whose layout-model regression produced a slightly
+        inverted bbox) can arrive with `bbox[0] > bbox[2]` or
+        `bbox[1] > bbox[3]`. After sorting, `left <= right` and
+        `top <= bottom` is guaranteed, so the ratios `x0 <= x1` and
+        `y0 <= y1` follow directly from positive page dimensions.
+        """
         left, right = sorted((bbox[0], bbox[2]))
         top, bottom = sorted((bbox[1], bbox[3]))
 

--- a/test/test_tokens.py
+++ b/test/test_tokens.py
@@ -1,0 +1,51 @@
+"""Unit tests for document tokens."""
+
+from docling_core.types.doc.tokens import DocumentToken
+
+
+def test_get_location_normal_bbox():
+    """A well-ordered bbox produces correctly-ordered location tokens."""
+    loc = DocumentToken.get_location(
+        bbox=(100.0, 200.0, 300.0, 400.0),
+        page_w=1000.0,
+        page_h=1000.0,
+    )
+    assert loc == "<loc_50><loc_100><loc_150><loc_200>"
+
+
+def test_get_location_inverted_bbox_does_not_crash():
+    """A near-degenerate, slightly inverted bbox must not raise.
+
+    Regression test for #620: layout-model regression can emit a bbox with
+    bbox[1] > bbox[3] (or bbox[0] > bbox[2]) on thin/degenerate elements.
+    get_location already normalizes coordinates via min()/max() downstream,
+    so it should serialize such boxes instead of crashing export_to_doctags.
+    """
+    # bbox from the issue: y is inverted by 7.7pt (633.39 > 625.68).
+    inverted = DocumentToken.get_location(
+        bbox=(0.0, 633.3925132751465, 100.0, 625.6789665222168),
+        page_w=1000.0,
+        page_h=1000.0,
+    )
+    # The result must equal the same box with y-coordinates ordered correctly.
+    normalized = DocumentToken.get_location(
+        bbox=(0.0, 625.6789665222168, 100.0, 633.3925132751465),
+        page_w=1000.0,
+        page_h=1000.0,
+    )
+    assert inverted == normalized
+
+
+def test_get_location_fully_inverted_bbox():
+    """Both axes inverted still normalizes to the ordered box."""
+    inverted = DocumentToken.get_location(
+        bbox=(300.0, 400.0, 100.0, 200.0),
+        page_w=1000.0,
+        page_h=1000.0,
+    )
+    ordered = DocumentToken.get_location(
+        bbox=(100.0, 200.0, 300.0, 400.0),
+        page_w=1000.0,
+        page_h=1000.0,
+    )
+    assert inverted == ordered


### PR DESCRIPTION
Fixes #620

## Problem

\`DocumentToken.get_location()\` in \`docling_core/types/doc/tokens.py\` asserted \`bbox[0] <= bbox[2]\` and \`bbox[1] <= bbox[3]\`. Near-degenerate elements (e.g. a thin decorative rule whose layout-model regression produces a slightly inverted bbox) can violate this by a fraction of a point, which crashes \`export_to_doctags(add_location=True)\`:

```
File ".../docling_core/types/doc/tokens.py", line 307, in get_location
    assert bbox[1] <= bbox[3], f"bbox[1]<=bbox[3] => {bbox[1]}<={bbox[3]}"
AssertionError: bbox[1]<=bbox[3] => 633.3925132751465<=625.6789665222168
```

The asserts were redundant: the method already emits correctly-ordered location tokens via \`min()\`/\`max()\` downstream. The probability of hitting one such element grows with page count, so long documents are the most affected.

## Fix

Sort the coordinates before normalization (mirroring the existing \`min()\`/\`max()\` behaviour) and drop the asserts. Output is unchanged for well-formed boxes and now correct instead of crashing for inverted ones.

## Tests

Added \`test/test_tokens.py\` covering:
- a normal bbox (exact token output)
- the partially inverted bbox from the issue repro
- a fully inverted bbox

All pass; existing \`test_serialization_doctag.py\` and \`test_doctags_load.py\` (17 tests) still pass, and \`ruff\` is clean.