### PR TITLE
fix(doclang): clamp deep section headers instead of raising

### DIFF
--- a/docling_core/transforms/serializer/doclang.py
+++ b/docling_core/transforms/serializer/doclang.py
@@ -824,7 +824,10 @@ class DocLangTextSerializer(BaseModel, BaseTextSerializer):
         if isinstance(item, TitleItem):
             wrap_open_token = DocLangVocabulary._create_heading_token(level=1)
         elif isinstance(item, SectionHeaderItem):
-            wrap_open_token = DocLangVocabulary._create_heading_token(level=item.level + 1)
+            # Clamp like the HTML serializer does: SectionHeaderItem.level goes
+            # up to 100 and the +1 shift (level 1 is the title) would otherwise
+            # push legitimate level-6 headings past the heading vocabulary.
+            wrap_open_token = DocLangVocabulary._create_heading_token(level=min(item.level + 1, 6))
         elif isinstance(item, ListItem):
             wrap_open_token, tok = self._determine_list_item_wrapper(
                 item=item, doc=doc, use_virtual_text=params.use_virtual_text

--- a/test/test_serialization_doclang.py
+++ b/test/test_serialization_doclang.py
@@ -363,6 +363,27 @@ def test_cdata_when_needed(sample_doc: DoclingDocument):
     verify_doclang(exp_file=exp_file, actual=ser_txt)
 
 
+def test_deep_section_header_levels_clamp_instead_of_raising():
+    """Section headers deeper than the heading vocabulary allows clamp to level 6.
+
+    ``SectionHeaderItem.level`` accepts up to 100 and docling's own heading
+    hierarchy inference emits level-6 headings by default, but the serializer
+    shifts by one (level 1 is the title), so level 6 used to overflow the
+    ``heading`` token's [1, 6] range and raise. ``html.py`` already clamps the
+    same ``item.level + 1`` computation.
+    """
+    doc = DoclingDocument(name="test")
+    doc.add_heading(text="Top", level=1)
+    doc.add_heading(text="Deep", level=6)
+    doc.add_heading(text="Deeper", level=42)
+
+    result = serialize_doclang(doc, params=DocLangParams(include_version=False, add_location=False))
+
+    assert '<heading level="2">Top</heading>' in result
+    assert '<heading level="6">Deep</heading>' in result
+    assert '<heading level="6">Deeper</heading>' in result
+
+
 def test_strikethrough_formatting():
     """Test strikethrough formatting serialization."""
     doc = DoclingDocument(name="test")


### PR DESCRIPTION
Fixes #685.

`DocLangDocSerializer` raised `ValueError: level must be in [1, 6]` for any `SectionHeaderItem` with `level == 6`. As @Steve-Allison's report shows, that's reachable in normal use rather than a synthetic edge case — `SectionHeaderItem.level` accepts up to 100, and docling's own heading-hierarchy inference emits level-6 headings by default, so a PDF with nested procedure lists takes the serializer down.

## Root cause

The `+1` shift (level 1 is reserved for `TitleItem`) pushes level 6 to 7, past the `heading` token's `(1, 6)` range in `_doclang_utils.py`, with nothing clamping it back.

## Fix

`html.py:173` already performs the identical `item.level + 1` computation for the same item type and clamps it with `min(..., 6)`. This applies the same treatment in `doclang.py`, which is both the smallest change and keeps the two serializers consistent with each other.

I went with the clamp rather than widening `ALLOWED_ATTRIBUTE_RANGE`'s upper bound because widening changes the emitted vocabulary — that felt like a call for maintainers rather than something to slip into a crash fix. Happy to switch if you'd prefer depth preserved over range stability.

## Scope

Deliberately limited to the crash in #685. The reporter flagged two related findings in a follow-up comment — DocTags emitting an unregistered `<section_header_level_6>` token, and `FieldHeadingItem` having the same unclamped shape at level 7+ (currently dormant). Both are open design questions rather than the crash, and they were offered as possible separate issues, so I've left them alone rather than bundling unrelated changes here.

## Verification

- New test `test_deep_section_header_levels_clamp_instead_of_raising` fails on `main` with the reported `ValueError` and passes with this change. It covers level 6 (the reported case) and level 42 (well past the shift) alongside a normal level-1 heading.
- Full suite: **560 passed, 6 skipped**.
- `ruff check` clean, `ruff format` applied, `mypy docling_core test`: no issues in 137 source files.
