### PR TITLE
fix(doclang): add deserialize size, depth, and element budgets

### DIFF
--- a/docling_core/transforms/deserializer/doclang.py
+++ b/docling_core/transforms/deserializer/doclang.py
@@ -87,8 +87,42 @@ from docling_core.types.doc.document import (
 )
 from docling_core.types.doc.labels import CodeLanguageLabel, GroupLabel
 from docling_core.types.doc.utils import resolve_archive_path
+from docling_core.utils.settings import settings
 
 __all__ = ["DocLangDocDeserializer"]
+
+
+def _utf8_byte_length(text: str) -> int:
+    """Return UTF-8 byte length of ``text`` without retaining the encoded buffer."""
+    # encode builds a temporary bytes object; acceptable for a one-shot gate check.
+    return len(text.encode("utf-8"))
+
+
+def _enforce_doclang_dom_budgets(
+    root: Element,
+    *,
+    max_depth: int,
+    max_elements: int,
+) -> None:
+    """Reject deeply nested or extremely large DocLang DOMs (iterative walk)."""
+    if max_depth <= 0:
+        raise ValueError(f"max_doclang_xml_depth must be positive, got {max_depth}")
+    if max_elements <= 0:
+        raise ValueError(f"max_doclang_xml_elements must be positive, got {max_elements}")
+
+    element_count = 0
+    # (node, depth) — depth is 1 for the documentElement
+    stack: list[tuple[Element, int]] = [(root, 1)]
+    while stack:
+        node, depth = stack.pop()
+        element_count += 1
+        if element_count > max_elements:
+            raise ValueError(f"DocLang XML exceeds element count limit of {max_elements}")
+        if depth > max_depth:
+            raise ValueError(f"DocLang XML exceeds nesting depth limit of {max_depth}")
+        for child in node.childNodes:
+            if isinstance(child, Element):
+                stack.append((child, depth + 1))
 
 
 class DocLangDocDeserializer(BaseDocDeserializer, BaseModel):
@@ -99,9 +133,35 @@ class DocLangDocDeserializer(BaseDocDeserializer, BaseModel):
     _default_resolution: int = PrivateAttr(default=DOCLANG_DFLT_RESOLUTION)
     _thread_registry: dict[tuple[str, str], NodeItem] = PrivateAttr(default_factory=dict)
     _media_root: Optional[Path] = PrivateAttr(default=None)
+    _max_xml_bytes: int = PrivateAttr(default=settings.max_doclang_xml_bytes)
+    _max_xml_depth: int = PrivateAttr(default=settings.max_doclang_xml_depth)
+    _max_xml_elements: int = PrivateAttr(default=settings.max_doclang_xml_elements)
 
     def _thread_registry_key(self, *, thread_id: str, host: str) -> tuple[str, str]:
         return (thread_id, host)
+
+    def _parse_xml_string(self, text: str) -> Element:
+        """Parse DocLang (or fragment) XML under configured size/depth/element budgets."""
+        if self._max_xml_bytes <= 0:
+            raise ValueError(f"max_doclang_xml_bytes must be positive, got {self._max_xml_bytes}")
+        nbytes = _utf8_byte_length(text)
+        if nbytes > self._max_xml_bytes:
+            raise ValueError(f"DocLang XML exceeds size limit of {self._max_xml_bytes} bytes")
+
+        try:
+            root_node = parseString(text).documentElement
+        except Exception as e:
+            ctx = _xml_error_context(text, e)
+            raise ValueError(f"Invalid DocLang XML: {e}\n--- XML context ---\n{ctx}") from e
+        if root_node is None:
+            raise ValueError("Invalid DocLang XML: missing documentElement")
+        root = cast(Element, root_node)
+        _enforce_doclang_dom_budgets(
+            root,
+            max_depth=self._max_xml_depth,
+            max_elements=self._max_xml_elements,
+        )
+        return root
 
     @override
     def deserialize_str(self, text: str, **kwargs: Any) -> DoclingDocument:
@@ -112,6 +172,9 @@ class DocLangDocDeserializer(BaseDocDeserializer, BaseModel):
             page_no: Starting page number (default 1), passed via ``kwargs``.
             media_root: Optional archive root for resolving relative ``<src uri="..."/>``
                 paths from a DocLang archive package.
+            max_xml_bytes: Optional override for ``settings.max_doclang_xml_bytes``.
+            max_xml_depth: Optional override for ``settings.max_doclang_xml_depth``.
+            max_xml_elements: Optional override for ``settings.max_doclang_xml_elements``.
 
         Returns:
             A populated `DoclingDocument` parsed from the input.
