### PR TITLE
docs(page): add Field descriptions to page primitives

### DIFF
--- a/docling_core/types/doc/page.py
+++ b/docling_core/types/doc/page.py
@@ -280,15 +280,46 @@ class TextDirection(str, Enum):
 class TextCell(ColorMixin, OrderedElement):
     """Model representing a text cell with positioning and content information."""
 
-    rect: BoundingRectangle
+    rect: Annotated[
+        BoundingRectangle,
+        Field(description="Oriented rectangle enclosing the cell on the page."),
+    ]
 
-    text: str
-    orig: str
+    text: Annotated[str, Field(description="Text content of the cell.")]
+    orig: Annotated[
+        str,
+        Field(
+            description=(
+                "Original, untreated text of the cell as produced by the "
+                "extraction backend, before any downstream normalization "
+                "applied to `text`."
+            )
+        ),
+    ]
 
-    text_direction: TextDirection = TextDirection.LEFT_TO_RIGHT
+    text_direction: Annotated[
+        TextDirection,
+        Field(description="Reading direction of the text within the cell."),
+    ] = TextDirection.LEFT_TO_RIGHT
 
-    confidence: float = 1.0
-    from_ocr: bool
+    confidence: Annotated[
+        float,
+        Field(
+            description=(
+                "Confidence of the text extraction. Cells read directly from "
+                "digital text keep the default of 1.0; OCR backends set the "
+                "recognition score reported by the OCR engine."
+            )
+        ),
+    ] = 1.0
+    from_ocr: Annotated[
+        bool,
+        Field(
+            description=(
+                "Whether the cell was produced by OCR rather than extracted from the document's digital text layer."
+            )
+        ),
+    ]
 
     @field_serializer("confidence")
     def _serialize(self, value: float, info: FieldSerializationInfo) -> float:
@@ -535,13 +566,48 @@ class PageGeometry(BaseModel):
 class PdfPageGeometry(PageGeometry):
     """Extended dimensions model specific to PDF pages with boundary types."""
 
-    boundary_type: PdfPageBoundaryType
+    boundary_type: Annotated[
+        PdfPageBoundaryType,
+        Field(
+            description=(
+                "The page boundary that `rect` was derived from. Note that "
+                "`width`, `height` and `origin` are always computed from "
+                "`crop_bbox`, independently of this value."
+            )
+        ),
+    ]
 
-    art_bbox: BoundingBox
-    bleed_bbox: BoundingBox
-    crop_bbox: BoundingBox
-    media_bbox: BoundingBox
-    trim_bbox: BoundingBox
+    art_bbox: Annotated[
+        BoundingBox,
+        Field(description=("PDF ArtBox: the extent of the page's meaningful content as intended by its creator.")),
+    ]
+    bleed_bbox: Annotated[
+        BoundingBox,
+        Field(
+            description=(
+                "PDF BleedBox: the clipping region for production output, "
+                "including any bleed area beyond the trim boundary."
+            )
+        ),
+    ]
+    crop_bbox: Annotated[
+        BoundingBox,
+        Field(
+            description=(
+                "PDF CropBox: the region the page contents are clipped to "
+                "when displayed or printed. This is the box `width`, `height` "
+                "and `origin` are computed from."
+            )
+        ),
+    ]
+    media_bbox: Annotated[
+        BoundingBox,
+        Field(description=("PDF MediaBox: the full extent of the physical medium the page is to be printed on.")),
+    ]
+    trim_bbox: Annotated[
+        BoundingBox,
+        Field(description=("PDF TrimBox: the intended dimensions of the page after trimming.")),
+    ]
 
     @property
     def width(self):
@@ -565,25 +631,76 @@ class PdfPageGeometry(PageGeometry):
 class SegmentedPage(BaseModel):
     """Model representing a segmented page with text cells and resources."""
 
-    dimension: PageGeometry
+    dimension: Annotated[
+        PageGeometry,
+        Field(description="Geometry of the page this segmentation belongs to."),
+    ]
 
-    bitmap_resources: list[BitmapResource] = []
+    bitmap_resources: Annotated[
+        list[BitmapResource],
+        Field(description="Bitmap images embedded in the page."),
+    ] = []
 
-    char_cells: list[TextCell] = []
-    word_cells: list[TextCell] = []
-    textline_cells: list[TextCell] = []
+    char_cells: Annotated[
+        list[TextCell],
+        Field(description="Text cells at character granularity."),
+    ] = []
+    word_cells: Annotated[
+        list[TextCell],
+        Field(description="Text cells at word granularity."),
+    ] = []
+    textline_cells: Annotated[
+        list[TextCell],
+        Field(description="Text cells at text-line granularity."),
+    ] = []
 
     # These flags are set to differentiate if above lists of this SegmentedPage
     # are empty (page had no content) or if they have not been computed (i.e. textline_cells may be present
     # but word_cells are not)
-    has_chars: bool = False
-    has_words: bool = False
-    has_lines: bool = False
+    has_chars: Annotated[
+        bool,
+        Field(
+            description=(
+                "Whether `char_cells` has been computed. Distinguishes an "
+                "empty list meaning 'no content' from one meaning "
+                "'not computed'."
+            )
+        ),
+    ] = False
+    has_words: Annotated[
+        bool,
+        Field(
+            description=(
+                "Whether `word_cells` has been computed. Distinguishes an "
+                "empty list meaning 'no content' from one meaning "
+                "'not computed'."
+            )
+        ),
+    ] = False
+    has_lines: Annotated[
+        bool,
+        Field(
+            description=(
+                "Whether `textline_cells` has been computed. Distinguishes an "
+                "empty list meaning 'no content' from one meaning "
+                "'not computed'."
+            )
+        ),
+    ] = False
 
