### PR TITLE
docs: fix typos in docstrings and comments

### DIFF
--- a/docling_core/transforms/visualizer/layout_visualizer.py
+++ b/docling_core/transforms/visualizer/layout_visualizer.py
@@ -148,7 +148,7 @@ class LayoutVisualizer(BaseVisualizer):
         images: Optional[dict[Optional[int], Image]] = None,
         included_content_layers: Optional[set[ContentLayer]] = None,
     ):
-        """Draw the document clusters and optionaly the reading order."""
+        """Draw the document clusters and optionally the reading order."""
         clusters = []
         my_images: dict[Optional[int], Image] = {}
 

--- a/docling_core/types/doc/document.py
+++ b/docling_core/types/doc/document.py
@@ -1321,7 +1321,7 @@ class ProvenanceItem(BaseModel):
     """Provenance information for elements extracted from a textual document.
 
     A `ProvenanceItem` object acts as a lightweight pointer back into the original
-    document for an extracted element. It applies to documents with an explicity
+    document for an extracted element. It applies to documents with an explicit
     or implicit layout, such as PDF, HTML, docx, or pptx.
     """
 
@@ -1391,7 +1391,7 @@ Currently supported source types:
 
 Notes:
     - Additional source types may be added to this union in the future to support other content sources.
-    - For documents with an implicit or explicity layout, such as PDF, HTML, docx, pptx, or markdown files, the
+    - For documents with an implicit or explicit layout, such as PDF, HTML, docx, pptx, or markdown files, the
         `ProvenanceItem` should still be used.
 """
 
@@ -2594,7 +2594,7 @@ class TableItem(FloatingItem):
         # Empty and full cells:
         # "ecel", "fcel"
         #
-        # Cell spans (horisontal, vertical, 2d):
+        # Cell spans (horizontal, vertical, 2d):
         # "lcel", "ucel", "xcel"
         #
         # New line:
@@ -6735,7 +6735,7 @@ class DoclingDocument(BaseModel):
         """Serializes the Docling document to WebVTT format.
 
         Args:
-            included_content_layers: The content layers to serializes. If ommitted, the `DEFAULT_CONTENT_LAYERS` will
+            included_content_layers: The content layers to serialize. If omitted, the `DEFAULT_CONTENT_LAYERS` will
                 be serialized.
             omit_hours_if_zero: If True, omit hours when they are 0 in the timings.
             omit_voice_end: If True and cue blocks have a WebVTT cue voice span as the only component, omit the voice
@@ -6769,7 +6769,7 @@ class DoclingDocument(BaseModel):
 
         Args:
             filename: The path to the WebVTT file.
-            included_content_layers: The content layers to serializes. If ommitted, the `DEFAULT_CONTENT_LAYERS` will
+            included_content_layers: The content layers to serialize. If omitted, the `DEFAULT_CONTENT_LAYERS` will
                 be serialized.
             omit_hours_if_zero: If True, omit hours when they are 0 in the timings.
             omit_voice_end: If True and cue blocks have a WebVTT cue voice span as the only component, omit the voice
@@ -7862,7 +7862,7 @@ class DoclingDocument(BaseModel):
     @model_validator(mode="after")
     def validate_misplaced_list_items(self) -> Self:
         """validate_misplaced_list_items."""
-        # find list items without list parent, putting succesive ones together
+        # find list items without list parent, putting successive ones together
         misplaced_list_items: list[list[ListItem]] = []
         prev: Optional[NodeItem] = None
         for item, _ in self.iterate_items(

--- a/docling_core/types/doc/labels.py
+++ b/docling_core/types/doc/labels.py
@@ -24,7 +24,7 @@ class DocItemLabel(str, Enum):
     CHECKBOX_UNSELECTED = "checkbox_unselected"
     FORM = "form"
     KEY_VALUE_REGION = "key_value_region"
-    GRADING_SCALE = "grading_scale"  # for elements in forms, questionaires representing a grading scale
+    GRADING_SCALE = "grading_scale"  # for elements in forms, questionnaires representing a grading scale
     # e.g. [strongly disagree | ... | ... | strongly agree]
     # e.g. ★★☆☆☆
     HANDWRITTEN_TEXT = "handwritten_text"

--- a/docs/DoclingDocument.json
+++ b/docs/DoclingDocument.json
@@ -3444,7 +3444,7 @@
       "type": "object"
     },
     "ProvenanceItem": {
-      "description": "Provenance information for elements extracted from a textual document.\n\nA `ProvenanceItem` object acts as a lightweight pointer back into the original\ndocument for an extracted element. It applies to documents with an explicity\nor implicit layout, such as PDF, HTML, docx, or pptx.",
+      "description": "Provenance information for elements extracted from a textual document.\n\nA `ProvenanceItem` object acts as a lightweight pointer back into the original\ndocument for an extracted element. It applies to documents with an explicit\nor implicit layout, such as PDF, HTML, docx, or pptx.",
       "properties": {
         "page_no": {
           "description": "Page number",


### PR DESCRIPTION
## Summary

Fixes several spelling mistakes found in docstrings and inline comments across the library. These are documentation-only changes with no functional impact.

| Location | Before | After |
|---|---|---|
| `types/doc/document.py` (`ProvenanceItem` docstring, x2) | explicity | explicit |
| `types/doc/document.py` (`TableItem` comment) | horisontal | horizontal |
| `types/doc/document.py` (WebVTT serializer docstrings, x2) | ommitted | omitted |
| `types/doc/document.py` (list-item validator comment) | succesive | successive |
| `types/doc/labels.py` (`GRADING_SCALE` comment) | questionaires | questionnaires |
| `transforms/visualizer/layout_visualizer.py` (docstring) | optionaly | optionally |
| `docs/DoclingDocument.json` (generated `ProvenanceItem` description) | explicity | explicit |

The `docs/DoclingDocument.json` change mirrors the `ProvenanceItem` docstring fix, so the checked-in schema stays in sync with what `docling_core.utils.generate_docs` would produce.

Note: the `explicity` fixes correct to `explicit` (adjective modifying "layout"), not `explicitly`.

## Verification

- No identifiers, enum values, or API strings changed (e.g. `GRADING_SCALE = "grading_scale"` is untouched).
- `docs/DoclingDocument.json` remains valid JSON.