@@ -119,14 +182,11 @@ class DocLangDocDeserializer(BaseDocDeserializer, BaseModel):
         page_no: int = kwargs.get("page_no", 1)
         media_root = kwargs.get("media_root")
         self._media_root = Path(media_root).resolve() if media_root is not None else None
-        try:
-            root_node = parseString(text).documentElement
-        except Exception as e:
-            ctx = _xml_error_context(text, e)
-            raise ValueError(f"Invalid DocLang XML: {e}\n--- XML context ---\n{ctx}") from e
-        if root_node is None:
-            raise ValueError("Invalid DocLang XML: missing documentElement")
-        root: Element = cast(Element, root_node)
+        self._max_xml_bytes = int(kwargs.get("max_xml_bytes", settings.max_doclang_xml_bytes))
+        self._max_xml_depth = int(kwargs.get("max_xml_depth", settings.max_doclang_xml_depth))
+        self._max_xml_elements = int(kwargs.get("max_xml_elements", settings.max_doclang_xml_elements))
+
+        root = self._parse_xml_string(text)
         if root.tagName != DocLangToken.DOCUMENT.value:
             candidates = root.getElementsByTagName(DocLangToken.DOCUMENT.value)
             if candidates:
@@ -1704,9 +1764,8 @@ class DocLangDocDeserializer(BaseDocDeserializer, BaseModel):
         values: list[int] = []
         res_for_group: Optional[int] = None
         for fragment in fragments:
-            frag_dom = parseString(fragment)
-            loc_el = frag_dom.documentElement
-            if loc_el is None or loc_el.tagName != DocLangToken.LOCATION.value:
+            loc_el = self._parse_xml_string(fragment)
+            if loc_el.tagName != DocLangToken.LOCATION.value:
                 return None
             try:
                 v = int(loc_el.getAttribute(DocLangAttributeKey.VALUE.value) or "0")
@@ -1778,10 +1837,7 @@ class DocLangDocDeserializer(BaseDocDeserializer, BaseModel):
         tokens: list[str] = []
         parts: list[str] = []
 
