### PR TITLE
fix(doclang): enforce size limits when extracting .dclx archives

### DIFF
--- a/docling_core/types/doc/document.py
+++ b/docling_core/types/doc/document.py
@@ -4854,12 +4854,23 @@ class DoclingDocument(BaseModel):
         *,
         artifacts_dir: Optional[Path] = None,
         validate: bool = False,
+        max_member_size: int = 512 * 1024 * 1024,  # 512 MiB
+        max_total_size: int = 2 * 1024 * 1024 * 1024,  # 2 GiB
     ) -> "DoclingDocument":
         """Load a DoclingDocument from a DocLang OPC archive (``.dclx``).
 
         The archive is extracted to ``artifacts_dir`` (default: ``<name>_artifacts`` next
         to the ``.dclx`` file). Relative ``<src uri=\"...\"/>`` paths and optional
         ``pages/`` images are resolved inside that directory.
+
+        Args:
+            filename: Path to the ``.dclx`` archive.
+            artifacts_dir: Optional extraction directory for package members.
+            validate: When True, run DocLang XSD/Schematron validation on ``document.xml``.
+            max_member_size: Maximum uncompressed size in bytes for any single archive member
+                (default: 512 MiB).
+            max_total_size: Maximum cumulative uncompressed size in bytes for all members
+                (default: 2 GiB).
         """
         from docling_core.transforms.deserializer.doclang import DocLangDocDeserializer
 
@@ -4867,7 +4878,12 @@ class DoclingDocument(BaseModel):
             filename = Path(filename)
 
         artifacts_dir, _ = cls(name="")._get_output_paths(filename, artifacts_dir)
-        safe_extract_zip_archive(filename, artifacts_dir)
+        safe_extract_zip_archive(
+            filename,
+            artifacts_dir,
+            max_member_size=max_member_size,
+            max_total_size=max_total_size,
+        )
 
         document_xml = artifacts_dir / "document.xml"
         if not document_xml.is_file():

--- a/docling_core/types/doc/utils.py
+++ b/docling_core/types/doc/utils.py
@@ -3,11 +3,10 @@
 import html
 import itertools
 import re
-import shutil
 import unicodedata
 import zipfile
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import IO, TYPE_CHECKING, Any
 
 from docling_core.types.doc.tokens import _LOC_PREFIX, DocumentToken, TableToken
 
@@ -106,23 +105,95 @@ def resolve_archive_path(archive_root: Path, relative_path: str) -> Path:
     return resolved
 
 
-def safe_extract_zip_archive(archive: Path, destination: Path) -> None:
-    """Extract a DocLang ``.dclx`` archive without zip-slip path traversal."""
+def _copy_zip_member_bounded(
+    src: IO[bytes],
+    dst: IO[bytes],
+    *,
+    member: str,
+    max_member_size: int,
+    max_total_size: int,
+    remaining_total: int,
+) -> int:
+    """Copy a zip member while enforcing per-member and remaining total byte caps.
+
+    Counts bytes actually read from the decompressed stream so lying
+    ``ZipInfo.file_size`` headers cannot bypass the budgets.
+    """
+    chunk_size = 64 * 1024
+    written = 0
+    while True:
+        member_room = max_member_size - written
+        total_room = remaining_total - written
+        if member_room <= 0 or total_room <= 0:
+            if src.read(1):
+                if written >= max_member_size:
+                    raise ValueError(f"Archive member exceeds size limit of {max_member_size} bytes: {member!r}")
+                raise ValueError(f"Archive exceeds total uncompressed size limit of {max_total_size} bytes")
+            break
+
+        chunk = src.read(min(chunk_size, member_room, total_room))
+        if not chunk:
+            break
+        dst.write(chunk)
+        written += len(chunk)
+
+    return written
+
+
+def safe_extract_zip_archive(
+    archive: Path,
+    destination: Path,
+    *,
+    max_member_size: int = 512 * 1024 * 1024,  # 512 MiB
+    max_total_size: int = 2 * 1024 * 1024 * 1024,  # 2 GiB
+) -> None:
+    """Extract a DocLang ``.dclx`` archive without zip-slip or zip-bomb abuse.
+
+    Args:
+        archive: Path to the ``.dclx`` zip archive.
+        destination: Directory to extract members into.
+        max_member_size: Maximum uncompressed size in bytes for any single member
+            (default: 512 MiB).
+        max_total_size: Maximum cumulative uncompressed size in bytes for all members
+            (default: 2 GiB).
+    """
+    if max_member_size <= 0:
+        raise ValueError(f"max_member_size must be positive, got {max_member_size}")
+    if max_total_size <= 0:
+        raise ValueError(f"max_total_size must be positive, got {max_total_size}")
+
     archive = archive.resolve()
     destination = destination.resolve()
     destination.mkdir(parents=True, exist_ok=True)
 
+    total_uncompressed = 0
     with zipfile.ZipFile(archive) as zf:
-        for member in zf.namelist():
-            if member.endswith("/"):
+        for info in zf.infolist():
+            member = info.filename
+            if member.endswith("/") or info.is_dir():
                 continue
             validate_archive_relative_path(member, label="archive member")
             target = (destination / member).resolve()
             if not target.is_relative_to(destination):
                 raise ValueError(f"Unsafe archive member path: {member!r}")
+
+            # Cheap reject from declared sizes; actual bytes are still bounded below.
+            if info.file_size > max_member_size:
+                raise ValueError(f"Archive member exceeds size limit of {max_member_size} bytes: {member!r}")
+            if total_uncompressed + info.file_size > max_total_size:
+                raise ValueError(f"Archive exceeds total uncompressed size limit of {max_total_size} bytes")
+
             target.parent.mkdir(parents=True, exist_ok=True)
             with zf.open(member) as src, open(target, "wb") as dst:
-                shutil.copyfileobj(src, dst)
+                written = _copy_zip_member_bounded(
+                    src,
+                    dst,
+                    member=member,
+                    max_member_size=max_member_size,
+                    max_total_size=max_total_size,
+                    remaining_total=max_total_size - total_uncompressed,
+                )
+            total_uncompressed += written
 
 
 def get_html_tag_with_text_direction(html_tag: str, text: str, attrs: dict | None = None) -> str:

--- a/test/test_doclang_archive.py
+++ b/test/test_doclang_archive.py
@@ -143,3 +143,94 @@ def test_doclang_archive_roundtrip(save_fixture_doc: DoclingDocument, tmp_path: 
     assert len(reloaded.pictures) == len(loaded.pictures)
     assert reloaded.pictures[0].image is not None
     assert reloaded.pictures[0].image.pil_image is not None
+
+
+def _write_zip(path: Path, members: dict[str, bytes]) -> None:
+    with zipfile.ZipFile(path, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+        for name, data in members.items():
+            archive.writestr(name, data)
+
+
+def test_safe_extract_zip_archive_rejects_oversize_member(tmp_path: Path) -> None:
+    from docling_core.types.doc.utils import safe_extract_zip_archive
+
+    archive_path = tmp_path / "oversize_member.dclx"
+    _write_zip(archive_path, {"document.xml": b"A" * 4096})
+
+    with pytest.raises(ValueError, match="Archive member exceeds size limit"):
+        safe_extract_zip_archive(
+            archive_path,
+            tmp_path / "out",
+            max_member_size=128,
+            max_total_size=10 * 1024 * 1024,
+        )
+
+
+def test_safe_extract_zip_archive_rejects_oversize_total(tmp_path: Path) -> None:
+    from docling_core.types.doc.utils import safe_extract_zip_archive
+
+    archive_path = tmp_path / "oversize_total.dclx"
+    _write_zip(
+        archive_path,
+        {
+            "a.txt": b"A" * 100,
+            "b.txt": b"B" * 100,
+        },
+    )
+
+    with pytest.raises(ValueError, match="total uncompressed size limit"):
+        safe_extract_zip_archive(
+            archive_path,
+            tmp_path / "out",
+            max_member_size=10 * 1024 * 1024,
+            max_total_size=150,
+        )
+
+
+def test_copy_zip_member_bounded_enforces_actual_bytes() -> None:
+    """Budgets must apply to bytes read, not only declared ZipInfo.file_size."""
+    from io import BytesIO
+
+    from docling_core.types.doc.utils import _copy_zip_member_bounded
+
+    src = BytesIO(b"C" * 4096)
+    dst = BytesIO()
+    with pytest.raises(ValueError, match="Archive member exceeds size limit"):
+        _copy_zip_member_bounded(
+            src,
+            dst,
+            member="document.xml",
+            max_member_size=128,
+            max_total_size=10 * 1024 * 1024,
+            remaining_total=10 * 1024 * 1024,
+        )
+    assert len(dst.getvalue()) == 128
+
+
+def test_copy_zip_member_bounded_enforces_remaining_total() -> None:
+    from io import BytesIO
+
+    from docling_core.types.doc.utils import _copy_zip_member_bounded
+
+    src = BytesIO(b"C" * 4096)
+    dst = BytesIO()
+    with pytest.raises(ValueError, match="total uncompressed size limit"):
+        _copy_zip_member_bounded(
+            src,
+            dst,
+            member="document.xml",
+            max_member_size=10 * 1024 * 1024,
+            max_total_size=200,
+            remaining_total=100,
+        )
+    assert len(dst.getvalue()) == 100
+
+
+def test_load_from_doclang_archive_forwards_size_limits(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="Archive member exceeds size limit"):
+        DoclingDocument.load_from_doclang_archive(
+            LOAD_FIXTURE_DCLX,
+            artifacts_dir=tmp_path / "artifacts",
+            max_member_size=128,
+            max_total_size=10 * 1024 * 1024,
+        )


### PR DESCRIPTION
- Cap per-member and total uncompressed size during safe archive extraction
- Apply limits to bytes actually read, not only declared ZipInfo sizes
- Expose the limits on `load_from_doclang_archive` and cover them with unit tests