### PR TITLE
feat(markdown): include table image in Markdown export when available

### DIFF
--- a/docling_core/transforms/serializer/markdown.py
+++ b/docling_core/transforms/serializer/markdown.py
@@ -427,6 +427,46 @@ class MarkdownAnnotationSerializer(BaseModel, BaseAnnotationSerializer):
         )
 
 
+def _serialize_image_part(
+    item: FloatingItem,
+    doc: DoclingDocument,
+    image_mode: ImageRefMode,
+    image_placeholder: str,
+    **kwargs: Any,
+) -> SerializationResult:
+    """Render a floating item's image per the image mode.
+
+    Shared by the picture and table serializers so both honor image_mode
+    identically for any FloatingItem that carries an image.
+    """
+    error_response = "<!-- 🖼️❌ Image not available. Please use `PdfPipelineOptions(generate_picture_images=True)` -->"
+    if image_mode == ImageRefMode.PLACEHOLDER:
+        text_res = image_placeholder
+    elif image_mode == ImageRefMode.EMBEDDED:
+        # short-cut: we already have the image in base64
+        if isinstance(item.image, ImageRef) and isinstance(item.image.uri, AnyUrl) and item.image.uri.scheme == "data":
+            text_res = f"![Image]({item.image.uri})"
+        else:
+            # get the item.image._pil or crop it out of the page-image
+            img = item.get_image(doc=doc)
+            if img is not None:
+                imgb64 = item._image_to_base64(img)
+                text_res = f"![Image](data:image/png;base64,{imgb64})"
+            else:
+                text_res = error_response
+    elif image_mode == ImageRefMode.REFERENCED:
+        if not isinstance(item.image, ImageRef) or (
+            isinstance(item.image.uri, AnyUrl) and item.image.uri.scheme == "data"
+        ):
+            text_res = image_placeholder
+        else:
+            text_res = f"![Image]({item.image.uri!s})"
+    else:
+        text_res = image_placeholder
+
+    return create_ser_result(text=text_res, span_source=item)
+
+
 class MarkdownTableSerializer(BaseTableSerializer):
     """Markdown-specific table item serializer."""
 
@@ -584,6 +624,18 @@ class MarkdownTableSerializer(BaseTableSerializer):
             if table_text:
                 res_parts.append(create_ser_result(text=table_text, span_source=item))
 
+            # Emit the table image alongside the text grid when one was generated.
+            # Tables without an image (the common case) stay a strict no-op.
+            if item.image is not None and params.image_mode != ImageRefMode.PLACEHOLDER:
+                img_res = _serialize_image_part(
+                    item=item,
+                    doc=doc,
+                    image_mode=params.image_mode,
+                    image_placeholder=params.image_placeholder,
+                )
+                if img_res.text:
+                    res_parts.append(img_res)
+
         text_res = "\n\n".join([r.text for r in res_parts])
 
         return create_ser_result(text=text_res, span_source=res_parts)
@@ -622,7 +674,7 @@ class MarkdownPictureSerializer(BasePictureSerializer):
                 if ann_res.text:
                     res_parts.append(ann_res)
 