-        dom = parseString(s)
-        otsl_el = dom.documentElement
-        if otsl_el is None:
-            raise ValueError("No document element found")
+        otsl_el = self._parse_xml_string(s)
 
         otsl_tokens = {
             DocLangToken.FCEL.value,
@@ -1916,10 +1972,7 @@ class DocLangDocDeserializer(BaseDocDeserializer, BaseModel):
                         text_parts: list[str] = []
                         for part in xml_parts:
                             wrapped_xml = f"<root>{part}</root>"
-                            dom = parseString(wrapped_xml)
-                            root_el = dom.documentElement
-                            if root_el is None:
-                                raise ValueError("No document element found")
+                            root_el = self._parse_xml_string(wrapped_xml)
                             for child_node in root_el.childNodes:
                                 if isinstance(child_node, Element):
                                     self._dispatch_element(doc=doc, el=child_node, parent=cell_group)

--- a/docling_core/types/doc/document.py
+++ b/docling_core/types/doc/document.py
@@ -155,6 +155,7 @@ from docling_core.types.doc.labels import (
 )
 from docling_core.types.doc.tokens import DocumentToken, TableToken
 from docling_core.types.doc.utils import (
+    _ensure_within_size_limit,
     is_remote_path,
     parse_otsl_table_content,
     relative_path,
@@ -4871,6 +4872,10 @@ class DoclingDocument(BaseModel):
                 (default: 512 MiB).
             max_total_size: Maximum cumulative uncompressed size in bytes for all members
                 (default: 2 GiB).
+
+        Notes:
+            ``document.xml`` is additionally capped by ``settings.max_doclang_xml_bytes`` before
+            parsing.
         """
         from docling_core.transforms.deserializer.doclang import DocLangDocDeserializer
 
@@ -4888,6 +4893,14 @@ class DoclingDocument(BaseModel):
         document_xml = artifacts_dir / "document.xml"
         if not document_xml.is_file():
             raise ValueError(f"DocLang archive missing document.xml: {filename}")
+
+        # Fail closed before reading/parsing: zip member caps are far larger than a
+        # safe DocLang DOM budget.
+        _ensure_within_size_limit(
+            document_xml,
+            max_size=settings.max_doclang_xml_bytes,
+            label="DocLang document.xml",
+        )
 
         if validate:
             from doclang.validation import validate as doclang_validate

--- a/docling_core/types/doc/utils.py
+++ b/docling_core/types/doc/utils.py
@@ -105,6 +105,19 @@ def resolve_archive_path(archive_root: Path, relative_path: str) -> Path:
     return resolved
 
 
+def _ensure_within_size_limit(path: Path, *, max_size: int, label: str = "file") -> int:
+    """Raise ``ValueError`` if ``path`` is larger than ``max_size`` bytes.
+
+    Returns the file size when within the limit.
+    """
+    if max_size <= 0:
+        raise ValueError(f"max_size must be positive, got {max_size}")
+    size = path.stat().st_size
+    if size > max_size:
+        raise ValueError(f"{label} exceeds size limit of {max_size} bytes: {path}")
+    return size
+
+
 def _copy_zip_member_bounded(
     src: IO[bytes],
     dst: IO[bytes],

--- a/docling_core/utils/settings.py
+++ b/docling_core/utils/settings.py
@@ -7,5 +7,10 @@ class CoreSettings(BaseSettings):
     allow_image_file_uri: bool = False
     max_image_decoded_size: int = 20 * 1024 * 1024  # 20MB
 
+    # DocLang deserialize budgets (DoS protection for untrusted markup / .dclx)
+    max_doclang_xml_bytes: int = 128 * 1024 * 1024  # 128 MiB
+    max_doclang_xml_depth: int = 128
+    max_doclang_xml_elements: int = 1_000_000
+
 
 settings = CoreSettings()

--- a/test/test_deserializer_doclang.py
+++ b/test/test_deserializer_doclang.py
@@ -2170,3 +2170,40 @@ def test_table_with_class_raises_error():
 
     with pytest.raises(ValueError, match="table element must not have a class attribute"):
         _deserialize(xml_str, validate=False)
+
+
+def test_deserialize_rejects_oversize_xml() -> None:
+    """Huge DocLang markup must fail closed before DOM construction grows unchecked."""
+    xml = "<doclang>" + ("x" * 200) + "</doclang>"
+    with pytest.raises(ValueError, match="exceeds size limit"):
+        DocLangDocDeserializer().deserialize_str(xml, max_xml_bytes=64)
+
+
+def test_deserialize_rejects_over_deep_xml() -> None:
+    """Extreme element nesting must fail closed (defusedxml does not bound depth)."""
+    depth = 20
+    xml = "".join(f"<g{i}>" for i in range(depth)) + "x" + "".join(f"</g{i}>" for i in reversed(range(depth)))
+    xml = f"<doclang>{xml}</doclang>"
+    with pytest.raises(ValueError, match="exceeds nesting depth limit"):
+        DocLangDocDeserializer().deserialize_str(xml, max_xml_depth=8)
+
+
+def test_deserialize_rejects_too_many_elements() -> None:
+    """Element floods must fail closed even when total byte size is modest."""
+    # 30 sibling elements under doclang — over a tight element budget.
+    children = "".join(f"<text>t{i}</text>" for i in range(30))
+    xml = f"<doclang>{children}</doclang>"
+    with pytest.raises(ValueError, match="exceeds element count limit"):
+        DocLangDocDeserializer().deserialize_str(xml, max_xml_elements=10)
+
+
+def test_deserialize_accepts_document_within_budgets() -> None:
+    xml = "<doclang><text>hello</text></doclang>"
+    doc = DocLangDocDeserializer().deserialize_str(
+        xml,
+        max_xml_bytes=1024,
+        max_xml_depth=16,
+        max_xml_elements=100,
+    )
+    assert len(doc.texts) == 1
+    assert doc.texts[0].text == "hello"

--- a/test/test_doclang_archive.py
+++ b/test/test_doclang_archive.py
@@ -234,3 +234,22 @@ def test_load_from_doclang_archive_forwards_size_limits(tmp_path: Path) -> None:
             max_member_size=128,
             max_total_size=10 * 1024 * 1024,
         )
+
+
+def test_load_from_doclang_archive_rejects_oversize_document_xml(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``document.xml`` is gated by the DocLang XML budget before parsing."""
+    from docling_core.utils.settings import settings
+
+    archive_path = tmp_path / "big_xml.dclx"
+    # Keep under default zip member caps; still over a tightened XML parse budget.
+    xml = b"<doclang>" + (b"x" * 4096) + b"</doclang>"
+    _write_zip(archive_path, {"document.xml": xml})
+
+    monkeypatch.setattr(settings, "max_doclang_xml_bytes", 1024)
+    with pytest.raises(ValueError, match="exceeds size limit"):
+        DoclingDocument.load_from_doclang_archive(
+            archive_path,
+            artifacts_dir=tmp_path / "artifacts",
+        )


### PR DESCRIPTION
- Cap DocLang XML input bytes before `parseString`
- Bound nesting depth and element count after DOM construction
- Expose limits via settings / `deserialize_str` kwargs and cover with unit tests