### PR TITLE
fix(doclang): enforce image size budgets for archive assets and ImageRef

### DIFF
--- a/docling_core/transforms/deserializer/doclang.py
+++ b/docling_core/transforms/deserializer/doclang.py
@@ -86,7 +86,7 @@ from docling_core.types.doc.document import (
     GroupItem as GroupItemType,
 )
 from docling_core.types.doc.labels import CodeLanguageLabel, GroupLabel
-from docling_core.types.doc.utils import resolve_archive_path
+from docling_core.types.doc.utils import _ensure_within_size_limit, resolve_archive_path
 from docling_core.utils.settings import settings
 
 __all__ = ["DocLangDocDeserializer"]
@@ -1582,6 +1582,11 @@ class DocLangDocDeserializer(BaseDocDeserializer, BaseModel):
         if not resolved.is_file():
             raise ValueError(f"Archive asset not found: {uri!r}")
 
+        _ensure_within_size_limit(
+            resolved,
+            max_size=settings.max_image_decoded_size,
+            label="Archive asset image",
+        )
         with PILImage.open(resolved) as pil:
             pil_copy = pil.copy()
         mimetype = mimetypes.guess_type(resolved.name)[0] or "image/png"

--- a/docling_core/types/doc/common/reference.py
+++ b/docling_core/types/doc/common/reference.py
@@ -15,6 +15,7 @@ from typing_extensions import Self
 from docling_core.types.base import _JSON_POINTER_REGEX
 from docling_core.types.doc.base import BoundingBox, Size
 from docling_core.types.doc.common.scalars import CharSpan
+from docling_core.types.doc.utils import _ensure_within_size_limit
 from docling_core.utils.settings import settings
 
 try:
@@ -98,7 +99,13 @@ class ImageRef(BaseModel):
             if self.uri.scheme == "file":
                 if not settings.allow_image_file_uri:
                     raise ValueError("file:// URI scheme is not enabled.")
-                self._pil = PILImage.open(unquote(str(self.uri.path)))
+                file_path = Path(unquote(str(self.uri.path)))
+                _ensure_within_size_limit(
+                    file_path,
+                    max_size=settings.max_image_decoded_size,
+                    label="Image file",
+                )
+                self._pil = PILImage.open(file_path)
             elif self.uri.scheme == "data":
                 encoded_img = str(self.uri).split(",")[1]
                 decoded_img = base64.b64decode(encoded_img)
@@ -109,6 +116,11 @@ class ImageRef(BaseModel):
                 self._pil = PILImage.open(BytesIO(decoded_img))
             # else: Handle http request or other protocols...
         elif isinstance(self.uri, Path):
+            _ensure_within_size_limit(
+                self.uri,
+                max_size=settings.max_image_decoded_size,
+                label="Image file",
+            )
             self._pil = PILImage.open(self.uri)
 
         return self._pil

--- a/docling_core/types/doc/common/reference.py
+++ b/docling_core/types/doc/common/reference.py
@@ -114,7 +114,9 @@ class ImageRef(BaseModel):
                     raise ValueError(f"Decoded image exceeds size limit of {settings.max_image_decoded_size} bytes.")
 
                 self._pil = PILImage.open(BytesIO(decoded_img))
