### PR TITLE
fix: DocLang deserialization of XML-sensitive OTSL cell content

### DIFF
--- a/docling_core/transforms/deserializer/doclang.py
+++ b/docling_core/transforms/deserializer/doclang.py
@@ -8,6 +8,7 @@ from itertools import groupby
 from pathlib import Path
 from typing import Any, ClassVar, Literal, Optional, cast
 from xml.dom.minidom import Element, Node, Text
+from xml.sax.saxutils import escape
 
 from defusedxml.minidom import parseString
 from PIL import Image as PILImage
@@ -945,7 +946,9 @@ class DocLangDocDeserializer(BaseDocDeserializer, BaseModel):
         parts: list[str] = []
         for node in nodes:
             if isinstance(node, Text):
-                parts.append(node.data)
+                # DOM parsing resolves entities and CDATA to plain character data.
+                # Escape it before placing the fragment in XML that will be reparsed.
+                parts.append(escape(node.data))
             elif isinstance(node, Element):
                 if node.tagName == DocLangToken.CONTENT.value:
                     parts.append(self._nodes_to_xml(node.childNodes))

--- a/docling_core/transforms/serializer/doclang.py
+++ b/docling_core/transforms/serializer/doclang.py
@@ -441,7 +441,9 @@ def _escape_text(text: str, params: DocLangParams) -> str:
     if params.escape_mode == EscapeMode.ALWAYS or (
         params.escape_mode == EscapeMode.AUTO and any(c in text for c in ['"', "'", "&", "<", ">"])
     ):
-        text = f"<![CDATA[{text}]]>"
+        # A CDATA section cannot contain its closing delimiter. Split such text
+        # across adjacent CDATA sections while preserving the exact characters.
+        text = f"<![CDATA[{text.replace(']]>', ']]]]><![CDATA[>')}]]>"
     if do_wrap:
         # text = f'<{el_str} xml:space="preserve">{text}</{el_str}>'
         text = _wrap(text=text, wrap_tag=DocLangToken.CONTENT.value)

--- a/test/test_deserializer_doclang.py
+++ b/test/test_deserializer_doclang.py
@@ -8,6 +8,7 @@ from docling_core.transforms.deserializer.doclang import DocLangDocDeserializer
 from docling_core.transforms.serializer.doclang import (
     DocLangDocSerializer,
     DocLangParams,
+    EscapeMode,
     LabelMode,
 )
 from docling_core.types.doc import (
@@ -1819,6 +1820,55 @@ def test_picture_tabular_chart_content_cdata_cells():
     assert doc.pictures[0].meta.tabular_chart.chart_data.grid[0][1].text == "Player expenses in million U.S. dollars"
     assert doc.pictures[0].meta.tabular_chart.chart_data.grid[1][0].text == "19/20"
     assert doc.pictures[0].meta.tabular_chart.chart_data.grid[1][1].text == "111"
+
+
+@pytest.mark.parametrize("escape_mode", [EscapeMode.AUTO, EscapeMode.ALWAYS])
+def test_roundtrip_otsl_xml_sensitive_cell_content(escape_mode: EscapeMode):
+    """OTSL cell text remains exact when DOM fragments are reparsed."""
+    cell_texts = [
+        'Parsing (Structure&Semantic) <test> "quoted"',
+        "ampersand & less < greater >",
+        "\"quotes\" and 'apostrophes'",
+        "literal entity-like text: &amp;",
+        "CDATA terminator: ]]>",
+        "multiline code:\nif a < b:\n    return a & b",
+        "Unicode and math: café ∀x ∈ ℝ, x² ≥ 0",  # noqa: RUF001
+    ]
+    doc = DoclingDocument(name="otsl-xml-sensitive")
+    table_data = TableData(num_rows=0, num_cols=1)
+    for text in cell_texts:
+        table_data.add_row([text])
+    doc.add_table(data=table_data)
+
+    serialized = (
+        DocLangDocSerializer(
+            doc=doc,
+            params=DocLangParams(include_version=False, escape_mode=escape_mode),
+        )
+        .serialize()
+        .text
+    )
+    roundtripped = _deserialize(serialized)
+
+    assert [row[0].text for row in roundtripped.tables[0].data.grid] == cell_texts
+
+
+def test_otsl_xml_sensitive_virtual_and_explicit_text_cells():
+    """Both virtual and explicit rich OTSL cell bodies preserve safe text."""
+    doclang = """\
+<doclang>
+  <table>
+    <fcel/><content><![CDATA[virtual & <cell> "quoted" 'apostrophe']]></content>
+    <fcel/><text><content><![CDATA[nested & <cell>]]></content><bold> bold &amp; styled</bold></text>
+    <nl/>
+  </table>
+</doclang>
+"""
+    doc = _deserialize(doclang)
+
+    assert doc.tables[0].data.grid[0][0].text == "virtual & <cell> \"quoted\" 'apostrophe'"
+    assert doc.tables[0].data.grid[0][1].text == "nested & <cell>bold & styled"
+    assert isinstance(doc.tables[0].data.grid[0][1], RichTableCell)
 
 
 def test_picture_body_table_is_semantic_content_not_chart_tabular():


### PR DESCRIPTION
  ### Summary

  Fix DocLang round trips for OTSL table cells containing XML-sensitive text such as &, <, >, quotes, and entity-like
  strings.

  ### Changes

  - Escape DOM text nodes when reconstructing XML fragments for reparsing.
  - Preserve <content> semantics for ordinary text and CDATA.
  - Safely serialize literal ]]> by splitting it across adjacent CDATA sections.
  - Add regression coverage for:
      - EscapeMode.AUTO and EscapeMode.ALWAYS
      - Virtual and explicit <text> cells
      - Nested formatting
      - Multiline, Unicode, and mathematical content
      - Literal entity-like strings such as &amp;