-    image: Optional[ImageRef] = None
+    image: Annotated[
+        Optional[ImageRef],
+        Field(description="Rendered image of the page, if available."),
+    ] = None
 
-    widgets: list[PdfWidget] = []
-    hyperlinks: list[PdfHyperlink] = []
+    widgets: Annotated[
+        list[PdfWidget],
+        Field(description="Interactive PDF form widgets found on the page."),
+    ] = []
+    hyperlinks: Annotated[
+        list[PdfHyperlink],
+        Field(description="Hyperlink annotations found on the page."),
+    ] = []
 
     @model_validator(mode="after")
     def validate_page(self) -> "SegmentedPage":

--- a/docling_core/types/doc/page.py
+++ b/docling_core/types/doc/page.py
@@ -570,9 +570,9 @@ class PdfPageGeometry(PageGeometry):
         PdfPageBoundaryType,
         Field(
             description=(
-                "The page boundary that `rect` was derived from. Note that "
-                "`width`, `height` and `origin` are always computed from "
-                "`crop_bbox`, independently of this value."
+                "The page boundary that `rect` was derived from. In "
+                "`PdfPageGeometry`, `width`, `height` and `origin` are "
+                "computed from `crop_bbox` regardless of this value."
             )
         ),
     ]
@@ -638,7 +638,7 @@ class SegmentedPage(BaseModel):
 
     bitmap_resources: Annotated[
         list[BitmapResource],
-        Field(description="Bitmap images embedded in the page."),
+        Field(description="Bitmap image resources found on the page."),
     ] = []
 
     char_cells: Annotated[
@@ -661,9 +661,10 @@ class SegmentedPage(BaseModel):
         bool,
         Field(
             description=(
-                "Whether `char_cells` has been computed. Distinguishes an "
-                "empty list meaning 'no content' from one meaning "
-                "'not computed'."
+                "Whether character extraction has been computed. When False, "
+                "`char_cells` being empty means extraction was not attempted; "
+                "when True, `char_cells` being empty means the page had no "
+                "extractable characters."
             )
         ),
     ] = False
@@ -671,9 +672,10 @@ class SegmentedPage(BaseModel):
         bool,
         Field(
             description=(
-                "Whether `word_cells` has been computed. Distinguishes an "
-                "empty list meaning 'no content' from one meaning "
-                "'not computed'."
+                "Whether word extraction has been computed. When False, "
+                "`word_cells` being empty means extraction was not attempted; "
+                "when True, `word_cells` being empty means the page had no "
+                "extractable words."
             )
         ),
     ] = False
@@ -681,9 +683,10 @@ class SegmentedPage(BaseModel):
         bool,
         Field(
             description=(
-                "Whether `textline_cells` has been computed. Distinguishes an "
-                "empty list meaning 'no content' from one meaning "
-                "'not computed'."
+                "Whether text-line extraction has been computed. When False, "
+                "`textline_cells` being empty means extraction was not "
+                "attempted; when True, `textline_cells` being empty means the "
+                "page had no extractable text lines."
             )
         ),
     ] = False


### PR DESCRIPTION
Closes #411.

@jamesbraza asked for Pydantic `description`s on the page primitives that are hard to interpret when writing a parser driver. @PeterStaar-IBM offered to take it back in October; since that never landed, I have picked it up (asked on the issue first).

## What

Adds `Annotated[..., Field(description=...)]` to the three primitives named in the issue, in `docling_core/types/doc/page.py`:

- **`TextCell`** — `rect`, `text`, `orig`, `text_direction`, `confidence`, `from_ocr`
- **`PdfPageGeometry`** — `boundary_type`, `art_bbox`, `bleed_bbox`, `crop_bbox`, `media_bbox`, `trim_bbox`
- **`SegmentedPage`** — all 11 fields, including the `has_chars` / `has_words` / `has_lines` flags

This matches the `Annotated[T, Field(description=...)]` style already used throughout `document.py`. **Metadata only — no behavior change.**

The five PDF boxes are described with their spec meanings. For `crop_bbox` and `boundary_type` I also noted the behavior that surprised me while reading the code: `width`, `height` and `origin` are always computed from `crop_bbox`, regardless of `boundary_type`.

## Two deliberate omissions

- **`PageGeometry.angle`** (inherited by `PdfPageGeometry`) is left undocumented. I could not establish its unit from the code: `BoundingRectangle.angle` is a property documented as radians, but a PDF `/Rotate` is conventionally degrees, and nothing in the repo pins down which one this field carries. I would rather leave it blank than guess — happy to add it if you tell me which it is.
- `TextCell.index` / `rgba` come from `OrderedElement` / `ColorMixin` and are out of scope for this issue.

## One open question

For `TextCell.orig` I wrote *"Original, untreated text of the cell as produced by the extraction backend, before any downstream normalization applied to `text`."*

That mirrors `TextItem.orig` in `document.py` (`# untreated representation`). Worth noting that every producer I checked in `docling` — `pypdfium2_backend`, `mets_gbs_backend`, `tesseract_ocr_model`, `easyocr_model` — currently sets `text` and `orig` identically, so the description states the intent rather than an observable difference. Let me know if you would phrase it differently.

## Verification

- `pytest test/` — 546 passed, 6 skipped
- `prek run` — Ruff linter, Ruff formatter, MyPy, Pytest, Docs all pass (the `Docs` hook confirms `docs/DoclingDocument.json` does not drift; these page primitives are not part of that schema)
- Confirmed the descriptions actually reach the generated schema, e.g. `SegmentedPage.model_json_schema()` now carries a description on all 11 properties.

Draft until the `orig` wording is confirmed.