-            img_res = self._serialize_image_part(
+            img_res = _serialize_image_part(
                 item=item,
                 doc=doc,
                 image_mode=params.image_mode,
@@ -647,51 +699,6 @@ class MarkdownPictureSerializer(BasePictureSerializer):
         text_res = "\n\n".join([r.text for r in res_parts if r.text])
 
         return create_ser_result(text=text_res, span_source=res_parts)
-
-    def _serialize_image_part(
-        self,
-        item: PictureItem,
-        doc: DoclingDocument,
-        image_mode: ImageRefMode,
-        image_placeholder: str,
-        **kwargs: Any,
-    ) -> SerializationResult:
-        error_response = (
-            "<!-- 🖼️❌ Image not available. Please use `PdfPipelineOptions(generate_picture_images=True)` -->"
-        )
-        if image_mode == ImageRefMode.PLACEHOLDER:
-            text_res = image_placeholder
-        elif image_mode == ImageRefMode.EMBEDDED:
-            # short-cut: we already have the image in base64
-            if (
-                isinstance(item.image, ImageRef)
-                and isinstance(item.image.uri, AnyUrl)
-                and item.image.uri.scheme == "data"
-            ):
-                text = f"![Image]({item.image.uri})"
-                text_res = text
-            else:
-                # get the item.image._pil or crop it out of the page-image
-                img = item.get_image(doc=doc)
-
-                if img is not None:
-                    imgb64 = item._image_to_base64(img)
-                    text = f"![Image](data:image/png;base64,{imgb64})"
-
-                    text_res = text
-                else:
-                    text_res = error_response
-        elif image_mode == ImageRefMode.REFERENCED:
-            if not isinstance(item.image, ImageRef) or (
-                isinstance(item.image.uri, AnyUrl) and item.image.uri.scheme == "data"
-            ):
-                text_res = image_placeholder
-            else:
-                text_res = f"![Image]({item.image.uri!s})"
-        else:
-            text_res = image_placeholder
-
-        return create_ser_result(text=text_res, span_source=item)
 
 
 class MarkdownKeyValueSerializer(BaseKeyValueSerializer):

--- a/docling_core/transforms/serializer/markdown.py
+++ b/docling_core/transforms/serializer/markdown.py
@@ -602,6 +602,46 @@ def _flatten_header_rows(header_rows: list[list[str]], num_cols: int) -> list[st
     return flattened
 
 
+def _serialize_image_part(
+    item: FloatingItem,
+    doc: DoclingDocument,
+    image_mode: ImageRefMode,
+    image_placeholder: str,
+    **kwargs: Any,
+) -> SerializationResult:
+    """Render a floating item's image per the image mode.
+
+    Shared by the picture and table serializers so both honor image_mode
+    identically for any FloatingItem that carries an image.
+    """
+    error_response = "<!-- 🖼️❌ Image not available. Please use `PdfPipelineOptions(generate_picture_images=True)` -->"
+    if image_mode == ImageRefMode.PLACEHOLDER:
+        text_res = image_placeholder
+    elif image_mode == ImageRefMode.EMBEDDED:
+        # short-cut: we already have the image in base64
+        if isinstance(item.image, ImageRef) and isinstance(item.image.uri, AnyUrl) and item.image.uri.scheme == "data":
+            text_res = f"![Image]({item.image.uri})"
+        else:
+            # get the item.image._pil or crop it out of the page-image
+            img = item.get_image(doc=doc)
+            if img is not None:
+                imgb64 = item._image_to_base64(img)
+                text_res = f"![Image](data:image/png;base64,{imgb64})"
+            else:
+                text_res = error_response
+    elif image_mode == ImageRefMode.REFERENCED:
+        if not isinstance(item.image, ImageRef) or (
+            isinstance(item.image.uri, AnyUrl) and item.image.uri.scheme == "data"
+        ):
+            text_res = image_placeholder
+        else:
+            text_res = f"![Image]({MarkdownPictureSerializer._escape_uri_path(item.image.uri)})"
+    else:
+        text_res = image_placeholder
+
+    return create_ser_result(text=text_res, span_source=item)
+
+
 class MarkdownTableSerializer(BaseTableSerializer):
     """Markdown-specific table item serializer.
 
@@ -773,6 +813,18 @@ class MarkdownTableSerializer(BaseTableSerializer):
             if table_text:
                 res_parts.append(create_ser_result(text=table_text, span_source=item))
 
+            # Emit the table image alongside the text grid when one was generated.
+            # Tables without an image (the common case) stay a strict no-op.
+            if item.image is not None and params.image_mode != ImageRefMode.PLACEHOLDER:
+                img_res = _serialize_image_part(
+                    item=item,
+                    doc=doc,
+                    image_mode=params.image_mode,
+                    image_placeholder=params.image_placeholder,
+                )
+                if img_res.text:
+                    res_parts.append(img_res)
+
         text_res = "\n\n".join([r.text for r in res_parts])
 
         return create_ser_result(text=text_res, span_source=res_parts)
@@ -823,7 +875,7 @@ class MarkdownPictureSerializer(BasePictureSerializer):
                 if ann_res.text:
                     res_parts.append(ann_res)
 
-            img_res = self._serialize_image_part(
+            img_res = _serialize_image_part(
                 item=item,
                 doc=doc,
                 image_mode=params.image_mode,
@@ -848,51 +900,6 @@ class MarkdownPictureSerializer(BasePictureSerializer):
         text_res = "\n\n".join([r.text for r in res_parts if r.text])
 
         return create_ser_result(text=text_res, span_source=res_parts)
-
-    def _serialize_image_part(
-        self,
-        item: PictureItem,
-        doc: DoclingDocument,
-        image_mode: ImageRefMode,
-        image_placeholder: str,
-        **kwargs: Any,
-    ) -> SerializationResult:
-        error_response = (
-            "<!-- 🖼️❌ Image not available. Please use `PdfPipelineOptions(generate_picture_images=True)` -->"
-        )
-        if image_mode == ImageRefMode.PLACEHOLDER:
-            text_res = image_placeholder
-        elif image_mode == ImageRefMode.EMBEDDED:
-            # short-cut: we already have the image in base64
-            if (
-                isinstance(item.image, ImageRef)
-                and isinstance(item.image.uri, AnyUrl)
-                and item.image.uri.scheme == "data"
-            ):
-                text = f"![Image]({item.image.uri})"
-                text_res = text
-            else:
-                # get the item.image._pil or crop it out of the page-image
-                img = item.get_image(doc=doc)
-
-                if img is not None:
-                    imgb64 = item._image_to_base64(img)
-                    text = f"![Image](data:image/png;base64,{imgb64})"
-
-                    text_res = text
-                else:
-                    text_res = error_response
-        elif image_mode == ImageRefMode.REFERENCED:
-            if not isinstance(item.image, ImageRef) or (
-                isinstance(item.image.uri, AnyUrl) and item.image.uri.scheme == "data"
-            ):
-                text_res = image_placeholder
-            else:
-                text_res = f"![Image]({self._escape_uri_path(item.image.uri)})"
-        else:
-            text_res = image_placeholder
-
-        return create_ser_result(text=text_res, span_source=item)
 
     @staticmethod
     def _escape_uri_path(value: AnyUrl | PurePath) -> str:

--- a/docling_core/types/doc/items/node.py
+++ b/docling_core/types/doc/items/node.py
@@ -1,6 +1,8 @@
 """Base document-tree node items: NodeItem, DocItem, FloatingItem."""
 
+import base64
 from collections.abc import Sequence
+from io import BytesIO
 from typing import TYPE_CHECKING, Annotated, Optional
 
 from PIL import Image as PILImage
@@ -231,3 +233,12 @@ class FloatingItem(DocItem):
         if self.image is not None:
             return self.image.pil_image
         return super().get_image(doc=doc, prov_index=prov_index)
+
+    # Convert the image to Base64
+    def _image_to_base64(self, pil_image, format="PNG"):
+        """Base64 representation of the image."""
+        buffered = BytesIO()
+        pil_image.save(buffered, format=format)  # Save the image to the byte stream
+        img_bytes = buffered.getvalue()  # Get the byte data
+        img_base64 = base64.b64encode(img_bytes).decode("utf-8")  # Encode to Base64 and decode to string
+        return img_base64

--- a/docling_core/types/doc/items/picture/picture.py
+++ b/docling_core/types/doc/items/picture/picture.py
@@ -1,12 +1,10 @@
 """Picture item and its annotation-data union."""
 
-import base64
 import hashlib
 import logging
 import typing
 import warnings
 from collections.abc import Sequence
-from io import BytesIO
 from typing import TYPE_CHECKING, Annotated, Optional, Union
 
 from PIL import Image as PILImage
@@ -142,15 +140,6 @@ class PictureItem(FloatingItem):
                         )
 
             return self
-
-    # Convert the image to Base64
-    def _image_to_base64(self, pil_image, format="PNG"):
-        """Base64 representation of the image."""
-        buffered = BytesIO()
-        pil_image.save(buffered, format=format)  # Save the image to the byte stream
-        img_bytes = buffered.getvalue()  # Get the byte data
-        img_base64 = base64.b64encode(img_bytes).decode("utf-8")  # Encode to Base64 and decode to string
-        return img_base64
 
     @staticmethod
     def _image_to_hexhash(img: Optional[PILImage.Image]) -> Optional[str]:

--- a/docling_core/types/doc/items/picture/picture.py
+++ b/docling_core/types/doc/items/picture/picture.py
@@ -1,12 +1,10 @@
 """Picture item and its annotation-data union."""
 
-import base64
 import hashlib
 import logging
 import typing
 import warnings
 from collections.abc import Sequence
-from io import BytesIO
 from typing import TYPE_CHECKING, Annotated, Optional, Union
 
 from PIL import Image as PILImage
@@ -140,15 +138,6 @@ class PictureItem(FloatingItem):
                         )
 
             return self
-
-    # Convert the image to Base64
-    def _image_to_base64(self, pil_image, format="PNG"):
-        """Base64 representation of the image."""
-        buffered = BytesIO()
-        pil_image.save(buffered, format=format)  # Save the image to the byte stream
-        img_bytes = buffered.getvalue()  # Get the byte data
-        img_base64 = base64.b64encode(img_bytes).decode("utf-8")  # Encode to Base64 and decode to string
-        return img_base64
 
     @staticmethod
     def _image_to_hexhash(img: PILImage.Image | None) -> str | None:

--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, patch
 from xml.etree import ElementTree as ET
 
 import pytest
+from PIL import Image
 
 from docling_core.transforms.serializer.common import _DEFAULT_LABELS
 from docling_core.transforms.serializer.html import (
@@ -32,12 +33,14 @@ from docling_core.types.doc.document import (
     DescriptionAnnotation,
     EntitiesMetaField,
     EntityMention,
+    ImageRef,
     LanguageMetaField,
     PictureClassificationMetaField,
     PictureClassificationPrediction,
     PictureMeta,
     RefItem,
     RichTableCell,
+    Size,
     SummaryMetaField,
     TableCell,
     TableData,
@@ -350,6 +353,82 @@ def test_md_single_row_table():
     ser = MarkdownDocSerializer(doc=doc)
     actual = ser.serialize().text
     verify(exp_file=exp_file, actual=actual)
+
+
+def test_md_table_with_image_embedded():
+    doc = DoclingDocument(name="")
+    table = doc.add_table(data=TableData(num_rows=1, num_cols=1))
+    doc.add_table_cell(
+        table_item=table,
+        cell=TableCell(
+            start_row_offset_idx=0,
+            end_row_offset_idx=1,
+            start_col_offset_idx=0,
+            end_col_offset_idx=1,
+            text="foo",
+        ),
+    )
+    table.image = ImageRef.from_pil(image=Image.new("RGB", (2, 2)), dpi=72)
+
+    ser = MarkdownDocSerializer(
+        doc=doc,
+        params=MarkdownParams(image_mode=ImageRefMode.EMBEDDED),
+    )
+    actual = ser.serialize().text
+    assert "| foo   |" in actual
+    assert "![Image](data:image/png;base64," in actual
+
+
+def test_md_table_with_image_referenced():
+    doc = DoclingDocument(name="")
+    table = doc.add_table(data=TableData(num_rows=1, num_cols=1))
+    doc.add_table_cell(
+        table_item=table,
+        cell=TableCell(
+            start_row_offset_idx=0,
+            end_row_offset_idx=1,
+            start_col_offset_idx=0,
+            end_col_offset_idx=1,
+            text="foo",
+        ),
+    )
+    table.image = ImageRef(
+        mimetype="image/png",
+        dpi=72,
+        size=Size(width=2, height=2),
+        uri="table_0.png",
+    )
+
+    ser = MarkdownDocSerializer(
+        doc=doc,
+        params=MarkdownParams(image_mode=ImageRefMode.REFERENCED),
+    )
+    actual = ser.serialize().text
+    assert actual == "| foo   |\n|-------|\n\n![Image](table_0.png)"
+
+
+def test_md_table_without_image_unaffected_by_image_mode():
+    """A table with no generated image must not gain an image line, even if
+    image_mode is set — this must remain a strict no-op for the common case."""
+    doc = DoclingDocument(name="")
+    table = doc.add_table(data=TableData(num_rows=1, num_cols=1))
+    doc.add_table_cell(
+        table_item=table,
+        cell=TableCell(
+            start_row_offset_idx=0,
+            end_row_offset_idx=1,
+            start_col_offset_idx=0,
+            end_col_offset_idx=1,
+            text="foo",
+        ),
+    )
+
+    ser = MarkdownDocSerializer(
+        doc=doc,
+        params=MarkdownParams(image_mode=ImageRefMode.EMBEDDED),
+    )
+    actual = ser.serialize().text
+    assert actual == "| foo   |\n|-------|"
 
 
 def test_md_pipe_in_table():

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, patch
 from xml.etree import ElementTree as ET
 
 import pytest
+from PIL import Image
 from pydantic import AnyUrl
 
 from docling_core.transforms.serializer.common import _DEFAULT_LABELS
@@ -627,6 +628,82 @@ def test_md_table_single_header_row_with_flags():
     assert lines[0] == "| Product   |   Price |"
     assert lines[2] == "| CAT-001   |   10.00 |"
     assert lines[3] == "| CAT-002   |    9.00 |"
+
+
+def test_md_table_with_image_embedded():
+    doc = DoclingDocument(name="")
+    table = doc.add_table(data=TableData(num_rows=1, num_cols=1))
+    doc.add_table_cell(
+        table_item=table,
+        cell=TableCell(
+            start_row_offset_idx=0,
+            end_row_offset_idx=1,
+            start_col_offset_idx=0,
+            end_col_offset_idx=1,
+            text="foo",
+        ),
+    )
+    table.image = ImageRef.from_pil(image=Image.new("RGB", (2, 2)), dpi=72)
+
+    ser = MarkdownDocSerializer(
+        doc=doc,
+        params=MarkdownParams(image_mode=ImageRefMode.EMBEDDED),
+    )
+    actual = ser.serialize().text
+    assert "| foo   |" in actual
+    assert "![Image](data:image/png;base64," in actual
+
+
+def test_md_table_with_image_referenced():
+    doc = DoclingDocument(name="")
+    table = doc.add_table(data=TableData(num_rows=1, num_cols=1))
+    doc.add_table_cell(
+        table_item=table,
+        cell=TableCell(
+            start_row_offset_idx=0,
+            end_row_offset_idx=1,
+            start_col_offset_idx=0,
+            end_col_offset_idx=1,
+            text="foo",
+        ),
+    )
+    table.image = ImageRef(
+        mimetype="image/png",
+        dpi=72,
+        size=Size(width=2, height=2),
+        uri="table_0.png",
+    )
+
+    ser = MarkdownDocSerializer(
+        doc=doc,
+        params=MarkdownParams(image_mode=ImageRefMode.REFERENCED),
+    )
+    actual = ser.serialize().text
+    assert actual == "| foo   |\n|-------|\n\n![Image](table_0.png)"
+
+
+def test_md_table_without_image_unaffected_by_image_mode():
+    """A table with no generated image must not gain an image line, even if
+    image_mode is set — this must remain a strict no-op for the common case."""
+    doc = DoclingDocument(name="")
+    table = doc.add_table(data=TableData(num_rows=1, num_cols=1))
+    doc.add_table_cell(
+        table_item=table,
+        cell=TableCell(
+            start_row_offset_idx=0,
+            end_row_offset_idx=1,
+            start_col_offset_idx=0,
+            end_col_offset_idx=1,
+            text="foo",
+        ),
+    )
+
+    ser = MarkdownDocSerializer(
+        doc=doc,
+        params=MarkdownParams(image_mode=ImageRefMode.EMBEDDED),
+    )
+    actual = ser.serialize().text
+    assert actual == "| foo   |\n|-------|"
 
 
 def test_md_pipe_in_table():


### PR DESCRIPTION
Closes #474.

## What

`MarkdownTableSerializer` only ever emitted the text/HTML table grid — `TableItem.image` was ignored entirely, unlike `MarkdownPictureSerializer`, which already honors `image_mode` (`PLACEHOLDER` / `EMBEDDED` / `REFERENCED`) for pictures.

## Change

- Extracted the shared image-emission logic (previously `MarkdownPictureSerializer._serialize_image_part`) into a module-level function reused by both the picture and table serializers — no behavior change to the existing picture path (verified byte-for-byte identical branches).
- Moved `_image_to_base64` from `PictureItem` up to the shared `FloatingItem` base so `TableItem` (which is also a `FloatingItem`) can use it.
- `MarkdownTableSerializer.serialize` now appends the table image **alongside** the existing text table when `item.image` is set and `image_mode` is not `PLACEHOLDER` — the text table is preserved so this is purely additive.

## Design choice (open in the issue, unconfirmed by a maintainer)

I'd asked in the issue whether the image should *replace* or be emitted *alongside* the text table, and whether it should reuse `image_mode` or a new dedicated option. I went with **alongside + reuse existing `image_mode`**, since:
- it requires no new public API surface, and
- replacing the text table by default would be a breaking output change for existing consumers who already rely on the Markdown table text (e.g. for RAG chunking).

Happy to adjust if a maintainer prefers different behavior.

## Backward compatibility

Tables without a generated image (`item.image is None` — the common case, since table images require the `generate_table_images` pipeline option) see **zero output change**, even if `image_mode` is explicitly set to something other than `PLACEHOLDER`. Covered by a dedicated regression test.

## Testing

Added 3 new tests in `test/test_serialization.py`:
- `test_md_table_with_image_embedded` — `EMBEDDED` mode, image present
- `test_md_table_with_image_referenced` — `REFERENCED` mode, image present (asserts exact output)
- `test_md_table_without_image_unaffected_by_image_mode` — no image present, asserts byte-exact no-op regardless of `image_mode`

Full suite: `uv run pytest -q` → 545 passed, 6 skipped (unrelated to this change).
`ruff check` / `ruff format --check` / `mypy docling_core test` all clean.