### PR TITLE
fix: accept application/epub+zip mimetype in DocumentOrigin

### DIFF
--- a/docling_core/types/doc/common/origin.py
+++ b/docling_core/types/doc/common/origin.py
@@ -25,6 +25,7 @@ class DocumentOrigin(BaseModel):
     )
 
     _extra_mimetypes: typing.ClassVar[list[str]] = [
+        "application/epub+zip",
         "application/vnd.box.boxnote",
         "application/vnd.oasis.opendocument.presentation",
         "application/vnd.oasis.opendocument.spreadsheet",


### PR DESCRIPTION
Adds `application/epub+zip` to `DocumentOrigin._extra_mimetypes` so EPUB documents
validate on hosts whose system mime map does not list EPUB (Windows, minimal
containers). This is docling's declared EPUB mimetype, previously rejected by
`validate_mimetype`. Follows the same convention as #654 (OpenDocument formats),
and adds a unit test (`test/test_origin.py`).

Resolves #691