### PR TITLE
fix(doclang): sanitize XML-illegal text characters

### DIFF
--- a/docling_core/transforms/serializer/doclang.py
+++ b/docling_core/transforms/serializer/doclang.py
@@ -434,7 +434,17 @@ def _get_delim(*, params: DocLangParams) -> str:
     return "" if params.pretty_indentation is None else "\n"
 
 
+_XML_10_ILLEGAL_CHARACTER_RE = re.compile(r"[\x00-\x08\x0B\x0C\x0E-\x1F\uD800-\uDFFF\uFFFE\uFFFF]")
+
+
+def _replace_xml_illegal_character(match: re.Match[str]) -> str:
+    """Return a visible representation for an XML 1.0-illegal character."""
+    return f"[U+{ord(match.group()):04X}]"
+
+
 def _escape_text(text: str, params: DocLangParams) -> str:
+    """Escape text for DocLang while preserving XML 1.0 validity."""
+    text = _XML_10_ILLEGAL_CHARACTER_RE.sub(_replace_xml_illegal_character, text)
     do_wrap = params.content_wrapping_mode == WrapMode.ALWAYS or (
         params.content_wrapping_mode == WrapMode.AUTO and (text != text.strip() or "\n" in text)
     )

--- a/test/test_serialization_doclang.py
+++ b/test/test_serialization_doclang.py
@@ -1,6 +1,7 @@
 """Unit tests for Doclang create_closing_token helper."""
 
 import warnings
+import xml.etree.ElementTree as ET
 from itertools import chain
 from pathlib import Path
 from typing import Optional
@@ -326,6 +327,30 @@ def _create_escape_test_doc(inp_doc: DoclingDocument):
     )
 
     return doc
+
+
+@pytest.mark.parametrize("pretty_indentation", [None, "  "])
+def test_doclang_replaces_xml_illegal_characters(pretty_indentation: Optional[str]):
+    """DocLang output remains valid when document text contains XML-illegal controls."""
+    doc = DoclingDocument(name="xml_illegal_character")
+    doc.add_text(label=DocItemLabel.TEXT, text="Before break\x0bAfter break")
+
+    result = (
+        DocLangDocSerializer(
+            doc=doc,
+            params=DocLangParams(
+                include_version=False,
+                add_location=False,
+                pretty_indentation=pretty_indentation,
+            ),
+        )
+        .serialize()
+        .text
+    )
+
+    ET.fromstring(result)
+    assert "Before break[U+000B]After break" in result
+    assert "\x0b" not in result
 
 
 def test_cdata_always(sample_doc: DoclingDocument):


### PR DESCRIPTION
## Summary

Preserves XML-illegal text characters as visible Unicode markers during DocLang serialization, preventing `parseString` from raising on content such as PPTX soft line breaks (`\x0b`).

Fixes #686

## Changes

- Normalize XML 1.0-illegal characters in the shared DocLang text-escaping path.
- Represent each removed control character as `[U+XXXX]` so the source anomaly remains visible.
- Add regression coverage for compact and pretty-printed output.

## Type of change

- [x] Bug fix

## How Has This Been Tested?

- `uv run pytest test/test_serialization_doclang.py -k xml_illegal -q`
- `uv run mypy docling_core/transforms/serializer/doclang.py test/test_serialization_doclang.py`
- `uv run ruff check docling_core/transforms/serializer/doclang.py test/test_serialization_doclang.py`
- `uv run ruff format --check docling_core/transforms/serializer/doclang.py test/test_serialization_doclang.py`

## Checklist

- [x] I added regression coverage for the reported failure.
- [x] The focused checks above pass locally.