-            # else: Handle http request or other protocols...
+            # else: HTTP(S) and other remote schemes are intentionally not fetched.
+            # If remote fetch is enabled, it must use host allowlists and block
+            # private, link-local, and cloud-metadata addresses (SSRF controls).
         elif isinstance(self.uri, Path):
             _ensure_within_size_limit(
                 self.uri,

--- a/docling_core/types/doc/document.py
+++ b/docling_core/types/doc/document.py
@@ -4875,7 +4875,8 @@ class DoclingDocument(BaseModel):
 
         Notes:
             ``document.xml`` is additionally capped by ``settings.max_doclang_xml_bytes`` before
-            parsing.
+            parsing. Archive ``assets/`` and ``pages/`` images are capped by
+            ``settings.max_image_decoded_size`` before Pillow opens them.
         """
         from docling_core.transforms.deserializer.doclang import DocLangDocDeserializer
 
@@ -4937,6 +4938,11 @@ class DoclingDocument(BaseModel):
             if page_no not in doc.pages:
                 continue
 
+            _ensure_within_size_limit(
+                resolved,
+                max_size=settings.max_image_decoded_size,
+                label="Archive page image",
+            )
             with PILImage.open(resolved) as pil:
                 pil_copy = pil.copy()
             mimetype = mimetypes.guess_type(page_file.name)[0] or "image/png"

--- a/test/test_doclang_archive.py
+++ b/test/test_doclang_archive.py
@@ -253,3 +253,58 @@ def test_load_from_doclang_archive_rejects_oversize_document_xml(
             archive_path,
             artifacts_dir=tmp_path / "artifacts",
         )
+
+
+def test_load_from_doclang_archive_rejects_oversize_page_image(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Extracted ``pages/`` rasters must respect ``max_image_decoded_size`` before PIL open."""
+    from docling_core.utils.settings import settings
+
+    archive_path = tmp_path / "big_page.dclx"
+    xml = b"""<doclang>
+  <page_break/>
+</doclang>"""
+    # Minimal valid-looking PNG header plus padding past the test budget.
+    oversize = b"\x89PNG\r\n\x1a\n" + (b"\x00" * 256)
+    _write_zip(
+        archive_path,
+        {
+            "document.xml": xml,
+            "pages/1.png": oversize,
+        },
+    )
+
+    monkeypatch.setattr(settings, "max_image_decoded_size", 64)
+    with pytest.raises(ValueError, match="exceeds size limit"):
+        DoclingDocument.load_from_doclang_archive(
+            archive_path,
+            artifacts_dir=tmp_path / "artifacts",
+        )
+
+
+def test_load_from_doclang_archive_rejects_oversize_asset_image(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Extracted ``assets/`` picture sources must respect ``max_image_decoded_size``."""
+    from docling_core.utils.settings import settings
+
+    archive_path = tmp_path / "big_asset.dclx"
+    xml = b"""<doclang>
+  <picture>
+    <src uri="assets/big.png"/>
+  </picture>
+</doclang>"""
+    oversize = b"\x89PNG\r\n\x1a\n" + (b"\x00" * 256)
+    _write_zip(
+        archive_path,
+        {
+            "document.xml": xml,
+            "assets/big.png": oversize,
+        },
+    )
+
+    monkeypatch.setattr(settings, "max_image_decoded_size", 64)
+    with pytest.raises(ValueError, match="exceeds size limit"):
+        DoclingDocument.load_from_doclang_archive(
+            archive_path,
+            artifacts_dir=tmp_path / "artifacts",
+        )

--- a/test/test_docling_doc.py
+++ b/test/test_docling_doc.py
@@ -950,6 +950,26 @@ def test_max_decoded_size_default():
     assert pil_img.size == (100, 100)
 
 
+def test_image_ref_path_rejects_oversize_file(tmp_path: Path):
+    """Path-based ImageRef must enforce ``max_image_decoded_size`` like data URIs."""
+    oversize = tmp_path / "big.png"
+    oversize.write_bytes(b"\x89PNG\r\n\x1a\n" + (b"\x00" * 256))
+
+    orig_max = settings.max_image_decoded_size
+    try:
+        settings.max_image_decoded_size = 64
+        image_ref = ImageRef(
+            dpi=72,
+            mimetype="image/png",
+            size=Size(width=1, height=1),
+            uri=oversize,
+        )
+        with pytest.raises(ValueError, match="exceeds size limit"):
+            _ = image_ref.pil_image
+    finally:
+        settings.max_image_decoded_size = orig_max
+
+
 def test_upgrade_content_layer_from_1_0_0() -> None:
     doc = DoclingDocument.load_from_json("test/data/doc/2206.01062-1.0.0.json")
 

--- a/uv.lock
+++ b/uv.lock
@@ -964,15 +964,15 @@ wheels = [
 
 [[package]]
 name = "doclang"
-version = "0.7.2"
+version = "0.7.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "lxml" },
     { name = "typer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/16/91/64ada5d5699e63e6c2c803a85d35a2fb2ee0ceea8e100e513047d56741f4/doclang-0.7.2.tar.gz", hash = "sha256:89c17a168ef9443c2f814284bae3ea3dbf2f1910e79d4fd6cbdde04aa7c06d40", size = 30593, upload-time = "2026-07-03T13:39:17.461Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f5/3a/005e4856ad8e9b9879414a4df4dbc56dc3663b96f9d8c920ef210e8931cf/doclang-0.7.3.tar.gz", hash = "sha256:ca50615357e46ebf9597bb9065b9112367103ec24bd539f8ae12649224cf50b0", size = 31569, upload-time = "2026-07-15T08:11:02.917Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ed/81/0bcdae48110bd5cc3ce078a53b351ec31af1e9f2db1a01574708a51a7983/doclang-0.7.2-py3-none-any.whl", hash = "sha256:fa4414931122c6b9d18a8b1fd6cec3d0dd22dad4efec495ab4461240a8cdf7ed", size = 31317, upload-time = "2026-07-03T13:39:16.48Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/81/334ccc0f0cd7c3d75996b6b596e7f4c62c4c46a0ca042003315c28170159/doclang-0.7.3-py3-none-any.whl", hash = "sha256:9440c4ca9f7e061a7b8d33bdf15b1029be69a4c13cd8952dd6ce541884e4c685", size = 32267, upload-time = "2026-07-15T08:11:01.977Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
- Cap `.dclx` `pages/` and `assets/` rasters with `max_image_decoded_size` before Pillow opens them
- Apply the same limit to Path and `file://` ImageRef loads
- Add tests covering oversize archive images and path-based ImageRefs