### PR TITLE
feat: make inline serializers concatenate runs faithfully

### DIFF
--- a/docling_core/compat.py
+++ b/docling_core/compat.py
@@ -198,6 +198,36 @@ def list_projectors() -> list[tuple[int, int]]:
 # the serialised dict without error.  Full semantic fidelity is not always
 # possible; the goal is a document that validates rather than crashes.
 
+# --- 1.11 → 1.10 ----------------------------------------------------------
+# Schema 1.11 (docling-core v2.86.0): InlineGroup runs carry their own
+# significant whitespace and serializers concatenate them faithfully.
+#
+# The 1.11 and 1.10 schemas are structurally identical -- no new fields,
+# labels, or lists.  The only difference is *semantic*: a 1.11 run's text
+# contains its boundary whitespace, whereas a 1.10 client re-inserts a
+# single " " between runs at serialization time.  A 1.10 client therefore
+# parses a 1.11 dict without error; it just renders the boundary twice
+# (e.g. "bold  tail"), the documented, harmless double-space case.  1.10
+# cannot represent a tight run boundary, so there is nothing to project
+# structurally -- only the version stamp is lowered so the old client's
+# version-compatibility gate accepts the document.
+# ---------------------------------------------------------------------------
+
+
+@register_projector(from_minor=11, to_minor=10)
+def _project_1_11_to_1_10(data: dict) -> dict:
+    """Downgrade a schema 1.11 document dict to schema 1.10.
+
+    1.11 and 1.10 share an identical structure; the difference is only in how
+    inline-run whitespace is represented. A 1.10 client validates the dict
+    as-is and re-applies its own single-space join between runs, so the sole
+    transform is re-stamping the version.
+    """
+    data = dict(data)
+    data["version"] = "1.10.0"
+    return data
+
+
 # --- 1.10 → 1.9 -----------------------------------------------------------
 # Schema 1.10 (docling-core v2.69.0, PR #519):
 #   • Added FieldRegionItem, FieldHeadingItem, FieldItem, FieldValueItem

--- a/docling_core/transforms/deserializer/doclang.py
+++ b/docling_core/transforms/deserializer/doclang.py
@@ -402,6 +402,8 @@ class DocLangDocDeserializer(BaseDocDeserializer, BaseModel):
                 }:
                     return None
                 elif tmp := self._get_children_simple_text_block(el):
+                    if result is not None:
+                        return None
                     result = tmp
             elif isinstance(el, Text) and el.data.strip():  # TODO should still support whitespace-only
                 if result is None:

--- a/docling_core/transforms/deserializer/doclang.py
+++ b/docling_core/transforms/deserializer/doclang.py
@@ -3,6 +3,7 @@
 Aligned to the DocLang specification version ``_DOCLANG_VERSION``.
 """
 
+import re
 from collections.abc import Callable, Sequence
 from itertools import groupby
 from pathlib import Path
@@ -102,6 +103,22 @@ def _utf8_byte_length(text: str) -> int:
     """Return UTF-8 byte length of ``text`` without retaining the encoded buffer."""
     # encode builds a temporary bytes object; acceptable for a one-shot gate check.
     return len(text.encode("utf-8"))
+
+
+# A whitespace run touching a newline is pretty-print indentation; one without is content.
+_PRETTY_INDENT = re.compile(r"\A\s*\n\s*|\s*\n\s*\Z")
+
+
+def _normalize_bare_text(data: str) -> str:
+    """Drop pretty-print indentation from a bare XML text node, keep significant whitespace.
+
+    Standard XML heuristic: whitespace containing a newline is layout noise, whitespace
+    without one is meaningful. Serialized DocLang uses ``<content>`` for whitespace-bearing
+    runs, so this only governs hand-written and VLM-emitted input.
+    """
+    if not data.strip():
+        return "" if "\n" in data else data
+    return _PRETTY_INDENT.sub("", data)
 
 
 def _enforce_doclang_dom_budgets(
@@ -426,7 +443,8 @@ class DocLangDocDeserializer(BaseDocDeserializer, BaseModel):
 
         prov_list = self._extract_provenance(doc=doc, el=el)
         content_layer = self._extract_layer(el=el)
-        text, formatting = self._extract_text_with_formatting(el)
+        # A run inside an inline group owns its edge whitespace; a block host does not.
+        text, formatting = self._extract_text_with_formatting(el, trim=not isinstance(parent, InlineGroup))
         if not text:
             if (
                 thread_id
@@ -581,16 +599,12 @@ class DocLangDocDeserializer(BaseDocDeserializer, BaseModel):
                     parts.append(node.data)
             elif isinstance(node, Element):
                 nm_child = node.tagName
-                if nm_child in {
-                    DocLangToken.LOCATION.value,
-                    DocLangToken.LAYER.value,
-                    DocLangToken.LABEL.value,
-                }:
+                if self._is_element_head_tag(node):
                     continue
                 elif nm_child == DocLangToken.BR.value:
                     parts.append("\n")
                 else:
-                    parts.append(self._get_text(node))
+                    parts.append(self._collect_text(node))
 
         return "".join(parts), lang_label
 
@@ -1419,8 +1433,11 @@ class DocLangDocDeserializer(BaseDocDeserializer, BaseModel):
                 # Recursively dispatch child elements with the inline group as parent
                 self._dispatch_element(doc=doc, el=node, parent=inline_group)
             elif isinstance(node, Text):
-                # Handle direct text content
-                text_content = node.data.strip()
+                # Direct text content: a run of the inline group, carrying its own whitespace.
+                # ponytail: no outer block-edge trim here -- pretty-printed input has newlines at
+                # the edges and loses them to the indentation heuristic anyway. Add edge trimming
+                # if hand-written single-line DocLang turns out to need it.
+                text_content = _normalize_bare_text(node.data)
                 if text_content:
                     doc.add_text(
                         label=DocItemLabel.TEXT,
@@ -2090,20 +2107,23 @@ class DocLangDocDeserializer(BaseDocDeserializer, BaseModel):
             table_cells=table_cells,
         )
 
-    def _extract_text_with_formatting(self, el: Element) -> tuple[str, Optional[Formatting]]:
+    def _extract_text_with_formatting(self, el: Element, *, trim: bool = True) -> tuple[str, Optional[Formatting]]:
         """Extract text content and formatting from an element.
 
         If the element contains a single formatting child (bold, italic, etc.),
         recursively extract the text and build up the Formatting object.
 
+        Args:
+            el: the element to extract from.
+            trim: trim the outer boundary. True for a block-level host, False when ``el`` is a
+                run inside an inline group, whose edge whitespace is significant.
+
         Returns:
             Tuple of (text_content, formatting_object or None)
         """
-        # Get non-whitespace, non-location child elements
+        # Body child elements only -- element-head tags carry metadata, not text.
         child_elements = [
-            node
-            for node in el.childNodes
-            if isinstance(node, Element) and node.tagName not in {DocLangToken.LOCATION.value}
+            node for node in el.childNodes if isinstance(node, Element) and not self._is_element_head_tag(node)
         ]
 
         # Check if we have a single child that is a formatting tag
@@ -2124,7 +2144,7 @@ class DocLangDocDeserializer(BaseDocDeserializer, BaseModel):
 
             if tag_name in format_tags:
                 # Recursively extract text and formatting from the child
-                text, child_formatting = self._extract_text_with_formatting(child)
+                text, child_formatting = self._extract_text_with_formatting(child, trim=trim)
 
                 # Build up the formatting object
                 if child_formatting is None:
@@ -2146,25 +2166,57 @@ class DocLangDocDeserializer(BaseDocDeserializer, BaseModel):
 
                 return text, child_formatting
 
-        # No formatting found, just extract plain text
-        return self._get_text(el), None
+        # No formatting found, just extract plain text.
+        return (self._trimmed_text(el) if trim else self._collect_text(el)), None
 
     def _get_text(self, el: Element) -> str:
-        out: list[str] = []
+        """Extract the text of a block-level element, trimming the block boundary only."""
+        return self._trimmed_text(el)
+
+    def _collect_text(self, el: Element) -> str:
+        """Concatenate descendant text verbatim, per the inline whitespace contract.
+
+        Fragments are joined faithfully -- stripping each one is what collapsed
+        `Advanced <bold>Topics</bold>` into `AdvancedTopics`.
+        """
+        return "".join(text for text, _ in self._collect_fragments(el))
+
+    def _trimmed_text(self, el: Element) -> str:
+        """Concatenate descendant text, trimming the outer block boundary only.
+
+        Whitespace delivered through ``<content>`` is protected: that tag is the format's
+        explicit "this whitespace is significant" marker, so a block edge never strips it.
+        Same shape as docling's ``_normalize_odf_text_runs``.
+        """
+        frags = self._collect_fragments(el)
+        for idx, strip in ((0, str.lstrip), (-1, str.rstrip)):
+            while frags and not frags[idx][1]:
+                if trimmed := strip(frags[idx][0]):
+                    frags[idx] = (trimmed, False)
+                    break
+                frags.pop(idx)
+        return "".join(text for text, _ in frags)
+
+    def _collect_fragments(self, el: Element) -> list[tuple[str, bool]]:
+        """Return ``(text, protected)`` fragments; protected text came from ``<content>``."""
+        out: list[tuple[str, bool]] = []
         for node in el.childNodes:
             if isinstance(node, Text):
-                # Skip pure indentation/pretty-print whitespace
-                if node.data.strip():
-                    out.append(node.data if el.tagName == DocLangToken.CONTENT.value else node.data.strip())
-            elif isinstance(node, Element):
-                nm = node.tagName
-                if nm in {DocLangToken.LOCATION.value}:
-                    continue
-                if nm == DocLangToken.BR.value:
-                    out.append("\n")
+                if el.tagName == DocLangToken.CONTENT.value:
+                    # `<content>` is the lossless whitespace channel: take it verbatim.
+                    out.append((node.data, True))
                 else:
-                    out.append(self._get_text(node))
-        return "".join(out)
+                    out.append((_normalize_bare_text(node.data), False))
+            elif isinstance(node, Element):
+                # Element-head children (<caption>, <description>, <summary>, <custom>, ...) are
+                # metadata; they are modelled in item.meta and must not bleed into body text.
+                if self._is_element_head_tag(node):
+                    continue
+                if node.tagName == DocLangToken.BR.value:
+                    out.append(("\n", False))
+                else:
+                    out.extend(self._collect_fragments(node))
+        return out
 
     # --------- Location helpers ---------
     def _ensure_page_exists(self, *, doc: DoclingDocument, page_no: int, resolution: int) -> None:

--- a/docling_core/transforms/deserializer/doclang.py
+++ b/docling_core/transforms/deserializer/doclang.py
@@ -3,6 +3,7 @@
 Aligned to the DocLang specification version ``_DOCLANG_VERSION``.
 """
 
+import re
 from collections.abc import Callable, Sequence
 from itertools import groupby
 from pathlib import Path
@@ -97,6 +98,22 @@ def _utf8_byte_length(text: str) -> int:
     """Return UTF-8 byte length of ``text`` without retaining the encoded buffer."""
     # encode builds a temporary bytes object; acceptable for a one-shot gate check.
     return len(text.encode("utf-8"))
+
+
+# A whitespace run touching a newline is pretty-print indentation; one without is content.
+_PRETTY_INDENT = re.compile(r"\A\s*\n\s*|\s*\n\s*\Z")
+
+
+def _normalize_bare_text(data: str) -> str:
+    """Drop pretty-print indentation from a bare XML text node, keep significant whitespace.
+
+    Standard XML heuristic: whitespace containing a newline is layout noise, whitespace
+    without one is meaningful. Serialized DocLang uses ``<content>`` for whitespace-bearing
+    runs, so this only governs hand-written and VLM-emitted input.
+    """
+    if not data.strip():
+        return "" if "\n" in data else data
+    return _PRETTY_INDENT.sub("", data)
 
 
 def _enforce_doclang_dom_budgets(
@@ -415,7 +432,8 @@ class DocLangDocDeserializer(BaseDocDeserializer, BaseModel):
 
         prov_list = self._extract_provenance(doc=doc, el=el)
         content_layer = self._extract_layer(el=el)
-        text, formatting = self._extract_text_with_formatting(el)
+        # A run inside an inline group owns its edge whitespace; a block host does not.
+        text, formatting = self._extract_text_with_formatting(el, trim=not isinstance(parent, InlineGroup))
         if not text:
             if (
                 thread_id
@@ -562,16 +580,12 @@ class DocLangDocDeserializer(BaseDocDeserializer, BaseModel):
                     parts.append(node.data)
             elif isinstance(node, Element):
                 nm_child = node.tagName
-                if nm_child in {
-                    DocLangToken.LOCATION.value,
-                    DocLangToken.LAYER.value,
-                    DocLangToken.LABEL.value,
-                }:
+                if self._is_element_head_tag(node):
                     continue
                 elif nm_child == DocLangToken.BR.value:
                     parts.append("\n")
                 else:
-                    parts.append(self._get_text(node))
+                    parts.append(self._collect_text(node))
 
         return "".join(parts), lang_label
 
@@ -1379,8 +1393,11 @@ class DocLangDocDeserializer(BaseDocDeserializer, BaseModel):
                 # Recursively dispatch child elements with the inline group as parent
                 self._dispatch_element(doc=doc, el=node, parent=inline_group)
             elif isinstance(node, Text):
-                # Handle direct text content
-                text_content = node.data.strip()
+                # Direct text content: a run of the inline group, carrying its own whitespace.
+                # ponytail: no outer block-edge trim here -- pretty-printed input has newlines at
+                # the edges and loses them to the indentation heuristic anyway. Add edge trimming
+                # if hand-written single-line DocLang turns out to need it.
+                text_content = _normalize_bare_text(node.data)
                 if text_content:
                     doc.add_text(
                         label=DocItemLabel.TEXT,
@@ -2052,20 +2069,23 @@ class DocLangDocDeserializer(BaseDocDeserializer, BaseModel):
             table_cells=table_cells,
         )
 
-    def _extract_text_with_formatting(self, el: Element) -> tuple[str, Optional[Formatting]]:
+    def _extract_text_with_formatting(self, el: Element, *, trim: bool = True) -> tuple[str, Optional[Formatting]]:
         """Extract text content and formatting from an element.
 
         If the element contains a single formatting child (bold, italic, etc.),
         recursively extract the text and build up the Formatting object.
 
+        Args:
+            el: the element to extract from.
+            trim: trim the outer boundary. True for a block-level host, False when ``el`` is a
+                run inside an inline group, whose edge whitespace is significant.
+
         Returns:
             Tuple of (text_content, formatting_object or None)
         """
-        # Get non-whitespace, non-location child elements
+        # Body child elements only -- element-head tags carry metadata, not text.
         child_elements = [
-            node
-            for node in el.childNodes
-            if isinstance(node, Element) and node.tagName not in {DocLangToken.LOCATION.value}
+            node for node in el.childNodes if isinstance(node, Element) and not self._is_element_head_tag(node)
         ]
 
         # Check if we have a single child that is a formatting tag
@@ -2086,7 +2106,7 @@ class DocLangDocDeserializer(BaseDocDeserializer, BaseModel):
 
             if tag_name in format_tags:
                 # Recursively extract text and formatting from the child
-                text, child_formatting = self._extract_text_with_formatting(child)
+                text, child_formatting = self._extract_text_with_formatting(child, trim=trim)
 
                 # Build up the formatting object
                 if child_formatting is None:
@@ -2108,25 +2128,57 @@ class DocLangDocDeserializer(BaseDocDeserializer, BaseModel):
 
                 return text, child_formatting
 
-        # No formatting found, just extract plain text
-        return self._get_text(el), None
+        # No formatting found, just extract plain text.
+        return (self._trimmed_text(el) if trim else self._collect_text(el)), None
 
     def _get_text(self, el: Element) -> str:
-        out: list[str] = []
+        """Extract the text of a block-level element, trimming the block boundary only."""
+        return self._trimmed_text(el)
+
+    def _collect_text(self, el: Element) -> str:
+        """Concatenate descendant text verbatim, per the inline whitespace contract.
+
+        Fragments are joined faithfully -- stripping each one is what collapsed
+        `Advanced <bold>Topics</bold>` into `AdvancedTopics`.
+        """
+        return "".join(text for text, _ in self._collect_fragments(el))
+
+    def _trimmed_text(self, el: Element) -> str:
+        """Concatenate descendant text, trimming the outer block boundary only.
+
+        Whitespace delivered through ``<content>`` is protected: that tag is the format's
+        explicit "this whitespace is significant" marker, so a block edge never strips it.
+        Same shape as docling's ``_normalize_odf_text_runs``.
+        """
+        frags = self._collect_fragments(el)
+        for idx, strip in ((0, str.lstrip), (-1, str.rstrip)):
+            while frags and not frags[idx][1]:
+                if trimmed := strip(frags[idx][0]):
+                    frags[idx] = (trimmed, False)
+                    break
+                frags.pop(idx)
+        return "".join(text for text, _ in frags)
+
+    def _collect_fragments(self, el: Element) -> list[tuple[str, bool]]:
+        """Return ``(text, protected)`` fragments; protected text came from ``<content>``."""
+        out: list[tuple[str, bool]] = []
         for node in el.childNodes:
             if isinstance(node, Text):
-                # Skip pure indentation/pretty-print whitespace
-                if node.data.strip():
-                    out.append(node.data if el.tagName == DocLangToken.CONTENT.value else node.data.strip())
-            elif isinstance(node, Element):
-                nm = node.tagName
-                if nm in {DocLangToken.LOCATION.value}:
-                    continue
-                if nm == DocLangToken.BR.value:
-                    out.append("\n")
+                if el.tagName == DocLangToken.CONTENT.value:
+                    # `<content>` is the lossless whitespace channel: take it verbatim.
+                    out.append((node.data, True))
                 else:
-                    out.append(self._get_text(node))
-        return "".join(out)
+                    out.append((_normalize_bare_text(node.data), False))
+            elif isinstance(node, Element):
+                # Element-head children (<caption>, <description>, <summary>, <custom>, ...) are
+                # metadata; they are modelled in item.meta and must not bleed into body text.
+                if self._is_element_head_tag(node):
+                    continue
+                if node.tagName == DocLangToken.BR.value:
+                    out.append(("\n", False))
+                else:
+                    out.extend(self._collect_fragments(node))
+        return out
 
     # --------- Location helpers ---------
     def _ensure_page_exists(self, *, doc: DoclingDocument, page_no: int, resolution: int) -> None:

--- a/docling_core/transforms/deserializer/doclang.py
+++ b/docling_core/transforms/deserializer/doclang.py
@@ -391,6 +391,8 @@ class DocLangDocDeserializer(BaseDocDeserializer, BaseModel):
                 }:
                     return None
                 elif tmp := self._get_children_simple_text_block(el):
+                    if result is not None:
+                        return None
                     result = tmp
             elif isinstance(el, Text) and el.data.strip():  # TODO should still support whitespace-only
                 if result is None:

--- a/docling_core/transforms/serializer/common.py
+++ b/docling_core/transforms/serializer/common.py
@@ -8,7 +8,7 @@ from abc import abstractmethod
 from collections.abc import Iterable
 from functools import cached_property
 from pathlib import Path
-from typing import Annotated, Any, Optional, Union
+from typing import Annotated, Any, ClassVar, Optional, Union
 
 from pydantic import (
     AnyUrl,
@@ -249,6 +249,11 @@ class DocSerializer(BaseModel, BaseDocSerializer):
     annotation_serializer: BaseAnnotationSerializer
 
     params: CommonParams = CommonParams()
+
+    # Move whitespace at the edges of a run outside the formatting/hyperlink markers.
+    # Off for formats whose own whitespace channel must keep it inside the markup
+    # (DocLang wraps it in `<content>`), on where adjacency breaks the markup (Markdown).
+    hoist_decoration_whitespace: ClassVar[bool] = False
 
     _excluded_refs_cache: dict[str, set[str]] = {}
 
@@ -555,7 +560,23 @@ class DocSerializer(BaseModel, BaseDocSerializer):
     ) -> str:
         """Apply some text post-processing steps."""
         params = self.params.merge_with_patch(patch=kwargs)
+
+        lead = trail = ""
         res = text
+        if self.hoist_decoration_whitespace:
+            # Inline runs carry their own significant whitespace, which may sit *inside* a
+            # formatted run (common in DOCX/HTML). Decorating it verbatim produces
+            # `**bold ** tail`, which CommonMark renders as literal asterisks. Hoist the edge
+            # whitespace around the *complete* decoration stack -- hoisting inside an
+            # individual formatter would let the hyperlink capture it again.
+            core = text.strip()
+            if not core:
+                # Whitespace-only (or empty) run: no markers, no empty hyperlink.
+                return text
+            lead = text[: len(text) - len(text.lstrip())]
+            trail = text[len(text.rstrip()) :]
+            res = core
+
         if params.include_formatting and formatting:
             if formatting.bold:
                 res = self.serialize_bold(text=res, **kwargs)
@@ -571,7 +592,7 @@ class DocSerializer(BaseModel, BaseDocSerializer):
                 res = self.serialize_superscript(text=res, **kwargs)
         if params.include_hyperlinks and hyperlink:
             res = self.serialize_hyperlink(text=res, hyperlink=hyperlink, **kwargs)
-        return res
+        return f"{lead}{res}{trail}"
 
     @override
     def serialize_bold(self, text: str, **kwargs: Any) -> str:

--- a/docling_core/transforms/serializer/common.py
+++ b/docling_core/transforms/serializer/common.py
@@ -8,7 +8,7 @@ from abc import abstractmethod
 from collections.abc import Iterable
 from functools import cached_property
 from pathlib import Path
-from typing import Annotated, Any, Optional, Union
+from typing import Annotated, Any, ClassVar, Optional, Union
 
 from pydantic import (
     AnyUrl,
@@ -249,6 +249,11 @@ class DocSerializer(BaseModel, BaseDocSerializer):
     annotation_serializer: BaseAnnotationSerializer
 
     params: CommonParams = CommonParams()
+
+    # Move whitespace at the edges of a run outside the formatting/hyperlink markers.
+    # Off for formats whose own whitespace channel must keep it inside the markup
+    # (DocLang wraps it in `<content>`), on where adjacency breaks the markup (Markdown).
+    hoist_decoration_whitespace: ClassVar[bool] = False
 
     _excluded_refs_cache: dict[str, set[str]] = {}
 
@@ -553,7 +558,23 @@ class DocSerializer(BaseModel, BaseDocSerializer):
     ) -> str:
         """Apply some text post-processing steps."""
         params = self.params.merge_with_patch(patch=kwargs)
+
+        lead = trail = ""
         res = text
+        if self.hoist_decoration_whitespace:
+            # Inline runs carry their own significant whitespace, which may sit *inside* a
+            # formatted run (common in DOCX/HTML). Decorating it verbatim produces
+            # `**bold ** tail`, which CommonMark renders as literal asterisks. Hoist the edge
+            # whitespace around the *complete* decoration stack -- hoisting inside an
+            # individual formatter would let the hyperlink capture it again.
+            core = text.strip()
+            if not core:
+                # Whitespace-only (or empty) run: no markers, no empty hyperlink.
+                return text
+            lead = text[: len(text) - len(text.lstrip())]
+            trail = text[len(text.rstrip()) :]
+            res = core
+
         if params.include_formatting and formatting:
             if formatting.bold:
                 res = self.serialize_bold(text=res, **kwargs)
@@ -569,7 +590,7 @@ class DocSerializer(BaseModel, BaseDocSerializer):
                 res = self.serialize_superscript(text=res, **kwargs)
         if params.include_hyperlinks and hyperlink:
             res = self.serialize_hyperlink(text=res, hyperlink=hyperlink, **kwargs)
-        return res
+        return f"{lead}{res}{trail}"
 
     @override
     def serialize_bold(self, text: str, **kwargs: Any) -> str:

--- a/docling_core/transforms/serializer/doclang.py
+++ b/docling_core/transforms/serializer/doclang.py
@@ -1620,17 +1620,23 @@ class DocLangInlineSerializer(BaseInlineSerializer):
                     )
                     parts.append(create_ser_result(text=loc_str))
             params.add_location = False
-        parts.extend(
-            doc_serializer.get_parts(
-                item=item,
-                list_level=list_level,
-                is_inline_scope=True,
-                visited=my_visited,
-                **{**kwargs, **params.model_dump()},
-            )
+        head_parts = list(parts)
+        inline_parts = doc_serializer.get_parts(
+            item=item,
+            list_level=list_level,
+            is_inline_scope=True,
+            visited=my_visited,
+            **{**kwargs, **params.model_dump()},
         )
+        parts.extend(inline_parts)
         delim = _get_delim(params=params)
-        text_res = delim.join([p.text for p in parts if p.text])
+        # Inline runs carry their own significant whitespace; concatenate them faithfully.
+        # The delimiter separates the element head from the body, it is not a whitespace
+        # channel — `<content>` is (see `_escape_text`).
+        segments = [p.text for p in head_parts if p.text]
+        if inline_text := "".join([p.text for p in inline_parts if p.text]):
+            segments.append(inline_text)
+        text_res = delim.join(segments)
         if text_res:
             text_res = f"{text_res}{delim}"
 

--- a/docling_core/transforms/serializer/doclang.py
+++ b/docling_core/transforms/serializer/doclang.py
@@ -1607,17 +1607,23 @@ class DocLangInlineSerializer(BaseInlineSerializer):
                     )
                     parts.append(create_ser_result(text=loc_str))
             params.add_location = False
-        parts.extend(
-            doc_serializer.get_parts(
-                item=item,
-                list_level=list_level,
-                is_inline_scope=True,
-                visited=my_visited,
-                **{**kwargs, **params.model_dump()},
-            )
+        head_parts = list(parts)
+        inline_parts = doc_serializer.get_parts(
+            item=item,
+            list_level=list_level,
+            is_inline_scope=True,
+            visited=my_visited,
+            **{**kwargs, **params.model_dump()},
         )
+        parts.extend(inline_parts)
         delim = _get_delim(params=params)
-        text_res = delim.join([p.text for p in parts if p.text])
+        # Inline runs carry their own significant whitespace; concatenate them faithfully.
+        # The delimiter separates the element head from the body, it is not a whitespace
+        # channel — `<content>` is (see `_escape_text`).
+        segments = [p.text for p in head_parts if p.text]
+        if inline_text := "".join([p.text for p in inline_parts if p.text]):
+            segments.append(inline_text)
+        text_res = delim.join(segments)
         if text_res:
             text_res = f"{text_res}{delim}"
 

--- a/docling_core/transforms/serializer/html.py
+++ b/docling_core/transforms/serializer/html.py
@@ -7,7 +7,7 @@ from enum import Enum
 from html.parser import HTMLParser
 from io import BytesIO
 from pathlib import Path
-from typing import Any, Optional, Union
+from typing import Any, ClassVar, Optional, Union
 from urllib.parse import quote
 from xml.etree.ElementTree import SubElement, tostring
 from xml.sax.saxutils import unescape
@@ -891,8 +891,8 @@ class HTMLInlineSerializer(BaseInlineSerializer):
             **kwargs,
         )
 
-        # Join all parts without separators
-        inline_html = " ".join([p.text for p in parts if p.text])
+        # Inline runs carry their own significant whitespace; concatenate faithfully.
+        inline_html = "".join([p.text for p in parts if p.text])
 
         # Wrap in span if needed
         if inline_html:
@@ -1078,6 +1078,8 @@ class HTMLDocSerializer(DocSerializer):
     annotation_serializer: BaseAnnotationSerializer = HTMLAnnotationSerializer()
 
     params: HTMLParams = HTMLParams()
+
+    hoist_decoration_whitespace: ClassVar[bool] = True
 
     @override
     def _item_wraps_meta(self, item: NodeItem) -> bool:

--- a/docling_core/transforms/serializer/latex.py
+++ b/docling_core/transforms/serializer/latex.py
@@ -2,7 +2,7 @@
 
 import re
 from pathlib import Path
-from typing import Any, Optional, Union
+from typing import Any, ClassVar, Optional, Union
 
 from pydantic import AnyUrl, BaseModel
 from typing_extensions import override
@@ -514,14 +514,15 @@ class LaTeXInlineSerializer(BaseInlineSerializer):
         list_level: int = 0,
         **kwargs: Any,
     ) -> SerializationResult:
-        """Serialize inline children joining them with spaces for LaTeX output."""
+        """Serialize inline children concatenating them faithfully for LaTeX output."""
         parts = doc_serializer.get_parts(
             item=item,
             list_level=list_level,
             is_inline_scope=True,
             **kwargs,
         )
-        text_res = " ".join([p.text for p in parts if p.text])
+        # Inline runs carry their own significant whitespace; concatenate faithfully.
+        text_res = "".join([p.text for p in parts if p.text])
         return create_ser_result(text=text_res, span_source=parts)
 
 
@@ -565,6 +566,10 @@ class LaTeXDocSerializer(DocSerializer):
     annotation_serializer: BaseAnnotationSerializer = LaTeXAnnotationSerializer()
 
     params: LaTeXParams = LaTeXParams()
+
+    # `\textbf{bold }tail` renders the same as `\textbf{bold} tail`, but keeping the space
+    # outside the group matches the other formats and keeps escaping predictable.
+    hoist_decoration_whitespace: ClassVar[bool] = True
 
     @override
     def serialize_bold(self, text: str, **kwargs: Any) -> str:

--- a/docling_core/transforms/serializer/markdown.py
+++ b/docling_core/transforms/serializer/markdown.py
@@ -6,7 +6,7 @@ import re
 import textwrap
 from enum import Enum
 from pathlib import Path
-from typing import Annotated, Any, Optional, Union
+from typing import Annotated, Any, ClassVar, Optional, Union
 
 from pydantic import AnyUrl, BaseModel, Field, PositiveInt
 from tabulate import _column_type, tabulate
@@ -824,7 +824,8 @@ class MarkdownInlineSerializer(BaseInlineSerializer):
             visited=my_visited,
             **kwargs,
         )
-        text_res = " ".join([p.text for p in parts if p.text])
+        # Inline runs carry their own significant whitespace; concatenate faithfully.
+        text_res = "".join([p.text for p in parts if p.text])
         return create_ser_result(text=text_res, span_source=parts)
 
 
@@ -869,6 +870,9 @@ class MarkdownDocSerializer(DocSerializer):
     annotation_serializer: BaseAnnotationSerializer = MarkdownAnnotationSerializer()
 
     params: MarkdownParams = MarkdownParams()
+
+    # `**bold ** tail` renders as literal asterisks in CommonMark.
+    hoist_decoration_whitespace: ClassVar[bool] = True
 
     @override
     def serialize_bold(self, text: str, **kwargs: Any):

--- a/docling_core/transforms/serializer/markdown.py
+++ b/docling_core/transforms/serializer/markdown.py
@@ -6,7 +6,7 @@ import re
 import textwrap
 from enum import Enum
 from pathlib import Path
-from typing import Annotated, Any, Optional, Union
+from typing import Annotated, Any, ClassVar, Optional, Union
 
 from pydantic import AnyUrl, BaseModel, Field, PositiveInt
 from tabulate import _column_type, tabulate
@@ -814,7 +814,8 @@ class MarkdownInlineSerializer(BaseInlineSerializer):
             visited=my_visited,
             **kwargs,
         )
-        text_res = " ".join([p.text for p in parts if p.text])
+        # Inline runs carry their own significant whitespace; concatenate faithfully.
+        text_res = "".join([p.text for p in parts if p.text])
         return create_ser_result(text=text_res, span_source=parts)
 
 
@@ -859,6 +860,9 @@ class MarkdownDocSerializer(DocSerializer):
     annotation_serializer: BaseAnnotationSerializer = MarkdownAnnotationSerializer()
 
     params: MarkdownParams = MarkdownParams()
+
+    # `**bold ** tail` renders as literal asterisks in CommonMark.
+    hoist_decoration_whitespace: ClassVar[bool] = True
 
     @override
     def serialize_bold(self, text: str, **kwargs: Any):

--- a/docling_core/types/doc/common/constants.py
+++ b/docling_core/types/doc/common/constants.py
@@ -5,7 +5,7 @@ from typing import Final
 
 from docling_core.types.doc.labels import DocItemLabel
 
-CURRENT_VERSION: Final = "1.10.0"
+CURRENT_VERSION: Final = "1.11.0"
 """Current DoclingDocument schema version.
 
 Bump this (minor) whenever a change to the serialised format would cause an
@@ -20,6 +20,7 @@ SCHEMA_VERSION_HISTORY: Final[list[dict]] = [
     {"schema": "1.8.0", "library_version": "v2.49.0", "note": "BasePrediction, BaseMeta, meta field"},
     {"schema": "1.9.0", "library_version": "v2.57.0", "note": "FineRef, DocItem.comments"},
     {"schema": "1.10.0", "library_version": "v2.69.0", "note": "FieldItem types, 7 new DocItemLabel values"},
+    {"schema": "1.11.0", "library_version": "v2.86.0", "note": "InlineGroup runs carry their own significant whitespace"},
 ]
 """Ordered history of DoclingDocument schema versions in docling-core v2.x.
 
@@ -46,6 +47,11 @@ This is the minor component of the first entry in ``SCHEMA_VERSION_HISTORY``
 (currently ``5``, corresponding to schema ``1.5.0``).  A projector exists for
 every step from ``_CURRENT_MINOR`` down to ``FIRST_SUPPORTED_MINOR + 1``.
 """
+
+# First schema version in which InlineGroup runs carry their own significant whitespace and
+# serializers concatenate them faithfully. Documents stamped below this are normalized on load
+# (see `DoclingDocument._migrate_legacy_inline_separators`).
+INLINE_WHITESPACE_CONTRACT_VERSION: Final = "1.11.0"
 
 
 DEFAULT_EXPORT_LABELS = {

--- a/docling_core/types/doc/common/constants.py
+++ b/docling_core/types/doc/common/constants.py
@@ -20,7 +20,11 @@ SCHEMA_VERSION_HISTORY: Final[list[dict]] = [
     {"schema": "1.8.0", "library_version": "v2.49.0", "note": "BasePrediction, BaseMeta, meta field"},
     {"schema": "1.9.0", "library_version": "v2.57.0", "note": "FineRef, DocItem.comments"},
     {"schema": "1.10.0", "library_version": "v2.69.0", "note": "FieldItem types, 7 new DocItemLabel values"},
-    {"schema": "1.11.0", "library_version": "v2.86.0", "note": "InlineGroup runs carry their own significant whitespace"},
+    {
+        "schema": "1.11.0",
+        "library_version": "v2.86.0",
+        "note": "InlineGroup runs carry their own significant whitespace",
+    },
 ]
 """Ordered history of DoclingDocument schema versions in docling-core v2.x.
 

--- a/docling_core/types/doc/common/constants.py
+++ b/docling_core/types/doc/common/constants.py
@@ -4,7 +4,12 @@ from typing import Final
 
 from docling_core.types.doc.labels import DocItemLabel
 
-CURRENT_VERSION: Final = "1.10.0"
+CURRENT_VERSION: Final = "1.11.0"
+
+# First schema version in which InlineGroup runs carry their own significant whitespace and
+# serializers concatenate them faithfully. Documents stamped below this are normalized on load
+# (see `DoclingDocument._migrate_legacy_inline_separators`).
+INLINE_WHITESPACE_CONTRACT_VERSION: Final = "1.11.0"
 
 
 DEFAULT_EXPORT_LABELS = {

--- a/docling_core/types/doc/document.py
+++ b/docling_core/types/doc/document.py
@@ -3,6 +3,7 @@
 import base64
 import copy
 import hashlib
+import itertools
 import json
 import logging
 import mimetypes
@@ -68,6 +69,7 @@ from docling_core.types.doc.common.constants import (
     CURRENT_VERSION,
     DEFAULT_EXPORT_LABELS,
     DOCUMENT_TOKENS_EXPORT_LABELS,
+    INLINE_WHITESPACE_CONTRACT_VERSION,
 )
 from docling_core.types.doc.common.content_layer import DEFAULT_CONTENT_LAYERS, ContentLayer
 from docling_core.types.doc.common.formatting import Formatting, Script
@@ -169,6 +171,34 @@ from docling_core.utils.settings import settings
 
 
 _logger = logging.getLogger(__name__)
+
+_warned_legacy_inline_separators = False
+
+
+def _predates_inline_whitespace_contract(version: str) -> bool:
+    """Return True when ``version`` is older than the inline whitespace contract."""
+    doc = re.match(VERSION_PATTERN, version)
+    contract = re.match(VERSION_PATTERN, INLINE_WHITESPACE_CONTRACT_VERSION)
+    if doc is None or contract is None:
+        return False
+    return (int(doc["major"]), int(doc["minor"])) < (int(contract["major"]), int(contract["minor"]))
+
+
+def _warn_legacy_inline_separators(version: str) -> None:
+    """Warn once per process that legacy inline separators were injected on load."""
+    global _warned_legacy_inline_separators
+    if _warned_legacy_inline_separators:
+        return
+    _warned_legacy_inline_separators = True
+    warnings.warn(
+        f"Document uses schema version {version}, predating the inline whitespace contract "
+        f"({INLINE_WHITESPACE_CONTRACT_VERSION}). Legacy inline separators were injected to "
+        "preserve the previous rendering; re-convert the source for faithful whitespace. "
+        "Note that inline text differs from a fresh conversion, which affects chunking and "
+        "any persisted embeddings.",
+        UserWarning,
+        stacklevel=2,
+    )
 
 
 class DoclingDocument(BaseModel):
@@ -1376,7 +1406,15 @@ class DoclingDocument(BaseModel):
         parent: Optional[NodeItem] = None,
         content_layer: Optional[ContentLayer] = None,
     ) -> InlineGroup:
-        """add_inline_group."""
+        """Add an inline group, whose children are runs of one visual line of text.
+
+        Whitespace contract: each run carries its own significant whitespace and serializers
+        concatenate the runs faithfully, with no separator of their own. A producer that omits
+        the boundary whitespace gets merged words (``["H", "2", "O"]`` renders as ``H2O``), so
+        put the boundary in the run text: ``["Advanced Topics", " in ", "Machine Learning"]``.
+        Whitespace at the edge of a formatted run is fine -- the serializers move it outside the
+        emphasis markers and hyperlink.
+        """
         _parent = parent or self.body
         cref = f"#/groups/{len(self.groups)}"
         group = InlineGroup(self_ref=cref, parent=_parent.get_ref())
@@ -5189,6 +5227,99 @@ class DoclingDocument(BaseModel):
 
         images = visualizer_obj.get_visualization(doc=self)
         return images
+
+    @model_validator(mode="before")
+    @classmethod
+    def _migrate_legacy_inline_separators(cls, data: Any) -> Any:
+        """Reproduce the legacy inline separator for documents written before the contract.
+
+        Serializers used to join inline runs with a hard ``" "``, so producers of that era did
+        not put boundary whitespace in the run text. Now that the join is faithful, those saved
+        documents would render ``Normalitalicbold``. Re-inject one separator at each boundary
+        the old serializer inserted, preserving the previous *visible* output -- including its
+        extra-space bugs (``["H", "2", "O"]`` stays ``H 2 O``).
+
+        This is compatibility normalization, not semantic repair: the old document does not
+        contain enough information to recover the real whitespace. It must run in ``mode="before"``
+        because ``check_version_is_compatible`` rewrites ``version`` to ``CURRENT_VERSION`` and
+        destroys the evidence. Versionless input is left alone rather than guessed at.
+        """
+        if not isinstance(data, dict):
+            return data
+        raw_version = data.get("version")
+        if not isinstance(raw_version, str) or not _predates_inline_whitespace_contract(raw_version):
+            return data
+
+        # Work on a copy: the caller owns the dict it passed in, and mutating it in place would
+        # make a second `model_validate` of the same value migrate again, compounding separators.
+        data = copy.deepcopy(data)
+        texts = data.get("texts")
+        groups = data.get("groups")
+        if not isinstance(texts, list) or not isinstance(groups, list):
+            return data
+
+        def resolve_run(child: Any) -> Optional[dict]:
+            """Return the text item dict for an inline run reference, else None."""
+            if not isinstance(child, dict):
+                return None
+            ref = child.get("$ref") or child.get("cref")
+            if not isinstance(ref, str) or not ref.startswith("#/texts/"):
+                return None
+            try:
+                item = texts[int(ref.removeprefix("#/texts/"))]
+            except (ValueError, IndexError):
+                return None
+            return item if isinstance(item, dict) and isinstance(item.get("text"), str) else None
+
+        # Code and formula runs are wrapped in delimiters (`` ` ``, ``$``) by the serializers, so a
+        # separator appended to their text would land *inside* the delimiter -- the same defect as
+        # `**bold **`. Put it on the neighbouring plain run instead.
+        delimited = {DocItemLabel.CODE.value, DocItemLabel.FORMULA.value}
+
+        migrated = False
+        for group in groups:
+            if not isinstance(group, dict) or group.get("label") != GroupLabel.INLINE.value:
+                continue
+            children = group.get("children")
+            if not isinstance(children, list):
+                continue
+            # ponytail: only `#/texts/N` children are treated as runs. A picture or table inside
+            # an inline group also received a separator, but whether it serialized to non-empty
+            # text is not knowable from the raw dict. Widen this if such a document shows up.
+            runs = [(idx, run) for idx, child in enumerate(children) if (run := resolve_run(child)) and run["text"]]
+            # Boundaries where the separator fits in neither neighbour; filled in afterwards so
+            # the indices collected here stay valid.
+            standalone: list[int] = []
+            for (_, run), (nxt_idx, nxt) in itertools.pairwise(runs):
+                if run.get("label") not in delimited:
+                    run["text"] += " "
+                elif nxt.get("label") not in delimited:
+                    nxt["text"] = " " + nxt["text"]
+                else:
+                    # Both sides are delimited: the separator would corrupt `` `a``b` `` or
+                    # ``$a$$b$``, so it becomes a plain run of its own between them.
+                    standalone.append(nxt_idx)
+                migrated = True
+
+            for shift, insert_at in enumerate(standalone):
+                ref = f"#/texts/{len(texts)}"
+                texts.append(
+                    {
+                        "self_ref": ref,
+                        "parent": {"$ref": group.get("self_ref")},
+                        "label": DocItemLabel.TEXT.value,
+                        "prov": [],
+                        "orig": " ",
+                        "text": " ",
+                        "children": [],
+                        "content_layer": group.get("content_layer", ContentLayer.BODY.value),
+                    }
+                )
+                children.insert(insert_at + shift, {"$ref": ref})
+
+        if migrated:
+            _warn_legacy_inline_separators(raw_version)
+        return data
 
     @field_validator("version")
     @classmethod

--- a/docling_core/types/doc/document.py
+++ b/docling_core/types/doc/document.py
@@ -3,6 +3,7 @@
 import base64
 import copy
 import hashlib
+import itertools
 import json
 import logging
 import mimetypes
@@ -68,6 +69,7 @@ from docling_core.types.doc.common.constants import (
     CURRENT_VERSION,
     DEFAULT_EXPORT_LABELS,
     DOCUMENT_TOKENS_EXPORT_LABELS,
+    INLINE_WHITESPACE_CONTRACT_VERSION,
 )
 from docling_core.types.doc.common.content_layer import DEFAULT_CONTENT_LAYERS, ContentLayer
 from docling_core.types.doc.common.formatting import Formatting, Script
@@ -169,6 +171,34 @@ from docling_core.utils.settings import settings
 
 
 _logger = logging.getLogger(__name__)
+
+_warned_legacy_inline_separators = False
+
+
+def _predates_inline_whitespace_contract(version: str) -> bool:
+    """Return True when ``version`` is older than the inline whitespace contract."""
+    doc = re.match(VERSION_PATTERN, version)
+    contract = re.match(VERSION_PATTERN, INLINE_WHITESPACE_CONTRACT_VERSION)
+    if doc is None or contract is None:
+        return False
+    return (int(doc["major"]), int(doc["minor"])) < (int(contract["major"]), int(contract["minor"]))
+
+
+def _warn_legacy_inline_separators(version: str) -> None:
+    """Warn once per process that legacy inline separators were injected on load."""
+    global _warned_legacy_inline_separators
+    if _warned_legacy_inline_separators:
+        return
+    _warned_legacy_inline_separators = True
+    warnings.warn(
+        f"Document uses schema version {version}, predating the inline whitespace contract "
+        f"({INLINE_WHITESPACE_CONTRACT_VERSION}). Legacy inline separators were injected to "
+        "preserve the previous rendering; re-convert the source for faithful whitespace. "
+        "Note that inline text differs from a fresh conversion, which affects chunking and "
+        "any persisted embeddings.",
+        UserWarning,
+        stacklevel=2,
+    )
 
 
 class DoclingDocument(BaseModel):
@@ -1376,7 +1406,15 @@ class DoclingDocument(BaseModel):
         parent: Optional[NodeItem] = None,
         content_layer: Optional[ContentLayer] = None,
     ) -> InlineGroup:
-        """add_inline_group."""
+        """Add an inline group, whose children are runs of one visual line of text.
+
+        Whitespace contract: each run carries its own significant whitespace and serializers
+        concatenate the runs faithfully, with no separator of their own. A producer that omits
+        the boundary whitespace gets merged words (``["H", "2", "O"]`` renders as ``H2O``), so
+        put the boundary in the run text: ``["Advanced Topics", " in ", "Machine Learning"]``.
+        Whitespace at the edge of a formatted run is fine -- the serializers move it outside the
+        emphasis markers and hyperlink.
+        """
         _parent = parent or self.body
         cref = f"#/groups/{len(self.groups)}"
         group = InlineGroup(self_ref=cref, parent=_parent.get_ref())
@@ -5119,6 +5157,99 @@ class DoclingDocument(BaseModel):
 
         images = visualizer_obj.get_visualization(doc=self)
         return images
+
+    @model_validator(mode="before")
+    @classmethod
+    def _migrate_legacy_inline_separators(cls, data: Any) -> Any:
+        """Reproduce the legacy inline separator for documents written before the contract.
+
+        Serializers used to join inline runs with a hard ``" "``, so producers of that era did
+        not put boundary whitespace in the run text. Now that the join is faithful, those saved
+        documents would render ``Normalitalicbold``. Re-inject one separator at each boundary
+        the old serializer inserted, preserving the previous *visible* output -- including its
+        extra-space bugs (``["H", "2", "O"]`` stays ``H 2 O``).
+
+        This is compatibility normalization, not semantic repair: the old document does not
+        contain enough information to recover the real whitespace. It must run in ``mode="before"``
+        because ``check_version_is_compatible`` rewrites ``version`` to ``CURRENT_VERSION`` and
+        destroys the evidence. Versionless input is left alone rather than guessed at.
+        """
+        if not isinstance(data, dict):
+            return data
+        raw_version = data.get("version")
+        if not isinstance(raw_version, str) or not _predates_inline_whitespace_contract(raw_version):
+            return data
+
+        # Work on a copy: the caller owns the dict it passed in, and mutating it in place would
+        # make a second `model_validate` of the same value migrate again, compounding separators.
+        data = copy.deepcopy(data)
+        texts = data.get("texts")
+        groups = data.get("groups")
+        if not isinstance(texts, list) or not isinstance(groups, list):
+            return data
+
+        def resolve_run(child: Any) -> Optional[dict]:
+            """Return the text item dict for an inline run reference, else None."""
+            if not isinstance(child, dict):
+                return None
+            ref = child.get("$ref") or child.get("cref")
+            if not isinstance(ref, str) or not ref.startswith("#/texts/"):
+                return None
+            try:
+                item = texts[int(ref.removeprefix("#/texts/"))]
+            except (ValueError, IndexError):
+                return None
+            return item if isinstance(item, dict) and isinstance(item.get("text"), str) else None
+
+        # Code and formula runs are wrapped in delimiters (`` ` ``, ``$``) by the serializers, so a
+        # separator appended to their text would land *inside* the delimiter -- the same defect as
+        # `**bold **`. Put it on the neighbouring plain run instead.
+        delimited = {DocItemLabel.CODE.value, DocItemLabel.FORMULA.value}
+
+        migrated = False
+        for group in groups:
+            if not isinstance(group, dict) or group.get("label") != GroupLabel.INLINE.value:
+                continue
+            children = group.get("children")
+            if not isinstance(children, list):
+                continue
+            # ponytail: only `#/texts/N` children are treated as runs. A picture or table inside
+            # an inline group also received a separator, but whether it serialized to non-empty
+            # text is not knowable from the raw dict. Widen this if such a document shows up.
+            runs = [(idx, run) for idx, child in enumerate(children) if (run := resolve_run(child)) and run["text"]]
+            # Boundaries where the separator fits in neither neighbour; filled in afterwards so
+            # the indices collected here stay valid.
+            standalone: list[int] = []
+            for (_, run), (nxt_idx, nxt) in itertools.pairwise(runs):
+                if run.get("label") not in delimited:
+                    run["text"] += " "
+                elif nxt.get("label") not in delimited:
+                    nxt["text"] = " " + nxt["text"]
+                else:
+                    # Both sides are delimited: the separator would corrupt `` `a``b` `` or
+                    # ``$a$$b$``, so it becomes a plain run of its own between them.
+                    standalone.append(nxt_idx)
+                migrated = True
+
+            for shift, insert_at in enumerate(standalone):
+                ref = f"#/texts/{len(texts)}"
+                texts.append(
+                    {
+                        "self_ref": ref,
+                        "parent": {"$ref": group.get("self_ref")},
+                        "label": DocItemLabel.TEXT.value,
+                        "prov": [],
+                        "orig": " ",
+                        "text": " ",
+                        "children": [],
+                        "content_layer": group.get("content_layer", ContentLayer.BODY.value),
+                    }
+                )
+                children.insert(insert_at + shift, {"$ref": ref})
+
+        if migrated:
+            _warn_legacy_inline_separators(raw_version)
+        return data
 
     @field_validator("version")
     @classmethod

--- a/docs/DoclingDocument.json
+++ b/docs/DoclingDocument.json
@@ -4494,7 +4494,7 @@
       "type": "string"
     },
     "version": {
-      "default": "1.10.0",
+      "default": "1.11.0",
       "pattern": "^(?P<major>0|[1-9]\\d*)\\.(?P<minor>0|[1-9]\\d*)\\.(?P<patch>0|[1-9]\\d*)(?:-(?P<prerelease>(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$",
       "title": "Version",
       "type": "string"

--- a/docs/schemas/DoclingDocument_1_11.json
+++ b/docs/schemas/DoclingDocument_1_11.json
@@ -1,0 +1,4655 @@
+{
+  "$defs": {
+    "BaseMeta": {
+      "additionalProperties": true,
+      "description": "Base class for metadata.",
+      "properties": {
+        "summary": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SummaryMetaField"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "A condensed natural-language summary of the content rooted at this node.",
+          "examples": [
+            {
+              "text": "A short company/location statement."
+            }
+          ]
+        },
+        "language": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/LanguageMetaField"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The detected human language of the node content, expressed as a BCP 47 code.",
+          "examples": [
+            {
+              "code": "en"
+            }
+          ]
+        },
+        "entities": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/EntitiesMetaField"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Named entities extracted from the node text (persons, organisations, locations, etc.). Each mention carries the entity text, an optional type label, and an optional character span.",
+          "examples": [
+            {
+              "mentions": [
+                {
+                  "charspan": [
+                    0,
+                    3
+                  ],
+                  "label": "ORG",
+                  "text": "IBM"
+                }
+              ]
+            }
+          ]
+        },
+        "keywords": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/KeywordsMetaField"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Salient terms or short keyphrases that characterise the node content. Keywords are more specific than topics and typically correspond to individual words or short multi-word expressions found in or closely related to the text. Values are order-preserving and deduplicated.",
+          "examples": [
+            {
+              "values": [
+                "transformer",
+                "attention mechanism",
+                "BERT"
+              ]
+            }
+          ]
+        },
+        "topics": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TopicsMetaField"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Higher-level subject categories or thematic labels inferred for the node content. Topics are broader than keywords and describe the domain or theme rather than specific terms (e.g., 'machine learning' rather than 'gradient descent'). Values are order-preserving and deduplicated.",
+          "examples": [
+            {
+              "values": [
+                "natural language processing",
+                "computer vision"
+              ]
+            }
+          ]
+        }
+      },
+      "title": "BaseMeta",
+      "type": "object"
+    },
+    "BoundingBox": {
+      "description": "BoundingBox.",
+      "properties": {
+        "l": {
+          "title": "L",
+          "type": "number"
+        },
+        "t": {
+          "title": "T",
+          "type": "number"
+        },
+        "r": {
+          "title": "R",
+          "type": "number"
+        },
+        "b": {
+          "title": "B",
+          "type": "number"
+        },
+        "coord_origin": {
+          "$ref": "#/$defs/CoordOrigin",
+          "default": "TOPLEFT"
+        }
+      },
+      "required": [
+        "l",
+        "t",
+        "r",
+        "b"
+      ],
+      "title": "BoundingBox",
+      "type": "object"
+    },
+    "ChartBar": {
+      "description": "Represents a bar in a bar chart.\n\nAttributes:\n    label (str): The label for the bar.\n    values (float): The value associated with the bar.",
+      "properties": {
+        "label": {
+          "title": "Label",
+          "type": "string"
+        },
+        "values": {
+          "title": "Values",
+          "type": "number"
+        }
+      },
+      "required": [
+        "label",
+        "values"
+      ],
+      "title": "ChartBar",
+      "type": "object"
+    },
+    "ChartLine": {
+      "description": "Represents a line in a line chart.\n\nAttributes:\n    label (str): The label for the line.\n    values (list[tuple[float, float]]): A list of (x, y) coordinate pairs\n        representing the line's data points.",
+      "properties": {
+        "label": {
+          "title": "Label",
+          "type": "string"
+        },
+        "values": {
+          "items": {
+            "maxItems": 2,
+            "minItems": 2,
+            "prefixItems": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "number"
+              }
+            ],
+            "type": "array"
+          },
+          "title": "Values",
+          "type": "array"
+        }
+      },
+      "required": [
+        "label",
+        "values"
+      ],
+      "title": "ChartLine",
+      "type": "object"
+    },
+    "ChartPoint": {
+      "description": "Represents a point in a scatter chart.\n\nAttributes:\n    value (Tuple[float, float]): A (x, y) coordinate pair representing a point in a\n        chart.",
+      "properties": {
+        "value": {
+          "maxItems": 2,
+          "minItems": 2,
+          "prefixItems": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "number"
+            }
+          ],
+          "title": "Value",
+          "type": "array"
+        }
+      },
+      "required": [
+        "value"
+      ],
+      "title": "ChartPoint",
+      "type": "object"
+    },
+    "ChartSlice": {
+      "description": "Represents a slice in a pie chart.\n\nAttributes:\n    label (str): The label for the slice.\n    value (float): The value represented by the slice.",
+      "properties": {
+        "label": {
+          "title": "Label",
+          "type": "string"
+        },
+        "value": {
+          "title": "Value",
+          "type": "number"
+        }
+      },
+      "required": [
+        "label",
+        "value"
+      ],
+      "title": "ChartSlice",
+      "type": "object"
+    },
+    "ChartStackedBar": {
+      "description": "Represents a stacked bar in a stacked bar chart.\n\nAttributes:\n    label (list[str]): The labels for the stacked bars. Multiple values are stored\n        in cases where the chart is \"double stacked,\" meaning bars are stacked both\n        horizontally and vertically.\n    values (list[tuple[str, int]]): A list of values representing different segments\n        of the stacked bar along with their label.",
+      "properties": {
+        "label": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Label",
+          "type": "array"
+        },
+        "values": {
+          "items": {
+            "maxItems": 2,
+            "minItems": 2,
+            "prefixItems": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "integer"
+              }
+            ],
+            "type": "array"
+          },
+          "title": "Values",
+          "type": "array"
+        }
+      },
+      "required": [
+        "label",
+        "values"
+      ],
+      "title": "ChartStackedBar",
+      "type": "object"
+    },
+    "CodeItem": {
+      "additionalProperties": false,
+      "description": "CodeItem.",
+      "properties": {
+        "self_ref": {
+          "pattern": "^#(?:/([\\w-]+)(?:/(\\d+))?)?$",
+          "title": "Self Ref",
+          "type": "string"
+        },
+        "parent": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RefItem"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "children": {
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/RefItem"
+          },
+          "title": "Children",
+          "type": "array"
+        },
+        "content_layer": {
+          "$ref": "#/$defs/ContentLayer",
+          "default": "body"
+        },
+        "meta": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/FloatingMeta"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "label": {
+          "const": "code",
+          "default": "code",
+          "title": "Label",
+          "type": "string"
+        },
+        "prov": {
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/ProvenanceItem"
+          },
+          "title": "Prov",
+          "type": "array"
+        },
+        "source": {
+          "default": [],
+          "description": "The provenance of this document item. Currently, it is only used for media track provenance.",
+          "items": {
+            "discriminator": {
+              "mapping": {
+                "track": "#/$defs/TrackSource"
+              },
+              "propertyName": "kind"
+            },
+            "oneOf": [
+              {
+                "$ref": "#/$defs/TrackSource"
+              }
+            ]
+          },
+          "title": "Source",
+          "type": "array"
+        },
+        "comments": {
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/FineRef"
+          },
+          "title": "Comments",
+          "type": "array"
+        },
+        "orig": {
+          "title": "Orig",
+          "type": "string"
+        },
+        "text": {
+          "title": "Text",
+          "type": "string"
+        },
+        "formatting": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Formatting"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "hyperlink": {
+          "anyOf": [
+            {
+              "format": "uri",
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "format": "path",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Hyperlink"
+        },
+        "captions": {
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/RefItem"
+          },
+          "title": "Captions",
+          "type": "array"
+        },
+        "references": {
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/RefItem"
+          },
+          "title": "References",
+          "type": "array"
+        },
+        "footnotes": {
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/RefItem"
+          },
+          "title": "Footnotes",
+          "type": "array"
+        },
+        "image": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ImageRef"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "code_language": {
+          "$ref": "#/$defs/CodeLanguageLabel",
+          "default": "unknown"
+        }
+      },
+      "required": [
+        "self_ref",
+        "orig",
+        "text"
+      ],
+      "title": "CodeItem",
+      "type": "object"
+    },
+    "CodeLanguageLabel": {
+      "description": "CodeLanguageLabel.",
+      "enum": [
+        "Ada",
+        "Awk",
+        "Bash",
+        "bc",
+        "C",
+        "C#",
+        "C++",
+        "CMake",
+        "COBOL",
+        "CSS",
+        "Ceylon",
+        "Clojure",
+        "Crystal",
+        "Cuda",
+        "Cython",
+        "D",
+        "Dart",
+        "dc",
+        "Dockerfile",
+        "DocLang",
+        "Elixir",
+        "Erlang",
+        "FORTRAN",
+        "Forth",
+        "Go",
+        "HTML",
+        "Haskell",
+        "Haxe",
+        "Java",
+        "JavaScript",
+        "JSON",
+        "Julia",
+        "Kotlin",
+        "Latex",
+        "Lisp",
+        "Lua",
+        "Matlab",
+        "MoonScript",
+        "Nim",
+        "OCaml",
+        "ObjectiveC",
+        "Octave",
+        "PHP",
+        "Pascal",
+        "Perl",
+        "Prolog",
+        "Python",
+        "Racket",
+        "Ruby",
+        "Rust",
+        "SML",
+        "SQL",
+        "Scala",
+        "Scheme",
+        "Swift",
+        "Tikz",
+        "TypeScript",
+        "unknown",
+        "VisualBasic",
+        "XML",
+        "YAML"
+      ],
+      "title": "CodeLanguageLabel",
+      "type": "string"
+    },
+    "CodeMetaField": {
+      "additionalProperties": true,
+      "description": "Code representation for the respective item.",
+      "properties": {
+        "confidence": {
+          "anyOf": [
+            {
+              "maximum": 1,
+              "minimum": 0,
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The confidence of the prediction.",
+          "examples": [
+            0.9,
+            0.42
+          ],
+          "title": "Confidence"
+        },
+        "created_by": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The origin of the prediction.",
+          "examples": [
+            "ibm-granite/granite-docling-258M"
+          ],
+          "title": "Created By"
+        },
+        "text": {
+          "title": "Text",
+          "type": "string"
+        },
+        "language": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/CodeLanguageLabel"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        }
+      },
+      "required": [
+        "text"
+      ],
+      "title": "CodeMetaField",
+      "type": "object"
+    },
+    "ContentLayer": {
+      "description": "ContentLayer.",
+      "enum": [
+        "body",
+        "furniture",
+        "background",
+        "invisible",
+        "notes"
+      ],
+      "title": "ContentLayer",
+      "type": "string"
+    },
+    "CoordOrigin": {
+      "description": "CoordOrigin.",
+      "enum": [
+        "TOPLEFT",
+        "BOTTOMLEFT"
+      ],
+      "title": "CoordOrigin",
+      "type": "string"
+    },
+    "DescriptionAnnotation": {
+      "description": "DescriptionAnnotation.",
+      "properties": {
+        "kind": {
+          "const": "description",
+          "default": "description",
+          "title": "Kind",
+          "type": "string"
+        },
+        "text": {
+          "title": "Text",
+          "type": "string"
+        },
+        "provenance": {
+          "title": "Provenance",
+          "type": "string"
+        }
+      },
+      "required": [
+        "text",
+        "provenance"
+      ],
+      "title": "DescriptionAnnotation",
+      "type": "object"
+    },
+    "DescriptionMetaField": {
+      "additionalProperties": true,
+      "description": "Description metadata field.",
+      "properties": {
+        "confidence": {
+          "anyOf": [
+            {
+              "maximum": 1,
+              "minimum": 0,
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The confidence of the prediction.",
+          "examples": [
+            0.9,
+            0.42
+          ],
+          "title": "Confidence"
+        },
+        "created_by": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The origin of the prediction.",
+          "examples": [
+            "ibm-granite/granite-docling-258M"
+          ],
+          "title": "Created By"
+        },
+        "text": {
+          "title": "Text",
+          "type": "string"
+        }
+      },
+      "required": [
+        "text"
+      ],
+      "title": "DescriptionMetaField",
+      "type": "object"
+    },
+    "DocumentOrigin": {
+      "description": "FileSource.",
+      "properties": {
+        "mimetype": {
+          "title": "Mimetype",
+          "type": "string"
+        },
+        "binary_hash": {
+          "maximum": 18446744073709551615,
+          "minimum": 0,
+          "title": "Binary Hash",
+          "type": "integer"
+        },
+        "filename": {
+          "title": "Filename",
+          "type": "string"
+        },
+        "uri": {
+          "anyOf": [
+            {
+              "format": "uri",
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Uri"
+        }
+      },
+      "required": [
+        "mimetype",
+        "binary_hash",
+        "filename"
+      ],
+      "title": "DocumentOrigin",
+      "type": "object"
+    },
+    "EntitiesMetaField": {
+      "additionalProperties": true,
+      "description": "Container for extracted entity mentions.",
+      "properties": {
+        "mentions": {
+          "items": {
+            "$ref": "#/$defs/EntityMention"
+          },
+          "minItems": 1,
+          "title": "Mentions",
+          "type": "array"
+        }
+      },
+      "required": [
+        "mentions"
+      ],
+      "title": "EntitiesMetaField",
+      "type": "object"
+    },
+    "EntityMention": {
+      "additionalProperties": true,
+      "description": "Entity mention extracted from text.",
+      "properties": {
+        "confidence": {
+          "anyOf": [
+            {
+              "maximum": 1,
+              "minimum": 0,
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The confidence of the prediction.",
+          "examples": [
+            0.9,
+            0.42
+          ],
+          "title": "Confidence"
+        },
+        "created_by": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The origin of the prediction.",
+          "examples": [
+            "ibm-granite/granite-docling-258M"
+          ],
+          "title": "Created By"
+        },
+        "text": {
+          "description": "Normalized text of the entity mention.",
+          "title": "Text",
+          "type": "string"
+        },
+        "orig": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Exact source text extracted from the original charspan, analogous to TextItem.orig. This may differ from 'text' when the mention has been normalized.",
+          "title": "Orig"
+        },
+        "label": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Entity type or category.",
+          "title": "Label"
+        },
+        "charspan": {
+          "anyOf": [
+            {
+              "description": "Character span (0-indexed)",
+              "maxItems": 2,
+              "minItems": 2,
+              "prefixItems": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "integer"
+                }
+              ],
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Character span (0-indexed) of the entity mention in the source text.",
+          "title": "Charspan"
+        }
+      },
+      "required": [
+        "text"
+      ],
+      "title": "EntityMention",
+      "type": "object"
+    },
+    "FieldHeadingItem": {
+      "additionalProperties": false,
+      "properties": {
+        "self_ref": {
+          "pattern": "^#(?:/([\\w-]+)(?:/(\\d+))?)?$",
+          "title": "Self Ref",
+          "type": "string"
+        },
+        "parent": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RefItem"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "children": {
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/RefItem"
+          },
+          "title": "Children",
+          "type": "array"
+        },
+        "content_layer": {
+          "$ref": "#/$defs/ContentLayer",
+          "default": "body"
+        },
+        "meta": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/BaseMeta"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "label": {
+          "const": "field_heading",
+          "default": "field_heading",
+          "title": "Label",
+          "type": "string"
+        },
+        "prov": {
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/ProvenanceItem"
+          },
+          "title": "Prov",
+          "type": "array"
+        },
+        "source": {
+          "default": [],
+          "description": "The provenance of this document item. Currently, it is only used for media track provenance.",
+          "items": {
+            "discriminator": {
+              "mapping": {
+                "track": "#/$defs/TrackSource"
+              },
+              "propertyName": "kind"
+            },
+            "oneOf": [
+              {
+                "$ref": "#/$defs/TrackSource"
+              }
+            ]
+          },
+          "title": "Source",
+          "type": "array"
+        },
+        "comments": {
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/FineRef"
+          },
+          "title": "Comments",
+          "type": "array"
+        },
+        "orig": {
+          "title": "Orig",
+          "type": "string"
+        },
+        "text": {
+          "title": "Text",
+          "type": "string"
+        },
+        "formatting": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Formatting"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "hyperlink": {
+          "anyOf": [
+            {
+              "format": "uri",
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "format": "path",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Hyperlink"
+        },
+        "level": {
+          "default": 1,
+          "maximum": 100,
+          "minimum": 1,
+          "title": "Level",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "self_ref",
+        "orig",
+        "text"
+      ],
+      "title": "FieldHeadingItem",
+      "type": "object"
+    },
+    "FieldItem": {
+      "additionalProperties": false,
+      "properties": {
+        "self_ref": {
+          "pattern": "^#(?:/([\\w-]+)(?:/(\\d+))?)?$",
+          "title": "Self Ref",
+          "type": "string"
+        },
+        "parent": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RefItem"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "children": {
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/RefItem"
+          },
+          "title": "Children",
+          "type": "array"
+        },
+        "content_layer": {
+          "$ref": "#/$defs/ContentLayer",
+          "default": "body"
+        },
+        "meta": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/BaseMeta"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "label": {
+          "const": "field_item",
+          "default": "field_item",
+          "title": "Label",
+          "type": "string"
+        },
+        "prov": {
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/ProvenanceItem"
+          },
+          "title": "Prov",
+          "type": "array"
+        },
+        "source": {
+          "default": [],
+          "description": "The provenance of this document item. Currently, it is only used for media track provenance.",
+          "items": {
+            "discriminator": {
+              "mapping": {
+                "track": "#/$defs/TrackSource"
+              },
+              "propertyName": "kind"
+            },
+            "oneOf": [
+              {
+                "$ref": "#/$defs/TrackSource"
+              }
+            ]
+          },
+          "title": "Source",
+          "type": "array"
+        },
+        "comments": {
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/FineRef"
+          },
+          "title": "Comments",
+          "type": "array"
+        }
+      },
+      "required": [
+        "self_ref"
+      ],
+      "title": "FieldItem",
+      "type": "object"
+    },
+    "FieldRegionItem": {
+      "additionalProperties": false,
+      "properties": {
+        "self_ref": {
+          "pattern": "^#(?:/([\\w-]+)(?:/(\\d+))?)?$",
+          "title": "Self Ref",
+          "type": "string"
+        },
+        "parent": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RefItem"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "children": {
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/RefItem"
+          },
+          "title": "Children",
+          "type": "array"
+        },
+        "content_layer": {
+          "$ref": "#/$defs/ContentLayer",
+          "default": "body"
+        },
+        "meta": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/BaseMeta"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "label": {
+          "const": "field_region",
+          "default": "field_region",
+          "title": "Label",
+          "type": "string"
+        },
+        "prov": {
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/ProvenanceItem"
+          },
+          "title": "Prov",
+          "type": "array"
+        },
+        "source": {
+          "default": [],
+          "description": "The provenance of this document item. Currently, it is only used for media track provenance.",
+          "items": {
+            "discriminator": {
+              "mapping": {
+                "track": "#/$defs/TrackSource"
+              },
+              "propertyName": "kind"
+            },
+            "oneOf": [
+              {
+                "$ref": "#/$defs/TrackSource"
+              }
+            ]
+          },
+          "title": "Source",
+          "type": "array"
+        },
+        "comments": {
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/FineRef"
+          },
+          "title": "Comments",
+          "type": "array"
+        }
+      },
+      "required": [
+        "self_ref"
+      ],
+      "title": "FieldRegionItem",
+      "type": "object"
+    },
+    "FieldValueItem": {
+      "additionalProperties": false,
+      "properties": {
+        "self_ref": {
+          "pattern": "^#(?:/([\\w-]+)(?:/(\\d+))?)?$",
+          "title": "Self Ref",
+          "type": "string"
+        },
+        "parent": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RefItem"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "children": {
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/RefItem"
+          },
+          "title": "Children",
+          "type": "array"
+        },
+        "content_layer": {
+          "$ref": "#/$defs/ContentLayer",
+          "default": "body"
+        },
+        "meta": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/BaseMeta"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "label": {
+          "const": "field_value",
+          "default": "field_value",
+          "title": "Label",
+          "type": "string"
+        },
+        "prov": {
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/ProvenanceItem"
+          },
+          "title": "Prov",
+          "type": "array"
+        },
+        "source": {
+          "default": [],
+          "description": "The provenance of this document item. Currently, it is only used for media track provenance.",
+          "items": {
+            "discriminator": {
+              "mapping": {
+                "track": "#/$defs/TrackSource"
+              },
+              "propertyName": "kind"
+            },
+            "oneOf": [
+              {
+                "$ref": "#/$defs/TrackSource"
+              }
+            ]
+          },
+          "title": "Source",
+          "type": "array"
+        },
+        "comments": {
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/FineRef"
+          },
+          "title": "Comments",
+          "type": "array"
+        },
+        "orig": {
+          "title": "Orig",
+          "type": "string"
+        },
+        "text": {
+          "title": "Text",
+          "type": "string"
+        },
+        "formatting": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Formatting"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "hyperlink": {
+          "anyOf": [
+            {
+              "format": "uri",
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "format": "path",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Hyperlink"
+        },
+        "kind": {
+          "default": "read_only",
+          "enum": [
+            "read_only",
+            "fillable"
+          ],
+          "title": "Kind",
+          "type": "string"
+        }
+      },
+      "required": [
+        "self_ref",
+        "orig",
+        "text"
+      ],
+      "title": "FieldValueItem",
+      "type": "object"
+    },
+    "FineRef": {
+      "description": "Fine-granular reference item that can capture span range info.",
+      "properties": {
+        "$ref": {
+          "pattern": "^#(?:/([\\w-]+)(?:/(\\d+))?)?$",
+          "title": "$Ref",
+          "type": "string"
+        },
+        "range": {
+          "anyOf": [
+            {
+              "maxItems": 2,
+              "minItems": 2,
+              "prefixItems": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "integer"
+                }
+              ],
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Range"
+        }
+      },
+      "required": [
+        "$ref"
+      ],
+      "title": "FineRef",
+      "type": "object"
+    },
+    "FloatingMeta": {
+      "additionalProperties": true,
+      "description": "Metadata model for floating.",
+      "properties": {
+        "summary": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SummaryMetaField"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "A condensed natural-language summary of the content rooted at this node.",
+          "examples": [
+            {
+              "text": "A short company/location statement."
+            }
+          ]
+        },
+        "language": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/LanguageMetaField"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The detected human language of the node content, expressed as a BCP 47 code.",
+          "examples": [
+            {
+              "code": "en"
+            }
+          ]
+        },
+        "entities": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/EntitiesMetaField"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Named entities extracted from the node text (persons, organisations, locations, etc.). Each mention carries the entity text, an optional type label, and an optional character span.",
+          "examples": [
+            {
+              "mentions": [
+                {
+                  "charspan": [
+                    0,
+                    3
+                  ],
+                  "label": "ORG",
+                  "text": "IBM"
+                }
+              ]
+            }
+          ]
+        },
+        "keywords": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/KeywordsMetaField"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Salient terms or short keyphrases that characterise the node content. Keywords are more specific than topics and typically correspond to individual words or short multi-word expressions found in or closely related to the text. Values are order-preserving and deduplicated.",
+          "examples": [
+            {
+              "values": [
+                "transformer",
+                "attention mechanism",
+                "BERT"
+              ]
+            }
+          ]
+        },
+        "topics": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TopicsMetaField"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Higher-level subject categories or thematic labels inferred for the node content. Topics are broader than keywords and describe the domain or theme rather than specific terms (e.g., 'machine learning' rather than 'gradient descent'). Values are order-preserving and deduplicated.",
+          "examples": [
+            {
+              "values": [
+                "natural language processing",
+                "computer vision"
+              ]
+            }
+          ]
+        },
+        "description": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DescriptionMetaField"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        }
+      },
+      "title": "FloatingMeta",
+      "type": "object"
+    },
+    "FormItem": {
+      "additionalProperties": false,
+      "description": "FormItem.",
+      "properties": {
+        "self_ref": {
+          "pattern": "^#(?:/([\\w-]+)(?:/(\\d+))?)?$",
+          "title": "Self Ref",
+          "type": "string"
+        },
+        "parent": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RefItem"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "children": {
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/RefItem"
+          },
+          "title": "Children",
+          "type": "array"
+        },
+        "content_layer": {
+          "$ref": "#/$defs/ContentLayer",
+          "default": "body"
+        },
+        "meta": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/FloatingMeta"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "label": {
+          "const": "form",
+          "default": "form",
+          "title": "Label",
+          "type": "string"
+        },
+        "prov": {
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/ProvenanceItem"
+          },
+          "title": "Prov",
+          "type": "array"
+        },
+        "source": {
+          "default": [],
+          "description": "The provenance of this document item. Currently, it is only used for media track provenance.",
+          "items": {
+            "discriminator": {
+              "mapping": {
+                "track": "#/$defs/TrackSource"
+              },
+              "propertyName": "kind"
+            },
+            "oneOf": [
+              {
+                "$ref": "#/$defs/TrackSource"
+              }
+            ]
+          },
+          "title": "Source",
+          "type": "array"
+        },
+        "comments": {
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/FineRef"
+          },
+          "title": "Comments",
+          "type": "array"
+        },
+        "captions": {
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/RefItem"
+          },
+          "title": "Captions",
+          "type": "array"
+        },
+        "references": {
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/RefItem"
+          },
+          "title": "References",
+          "type": "array"
+        },
+        "footnotes": {
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/RefItem"
+          },
+          "title": "Footnotes",
+          "type": "array"
+        },
+        "image": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ImageRef"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "graph": {
+          "$ref": "#/$defs/GraphData"
+        }
+      },
+      "required": [
+        "self_ref",
+        "graph"
+      ],
+      "title": "FormItem",
+      "type": "object"
+    },
+    "Formatting": {
+      "description": "Formatting.",
+      "properties": {
+        "bold": {
+          "default": false,
+          "title": "Bold",
+          "type": "boolean"
+        },
+        "italic": {
+          "default": false,
+          "title": "Italic",
+          "type": "boolean"
+        },
+        "underline": {
+          "default": false,
+          "title": "Underline",
+          "type": "boolean"
+        },
+        "strikethrough": {
+          "default": false,
+          "title": "Strikethrough",
+          "type": "boolean"
+        },
+        "script": {
+          "$ref": "#/$defs/Script",
+          "default": "baseline"
+        }
+      },
+      "title": "Formatting",
+      "type": "object"
+    },
+    "FormulaItem": {
+      "additionalProperties": false,
+      "description": "FormulaItem.",
+      "properties": {
+        "self_ref": {
+          "pattern": "^#(?:/([\\w-]+)(?:/(\\d+))?)?$",
+          "title": "Self Ref",
+          "type": "string"
+        },
+        "parent": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RefItem"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "children": {
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/RefItem"
+          },
+          "title": "Children",
+          "type": "array"
+        },
+        "content_layer": {
+          "$ref": "#/$defs/ContentLayer",
+          "default": "body"
+        },
+        "meta": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/BaseMeta"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "label": {
+          "const": "formula",
+          "default": "formula",
+          "title": "Label",
+          "type": "string"
+        },
+        "prov": {
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/ProvenanceItem"
+          },
+          "title": "Prov",
+          "type": "array"
+        },
+        "source": {
+          "default": [],
+          "description": "The provenance of this document item. Currently, it is only used for media track provenance.",
+          "items": {
+            "discriminator": {
+              "mapping": {
+                "track": "#/$defs/TrackSource"
+              },
+              "propertyName": "kind"
+            },
+            "oneOf": [
+              {
+                "$ref": "#/$defs/TrackSource"
+              }
+            ]
+          },
+          "title": "Source",
+          "type": "array"
+        },
+        "comments": {
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/FineRef"
+          },
+          "title": "Comments",
+          "type": "array"
+        },
+        "orig": {
+          "title": "Orig",
+          "type": "string"
+        },
+        "text": {
+          "title": "Text",
+          "type": "string"
+        },
+        "formatting": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Formatting"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "hyperlink": {
+          "anyOf": [
+            {
+              "format": "uri",
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "format": "path",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Hyperlink"
+        }
+      },
+      "required": [
+        "self_ref",
+        "orig",
+        "text"
+      ],
+      "title": "FormulaItem",
+      "type": "object"
+    },
+    "GraphCell": {
+      "description": "GraphCell.",
+      "properties": {
+        "label": {
+          "$ref": "#/$defs/GraphCellLabel"
+        },
+        "cell_id": {
+          "title": "Cell Id",
+          "type": "integer"
+        },
+        "text": {
+          "title": "Text",
+          "type": "string"
+        },
+        "orig": {
+          "title": "Orig",
+          "type": "string"
+        },
+        "prov": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ProvenanceItem"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "item_ref": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RefItem"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        }
+      },
+      "required": [
+        "label",
+        "cell_id",
+        "text",
+        "orig"
+      ],
+      "title": "GraphCell",
+      "type": "object"
+    },
+    "GraphCellLabel": {
+      "description": "GraphCellLabel.",
+      "enum": [
+        "unspecified",
+        "key",
+        "value",
+        "checkbox"
+      ],
+      "title": "GraphCellLabel",
+      "type": "string"
+    },
+    "GraphData": {
+      "description": "GraphData.",
+      "properties": {
+        "cells": {
+          "items": {
+            "$ref": "#/$defs/GraphCell"
+          },
+          "title": "Cells",
+          "type": "array"
+        },
+        "links": {
+          "items": {
+            "$ref": "#/$defs/GraphLink"
+          },
+          "title": "Links",
+          "type": "array"
+        }
+      },
+      "title": "GraphData",
+      "type": "object"
+    },
+    "GraphLink": {
+      "description": "GraphLink.",
+      "properties": {
+        "label": {
+          "$ref": "#/$defs/GraphLinkLabel"
+        },
+        "source_cell_id": {
+          "title": "Source Cell Id",
+          "type": "integer"
+        },
+        "target_cell_id": {
+          "title": "Target Cell Id",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "label",
+        "source_cell_id",
+        "target_cell_id"
+      ],
+      "title": "GraphLink",
+      "type": "object"
+    },
+    "GraphLinkLabel": {
+      "description": "GraphLinkLabel.",
+      "enum": [
+        "unspecified",
+        "to_value",
+        "to_key",
+        "to_parent",
+        "to_child"
+      ],
+      "title": "GraphLinkLabel",
+      "type": "string"
+    },
+    "GroupItem": {
+      "additionalProperties": false,
+      "description": "GroupItem.",
+      "properties": {
+        "self_ref": {
+          "pattern": "^#(?:/([\\w-]+)(?:/(\\d+))?)?$",
+          "title": "Self Ref",
+          "type": "string"
+        },
+        "parent": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RefItem"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "children": {
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/RefItem"
+          },
+          "title": "Children",
+          "type": "array"
+        },
+        "content_layer": {
+          "$ref": "#/$defs/ContentLayer",
+          "default": "body"
+        },
+        "meta": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/BaseMeta"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "name": {
+          "default": "group",
+          "title": "Name",
+          "type": "string"
+        },
+        "label": {
+          "$ref": "#/$defs/GroupLabel",
+          "default": "unspecified"
+        }
+      },
+      "required": [
+        "self_ref"
+      ],
+      "title": "GroupItem",
+      "type": "object"
+    },
+    "GroupLabel": {
+      "description": "GroupLabel.",
+      "enum": [
+        "unspecified",
+        "list",
+        "ordered_list",
+        "chapter",
+        "section",
+        "sheet",
+        "slide",
+        "form_area",
+        "key_value_area",
+        "comment_section",
+        "inline",
+        "picture_area"
+      ],
+      "title": "GroupLabel",
+      "type": "string"
+    },
+    "HumanLanguageLabel": {
+      "description": "Two-letter human language primary subtags using BCP-47 values.",
+      "enum": [
+        "aa",
+        "ab",
+        "ae",
+        "af",
+        "ak",
+        "am",
+        "an",
+        "ar",
+        "as",
+        "av",
+        "ay",
+        "az",
+        "ba",
+        "be",
+        "bg",
+        "bh",
+        "bi",
+        "bm",
+        "bn",
+        "bo",
+        "br",
+        "bs",
+        "ca",
+        "ce",
+        "ch",
+        "co",
+        "cr",
+        "cs",
+        "cu",
+        "cv",
+        "cy",
+        "da",
+        "de",
+        "dv",
+        "dz",
+        "ee",
+        "el",
+        "en",
+        "eo",
+        "es",
+        "et",
+        "eu",
+        "fa",
+        "ff",
+        "fi",
+        "fj",
+        "fo",
+        "fr",
+        "fy",
+        "ga",
+        "gd",
+        "gl",
+        "gn",
+        "gu",
+        "gv",
+        "ha",
+        "he",
+        "hi",
+        "ho",
+        "hr",
+        "ht",
+        "hu",
+        "hy",
+        "hz",
+        "ia",
+        "id",
+        "ie",
+        "ig",
+        "ii",
+        "ik",
+        "io",
+        "is",
+        "it",
+        "iu",
+        "ja",
+        "jv",
+        "ka",
+        "kg",
+        "ki",
+        "kj",
+        "kk",
+        "kl",
+        "km",
+        "kn",
+        "ko",
+        "kr",
+        "ks",
+        "ku",
+        "kv",
+        "kw",
+        "ky",
+        "la",
+        "lb",
+        "lg",
+        "li",
+        "ln",
+        "lo",
+        "lt",
+        "lu",
+        "lv",
+        "mg",
+        "mh",
+        "mi",
+        "mk",
+        "ml",
+        "mn",
+        "mr",
+        "ms",
+        "mt",
+        "my",
+        "na",
+        "nb",
+        "nd",
+        "ne",
+        "ng",
+        "nl",
+        "nn",
+        "no",
+        "nr",
+        "nv",
+        "ny",
+        "oc",
+        "oj",
+        "om",
+        "or",
+        "os",
+        "pa",
+        "pi",
+        "pl",
+        "ps",
+        "pt",
+        "qu",
+        "rm",
+        "rn",
+        "ro",
+        "ru",
+        "rw",
+        "sa",
+        "sc",
+        "sd",
+        "se",
+        "sg",
+        "sh",
+        "si",
+        "sk",
+        "sl",
+        "sm",
+        "sn",
+        "so",
+        "sq",
+        "sr",
+        "ss",
+        "st",
+        "su",
+        "sv",
+        "sw",
+        "ta",
+        "te",
+        "tg",
+        "th",
+        "ti",
+        "tk",
+        "tl",
+        "tn",
+        "to",
+        "tr",
+        "ts",
+        "tt",
+        "tw",
+        "ty",
+        "ug",
+        "uk",
+        "ur",
+        "uz",
+        "ve",
+        "vi",
+        "vo",
+        "wa",
+        "wo",
+        "xh",
+        "yi",
+        "yo",
+        "za",
+        "zh",
+        "zu"
+      ],
+      "title": "HumanLanguageLabel",
+      "type": "string"
+    },
+    "ImageRef": {
+      "description": "ImageRef.",
+      "properties": {
+        "mimetype": {
+          "title": "Mimetype",
+          "type": "string"
+        },
+        "dpi": {
+          "title": "Dpi",
+          "type": "integer"
+        },
+        "size": {
+          "$ref": "#/$defs/Size"
+        },
+        "uri": {
+          "anyOf": [
+            {
+              "format": "uri",
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "format": "path",
+              "type": "string"
+            }
+          ],
+          "title": "Uri"
+        }
+      },
+      "required": [
+        "mimetype",
+        "dpi",
+        "size",
+        "uri"
+      ],
+      "title": "ImageRef",
+      "type": "object"
+    },
+    "InlineGroup": {
+      "additionalProperties": false,
+      "description": "InlineGroup.",
+      "properties": {
+        "self_ref": {
+          "pattern": "^#(?:/([\\w-]+)(?:/(\\d+))?)?$",
+          "title": "Self Ref",
+          "type": "string"
+        },
+        "parent": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RefItem"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "children": {
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/RefItem"
+          },
+          "title": "Children",
+          "type": "array"
+        },
+        "content_layer": {
+          "$ref": "#/$defs/ContentLayer",
+          "default": "body"
+        },
+        "meta": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/BaseMeta"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "name": {
+          "default": "group",
+          "title": "Name",
+          "type": "string"
+        },
+        "label": {
+          "const": "inline",
+          "default": "inline",
+          "title": "Label",
+          "type": "string"
+        }
+      },
+      "required": [
+        "self_ref"
+      ],
+      "title": "InlineGroup",
+      "type": "object"
+    },
+    "KeyValueItem": {
+      "additionalProperties": false,
+      "description": "KeyValueItem.",
+      "properties": {
+        "self_ref": {
+          "pattern": "^#(?:/([\\w-]+)(?:/(\\d+))?)?$",
+          "title": "Self Ref",
+          "type": "string"
+        },
+        "parent": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RefItem"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "children": {
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/RefItem"
+          },
+          "title": "Children",
+          "type": "array"
+        },
+        "content_layer": {
+          "$ref": "#/$defs/ContentLayer",
+          "default": "body"
+        },
+        "meta": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/FloatingMeta"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "label": {
+          "const": "key_value_region",
+          "default": "key_value_region",
+          "title": "Label",
+          "type": "string"
+        },
+        "prov": {
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/ProvenanceItem"
+          },
+          "title": "Prov",
+          "type": "array"
+        },
+        "source": {
+          "default": [],
+          "description": "The provenance of this document item. Currently, it is only used for media track provenance.",
+          "items": {
+            "discriminator": {
+              "mapping": {
+                "track": "#/$defs/TrackSource"
+              },
+              "propertyName": "kind"
+            },
+            "oneOf": [
+              {
+                "$ref": "#/$defs/TrackSource"
+              }
+            ]
+          },
+          "title": "Source",
+          "type": "array"
+        },
+        "comments": {
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/FineRef"
+          },
+          "title": "Comments",
+          "type": "array"
+        },
+        "captions": {
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/RefItem"
+          },
+          "title": "Captions",
+          "type": "array"
+        },
+        "references": {
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/RefItem"
+          },
+          "title": "References",
+          "type": "array"
+        },
+        "footnotes": {
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/RefItem"
+          },
+          "title": "Footnotes",
+          "type": "array"
+        },
+        "image": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ImageRef"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "graph": {
+          "$ref": "#/$defs/GraphData"
+        }
+      },
+      "required": [
+        "self_ref",
+        "graph"
+      ],
+      "title": "KeyValueItem",
+      "type": "object"
+    },
+    "KeywordsMetaField": {
+      "additionalProperties": true,
+      "description": "Container for a list of unique keywords / keyphrases.",
+      "properties": {
+        "values": {
+          "items": {
+            "type": "string"
+          },
+          "minItems": 1,
+          "title": "Values",
+          "type": "array",
+          "uniqueItems": true
+        }
+      },
+      "required": [
+        "values"
+      ],
+      "title": "KeywordsMetaField",
+      "type": "object"
+    },
+    "LanguageMetaField": {
+      "additionalProperties": true,
+      "description": "Detected human language.",
+      "properties": {
+        "confidence": {
+          "anyOf": [
+            {
+              "maximum": 1,
+              "minimum": 0,
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The confidence of the prediction.",
+          "examples": [
+            0.9,
+            0.42
+          ],
+          "title": "Confidence"
+        },
+        "created_by": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The origin of the prediction.",
+          "examples": [
+            "ibm-granite/granite-docling-258M"
+          ],
+          "title": "Created By"
+        },
+        "code": {
+          "$ref": "#/$defs/HumanLanguageLabel"
+        }
+      },
+      "required": [
+        "code"
+      ],
+      "title": "LanguageMetaField",
+      "type": "object"
+    },
+    "ListGroup": {
+      "additionalProperties": false,
+      "description": "ListGroup.",
+      "properties": {
+        "self_ref": {
+          "pattern": "^#(?:/([\\w-]+)(?:/(\\d+))?)?$",
+          "title": "Self Ref",
+          "type": "string"
+        },
+        "parent": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RefItem"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "children": {
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/RefItem"
+          },
+          "title": "Children",
+          "type": "array"
+        },
+        "content_layer": {
+          "$ref": "#/$defs/ContentLayer",
+          "default": "body"
+        },
+        "meta": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/BaseMeta"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "name": {
+          "default": "group",
+          "title": "Name",
+          "type": "string"
+        },
+        "label": {
+          "const": "list",
+          "default": "list",
+          "title": "Label",
+          "type": "string"
+        }
+      },
+      "required": [
+        "self_ref"
+      ],
+      "title": "ListGroup",
+      "type": "object"
+    },
+    "ListItem": {
+      "additionalProperties": false,
+      "description": "SectionItem.",
+      "properties": {
+        "self_ref": {
+          "pattern": "^#(?:/([\\w-]+)(?:/(\\d+))?)?$",
+          "title": "Self Ref",
+          "type": "string"
+        },
+        "parent": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RefItem"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "children": {
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/RefItem"
+          },
+          "title": "Children",
+          "type": "array"
+        },
+        "content_layer": {
+          "$ref": "#/$defs/ContentLayer",
+          "default": "body"
+        },
+        "meta": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/BaseMeta"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "label": {
+          "const": "list_item",
+          "default": "list_item",
+          "title": "Label",
+          "type": "string"
+        },
+        "prov": {
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/ProvenanceItem"
+          },
+          "title": "Prov",
+          "type": "array"
+        },
+        "source": {
+          "default": [],
+          "description": "The provenance of this document item. Currently, it is only used for media track provenance.",
+          "items": {
+            "discriminator": {
+              "mapping": {
+                "track": "#/$defs/TrackSource"
+              },
+              "propertyName": "kind"
+            },
+            "oneOf": [
+              {
+                "$ref": "#/$defs/TrackSource"
+              }
+            ]
+          },
+          "title": "Source",
+          "type": "array"
+        },
+        "comments": {
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/FineRef"
+          },
+          "title": "Comments",
+          "type": "array"
+        },
+        "orig": {
+          "title": "Orig",
+          "type": "string"
+        },
+        "text": {
+          "title": "Text",
+          "type": "string"
+        },
+        "formatting": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Formatting"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "hyperlink": {
+          "anyOf": [
+            {
+              "format": "uri",
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "format": "path",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Hyperlink"
+        },
+        "enumerated": {
+          "default": false,
+          "title": "Enumerated",
+          "type": "boolean"
+        },
+        "marker": {
+          "default": "-",
+          "title": "Marker",
+          "type": "string"
+        }
+      },
+      "required": [
+        "self_ref",
+        "orig",
+        "text"
+      ],
+      "title": "ListItem",
+      "type": "object"
+    },
+    "MiscAnnotation": {
+      "description": "MiscAnnotation.",
+      "properties": {
+        "kind": {
+          "const": "misc",
+          "default": "misc",
+          "title": "Kind",
+          "type": "string"
+        },
+        "content": {
+          "additionalProperties": true,
+          "title": "Content",
+          "type": "object"
+        }
+      },
+      "required": [
+        "content"
+      ],
+      "title": "MiscAnnotation",
+      "type": "object"
+    },
+    "MoleculeMetaField": {
+      "additionalProperties": true,
+      "description": "Molecule metadata field.",
+      "properties": {
+        "confidence": {
+          "anyOf": [
+            {
+              "maximum": 1,
+              "minimum": 0,
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The confidence of the prediction.",
+          "examples": [
+            0.9,
+            0.42
+          ],
+          "title": "Confidence"
+        },
+        "created_by": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The origin of the prediction.",
+          "examples": [
+            "ibm-granite/granite-docling-258M"
+          ],
+          "title": "Created By"
+        },
+        "smi": {
+          "description": "The SMILES representation of the molecule.",
+          "title": "Smi",
+          "type": "string"
+        }
+      },
+      "required": [
+        "smi"
+      ],
+      "title": "MoleculeMetaField",
+      "type": "object"
+    },
+    "Orientation": {
+      "description": "Counter-clockwise rotation of a table on the page, in degrees.\n\nFollows the convention used by PIL/Pillow's ``Image.rotate``: positive\nangles rotate the table counter-clockwise. ``ROT_0`` / ``ROT_180`` keep\nrows running horizontally on the page; ``ROT_90`` / ``ROT_270`` turn\nrows into vertical stripes.",
+      "enum": [
+        "rot_0",
+        "rot_90",
+        "rot_180",
+        "rot_270"
+      ],
+      "title": "Orientation",
+      "type": "string"
+    },
+    "PageItem": {
+      "description": "PageItem.",
+      "properties": {
+        "size": {
+          "$ref": "#/$defs/Size"
+        },
+        "image": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ImageRef"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "page_no": {
+          "title": "Page No",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "size",
+        "page_no"
+      ],
+      "title": "PageItem",
+      "type": "object"
+    },
+    "PictureBarChartData": {
+      "description": "Represents data of a bar chart.\n\nAttributes:\n    kind (Literal[\"bar_chart_data\"]): The type of the chart.\n    x_axis_label (str): The label for the x-axis.\n    y_axis_label (str): The label for the y-axis.\n    bars (list[ChartBar]): A list of bars in the chart.",
+      "properties": {
+        "kind": {
+          "const": "bar_chart_data",
+          "default": "bar_chart_data",
+          "title": "Kind",
+          "type": "string"
+        },
+        "title": {
+          "title": "Title",
+          "type": "string"
+        },
+        "x_axis_label": {
+          "title": "X Axis Label",
+          "type": "string"
+        },
+        "y_axis_label": {
+          "title": "Y Axis Label",
+          "type": "string"
+        },
+        "bars": {
+          "items": {
+            "$ref": "#/$defs/ChartBar"
+          },
+          "title": "Bars",
+          "type": "array"
+        }
+      },
+      "required": [
+        "title",
+        "x_axis_label",
+        "y_axis_label",
+        "bars"
+      ],
+      "title": "PictureBarChartData",
+      "type": "object"
+    },
+    "PictureClassificationClass": {
+      "description": "PictureClassificationData.",
+      "properties": {
+        "class_name": {
+          "title": "Class Name",
+          "type": "string"
+        },
+        "confidence": {
+          "title": "Confidence",
+          "type": "number"
+        }
+      },
+      "required": [
+        "class_name",
+        "confidence"
+      ],
+      "title": "PictureClassificationClass",
+      "type": "object"
+    },
+    "PictureClassificationData": {
+      "description": "PictureClassificationData.",
+      "properties": {
+        "kind": {
+          "const": "classification",
+          "default": "classification",
+          "title": "Kind",
+          "type": "string"
+        },
+        "provenance": {
+          "title": "Provenance",
+          "type": "string"
+        },
+        "predicted_classes": {
+          "items": {
+            "$ref": "#/$defs/PictureClassificationClass"
+          },
+          "title": "Predicted Classes",
+          "type": "array"
+        }
+      },
+      "required": [
+        "provenance",
+        "predicted_classes"
+      ],
+      "title": "PictureClassificationData",
+      "type": "object"
+    },
+    "PictureClassificationMetaField": {
+      "additionalProperties": true,
+      "description": "Picture classification metadata field.",
+      "properties": {
+        "predictions": {
+          "items": {
+            "$ref": "#/$defs/PictureClassificationPrediction"
+          },
+          "minItems": 1,
+          "title": "Predictions",
+          "type": "array"
+        }
+      },
+      "title": "PictureClassificationMetaField",
+      "type": "object"
+    },
+    "PictureClassificationPrediction": {
+      "additionalProperties": true,
+      "description": "Picture classification instance.",
+      "properties": {
+        "confidence": {
+          "anyOf": [
+            {
+              "maximum": 1,
+              "minimum": 0,
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The confidence of the prediction.",
+          "examples": [
+            0.9,
+            0.42
+          ],
+          "title": "Confidence"
+        },
+        "created_by": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The origin of the prediction.",
+          "examples": [
+            "ibm-granite/granite-docling-258M"
+          ],
+          "title": "Created By"
+        },
+        "class_name": {
+          "title": "Class Name",
+          "type": "string"
+        }
+      },
+      "required": [
+        "class_name"
+      ],
+      "title": "PictureClassificationPrediction",
+      "type": "object"
+    },
+    "PictureItem": {
+      "additionalProperties": false,
+      "description": "PictureItem.",
+      "properties": {
+        "self_ref": {
+          "pattern": "^#(?:/([\\w-]+)(?:/(\\d+))?)?$",
+          "title": "Self Ref",
+          "type": "string"
+        },
+        "parent": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RefItem"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "children": {
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/RefItem"
+          },
+          "title": "Children",
+          "type": "array"
+        },
+        "content_layer": {
+          "$ref": "#/$defs/ContentLayer",
+          "default": "body"
+        },
+        "meta": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/PictureMeta"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "label": {
+          "default": "picture",
+          "enum": [
+            "picture",
+            "chart"
+          ],
+          "title": "Label",
+          "type": "string"
+        },
+        "prov": {
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/ProvenanceItem"
+          },
+          "title": "Prov",
+          "type": "array"
+        },
+        "source": {
+          "default": [],
+          "description": "The provenance of this document item. Currently, it is only used for media track provenance.",
+          "items": {
+            "discriminator": {
+              "mapping": {
+                "track": "#/$defs/TrackSource"
+              },
+              "propertyName": "kind"
+            },
+            "oneOf": [
+              {
+                "$ref": "#/$defs/TrackSource"
+              }
+            ]
+          },
+          "title": "Source",
+          "type": "array"
+        },
+        "comments": {
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/FineRef"
+          },
+          "title": "Comments",
+          "type": "array"
+        },
+        "captions": {
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/RefItem"
+          },
+          "title": "Captions",
+          "type": "array"
+        },
+        "references": {
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/RefItem"
+          },
+          "title": "References",
+          "type": "array"
+        },
+        "footnotes": {
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/RefItem"
+          },
+          "title": "Footnotes",
+          "type": "array"
+        },
+        "image": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ImageRef"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "annotations": {
+          "default": [],
+          "deprecated": true,
+          "items": {
+            "discriminator": {
+              "mapping": {
+                "bar_chart_data": "#/$defs/PictureBarChartData",
+                "classification": "#/$defs/PictureClassificationData",
+                "description": "#/$defs/DescriptionAnnotation",
+                "line_chart_data": "#/$defs/PictureLineChartData",
+                "misc": "#/$defs/MiscAnnotation",
+                "molecule_data": "#/$defs/PictureMoleculeData",
+                "pie_chart_data": "#/$defs/PicturePieChartData",
+                "scatter_chart_data": "#/$defs/PictureScatterChartData",
+                "stacked_bar_chart_data": "#/$defs/PictureStackedBarChartData",
+                "tabular_chart_data": "#/$defs/PictureTabularChartData"
+              },
+              "propertyName": "kind"
+            },
+            "oneOf": [
+              {
+                "$ref": "#/$defs/DescriptionAnnotation"
+              },
+              {
+                "$ref": "#/$defs/MiscAnnotation"
+              },
+              {
+                "$ref": "#/$defs/PictureClassificationData"
+              },
+              {
+                "$ref": "#/$defs/PictureMoleculeData"
+              },
+              {
+                "$ref": "#/$defs/PictureTabularChartData"
+              },
+              {
+                "$ref": "#/$defs/PictureLineChartData"
+              },
+              {
+                "$ref": "#/$defs/PictureBarChartData"
+              },
+              {
+                "$ref": "#/$defs/PictureStackedBarChartData"
+              },
+              {
+                "$ref": "#/$defs/PicturePieChartData"
+              },
+              {
+                "$ref": "#/$defs/PictureScatterChartData"
+              }
+            ]
+          },
+          "title": "Annotations",
+          "type": "array"
+        }
+      },
+      "required": [
+        "self_ref"
+      ],
+      "title": "PictureItem",
+      "type": "object"
+    },
+    "PictureLineChartData": {
+      "description": "Represents data of a line chart.\n\nAttributes:\n    kind (Literal[\"line_chart_data\"]): The type of the chart.\n    x_axis_label (str): The label for the x-axis.\n    y_axis_label (str): The label for the y-axis.\n    lines (list[ChartLine]): A list of lines in the chart.",
+      "properties": {
+        "kind": {
+          "const": "line_chart_data",
+          "default": "line_chart_data",
+          "title": "Kind",
+          "type": "string"
+        },
+        "title": {
+          "title": "Title",
+          "type": "string"
+        },
+        "x_axis_label": {
+          "title": "X Axis Label",
+          "type": "string"
+        },
+        "y_axis_label": {
+          "title": "Y Axis Label",
+          "type": "string"
+        },
+        "lines": {
+          "items": {
+            "$ref": "#/$defs/ChartLine"
+          },
+          "title": "Lines",
+          "type": "array"
+        }
+      },
+      "required": [
+        "title",
+        "x_axis_label",
+        "y_axis_label",
+        "lines"
+      ],
+      "title": "PictureLineChartData",
+      "type": "object"
+    },
+    "PictureMeta": {
+      "additionalProperties": true,
+      "description": "Metadata model for pictures.",
+      "properties": {
+        "summary": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SummaryMetaField"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "A condensed natural-language summary of the content rooted at this node.",
+          "examples": [
+            {
+              "text": "A short company/location statement."
+            }
+          ]
+        },
+        "language": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/LanguageMetaField"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The detected human language of the node content, expressed as a BCP 47 code.",
+          "examples": [
+            {
+              "code": "en"
+            }
+          ]
+        },
+        "entities": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/EntitiesMetaField"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Named entities extracted from the node text (persons, organisations, locations, etc.). Each mention carries the entity text, an optional type label, and an optional character span.",
+          "examples": [
+            {
+              "mentions": [
+                {
+                  "charspan": [
+                    0,
+                    3
+                  ],
+                  "label": "ORG",
+                  "text": "IBM"
+                }
+              ]
+            }
+          ]
+        },
+        "keywords": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/KeywordsMetaField"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Salient terms or short keyphrases that characterise the node content. Keywords are more specific than topics and typically correspond to individual words or short multi-word expressions found in or closely related to the text. Values are order-preserving and deduplicated.",
+          "examples": [
+            {
+              "values": [
+                "transformer",
+                "attention mechanism",
+                "BERT"
+              ]
+            }
+          ]
+        },
+        "topics": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TopicsMetaField"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Higher-level subject categories or thematic labels inferred for the node content. Topics are broader than keywords and describe the domain or theme rather than specific terms (e.g., 'machine learning' rather than 'gradient descent'). Values are order-preserving and deduplicated.",
+          "examples": [
+            {
+              "values": [
+                "natural language processing",
+                "computer vision"
+              ]
+            }
+          ]
+        },
+        "description": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DescriptionMetaField"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "classification": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/PictureClassificationMetaField"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "molecule": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/MoleculeMetaField"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "tabular_chart": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TabularChartMetaField"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "code": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/CodeMetaField"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        }
+      },
+      "title": "PictureMeta",
+      "type": "object"
+    },
+    "PictureMoleculeData": {
+      "description": "PictureMoleculeData.",
+      "properties": {
+        "kind": {
+          "const": "molecule_data",
+          "default": "molecule_data",
+          "title": "Kind",
+          "type": "string"
+        },
+        "smi": {
+          "title": "Smi",
+          "type": "string"
+        },
+        "confidence": {
+          "title": "Confidence",
+          "type": "number"
+        },
+        "class_name": {
+          "title": "Class Name",
+          "type": "string"
+        },
+        "segmentation": {
+          "items": {
+            "maxItems": 2,
+            "minItems": 2,
+            "prefixItems": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "number"
+              }
+            ],
+            "type": "array"
+          },
+          "title": "Segmentation",
+          "type": "array"
+        },
+        "provenance": {
+          "title": "Provenance",
+          "type": "string"
+        }
+      },
+      "required": [
+        "smi",
+        "confidence",
+        "class_name",
+        "segmentation",
+        "provenance"
+      ],
+      "title": "PictureMoleculeData",
+      "type": "object"
+    },
+    "PicturePieChartData": {
+      "description": "Represents data of a pie chart.\n\nAttributes:\n    kind (Literal[\"pie_chart_data\"]): The type of the chart.\n    slices (list[ChartSlice]): A list of slices in the pie chart.",
+      "properties": {
+        "kind": {
+          "const": "pie_chart_data",
+          "default": "pie_chart_data",
+          "title": "Kind",
+          "type": "string"
+        },
+        "title": {
+          "title": "Title",
+          "type": "string"
+        },
+        "slices": {
+          "items": {
+            "$ref": "#/$defs/ChartSlice"
+          },
+          "title": "Slices",
+          "type": "array"
+        }
+      },
+      "required": [
+        "title",
+        "slices"
+      ],
+      "title": "PicturePieChartData",
+      "type": "object"
+    },
+    "PictureScatterChartData": {
+      "description": "Represents data of a scatter chart.\n\nAttributes:\n    kind (Literal[\"scatter_chart_data\"]): The type of the chart.\n    x_axis_label (str): The label for the x-axis.\n    y_axis_label (str): The label for the y-axis.\n    points (list[ChartPoint]): A list of points in the scatter chart.",
+      "properties": {
+        "kind": {
+          "const": "scatter_chart_data",
+          "default": "scatter_chart_data",
+          "title": "Kind",
+          "type": "string"
+        },
+        "title": {
+          "title": "Title",
+          "type": "string"
+        },
+        "x_axis_label": {
+          "title": "X Axis Label",
+          "type": "string"
+        },
+        "y_axis_label": {
+          "title": "Y Axis Label",
+          "type": "string"
+        },
+        "points": {
+          "items": {
+            "$ref": "#/$defs/ChartPoint"
+          },
+          "title": "Points",
+          "type": "array"
+        }
+      },
+      "required": [
+        "title",
+        "x_axis_label",
+        "y_axis_label",
+        "points"
+      ],
+      "title": "PictureScatterChartData",
+      "type": "object"
+    },
+    "PictureStackedBarChartData": {
+      "description": "Represents data of a stacked bar chart.\n\nAttributes:\n    kind (Literal[\"stacked_bar_chart_data\"]): The type of the chart.\n    x_axis_label (str): The label for the x-axis.\n    y_axis_label (str): The label for the y-axis.\n    stacked_bars (list[ChartStackedBar]): A list of stacked bars in the chart.",
+      "properties": {
+        "kind": {
+          "const": "stacked_bar_chart_data",
+          "default": "stacked_bar_chart_data",
+          "title": "Kind",
+          "type": "string"
+        },
+        "title": {
+          "title": "Title",
+          "type": "string"
+        },
+        "x_axis_label": {
+          "title": "X Axis Label",
+          "type": "string"
+        },
+        "y_axis_label": {
+          "title": "Y Axis Label",
+          "type": "string"
+        },
+        "stacked_bars": {
+          "items": {
+            "$ref": "#/$defs/ChartStackedBar"
+          },
+          "title": "Stacked Bars",
+          "type": "array"
+        }
+      },
+      "required": [
+        "title",
+        "x_axis_label",
+        "y_axis_label",
+        "stacked_bars"
+      ],
+      "title": "PictureStackedBarChartData",
+      "type": "object"
+    },
+    "PictureTabularChartData": {
+      "description": "Base class for picture chart data.\n\nAttributes:\n    title (str): The title of the chart.\n    chart_data (TableData): Chart data in the table format.",
+      "properties": {
+        "kind": {
+          "const": "tabular_chart_data",
+          "default": "tabular_chart_data",
+          "title": "Kind",
+          "type": "string"
+        },
+        "title": {
+          "title": "Title",
+          "type": "string"
+        },
+        "chart_data": {
+          "$ref": "#/$defs/TableData"
+        }
+      },
+      "required": [
+        "title",
+        "chart_data"
+      ],
+      "title": "PictureTabularChartData",
+      "type": "object"
+    },
+    "ProvenanceItem": {
+      "description": "Provenance information for elements extracted from a textual document.\n\nA `ProvenanceItem` object acts as a lightweight pointer back into the original\ndocument for an extracted element. It applies to documents with an explicit\nor implicit layout, such as PDF, HTML, docx, or pptx.",
+      "properties": {
+        "page_no": {
+          "description": "Page number",
+          "title": "Page No",
+          "type": "integer"
+        },
+        "bbox": {
+          "$ref": "#/$defs/BoundingBox",
+          "description": "Bounding box"
+        },
+        "charspan": {
+          "description": "Character span (0-indexed)",
+          "maxItems": 2,
+          "minItems": 2,
+          "prefixItems": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "integer"
+            }
+          ],
+          "title": "Charspan",
+          "type": "array"
+        }
+      },
+      "required": [
+        "page_no",
+        "bbox",
+        "charspan"
+      ],
+      "title": "ProvenanceItem",
+      "type": "object"
+    },
+    "RefItem": {
+      "description": "RefItem.",
+      "properties": {
+        "$ref": {
+          "pattern": "^#(?:/([\\w-]+)(?:/(\\d+))?)?$",
+          "title": "$Ref",
+          "type": "string"
+        }
+      },
+      "required": [
+        "$ref"
+      ],
+      "title": "RefItem",
+      "type": "object"
+    },
+    "RichTableCell": {
+      "description": "RichTableCell.",
+      "properties": {
+        "bbox": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/BoundingBox"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "row_span": {
+          "default": 1,
+          "title": "Row Span",
+          "type": "integer"
+        },
+        "col_span": {
+          "default": 1,
+          "title": "Col Span",
+          "type": "integer"
+        },
+        "start_row_offset_idx": {
+          "title": "Start Row Offset Idx",
+          "type": "integer"
+        },
+        "end_row_offset_idx": {
+          "title": "End Row Offset Idx",
+          "type": "integer"
+        },
+        "start_col_offset_idx": {
+          "title": "Start Col Offset Idx",
+          "type": "integer"
+        },
+        "end_col_offset_idx": {
+          "title": "End Col Offset Idx",
+          "type": "integer"
+        },
+        "text": {
+          "title": "Text",
+          "type": "string"
+        },
+        "column_header": {
+          "default": false,
+          "title": "Column Header",
+          "type": "boolean"
+        },
+        "row_header": {
+          "default": false,
+          "title": "Row Header",
+          "type": "boolean"
+        },
+        "row_section": {
+          "default": false,
+          "title": "Row Section",
+          "type": "boolean"
+        },
+        "fillable": {
+          "default": false,
+          "title": "Fillable",
+          "type": "boolean"
+        },
+        "ref": {
+          "$ref": "#/$defs/RefItem"
+        }
+      },
+      "required": [
+        "start_row_offset_idx",
+        "end_row_offset_idx",
+        "start_col_offset_idx",
+        "end_col_offset_idx",
+        "text",
+        "ref"
+      ],
+      "title": "RichTableCell",
+      "type": "object"
+    },
+    "Script": {
+      "description": "Text script position.",
+      "enum": [
+        "baseline",
+        "sub",
+        "super"
+      ],
+      "title": "Script",
+      "type": "string"
+    },
+    "SectionHeaderItem": {
+      "additionalProperties": false,
+      "description": "SectionItem.",
+      "properties": {
+        "self_ref": {
+          "pattern": "^#(?:/([\\w-]+)(?:/(\\d+))?)?$",
+          "title": "Self Ref",
+          "type": "string"
+        },
+        "parent": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RefItem"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "children": {
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/RefItem"
+          },
+          "title": "Children",
+          "type": "array"
+        },
+        "content_layer": {
+          "$ref": "#/$defs/ContentLayer",
+          "default": "body"
+        },
+        "meta": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/BaseMeta"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "label": {
+          "const": "section_header",
+          "default": "section_header",
+          "title": "Label",
+          "type": "string"
+        },
+        "prov": {
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/ProvenanceItem"
+          },
+          "title": "Prov",
+          "type": "array"
+        },
+        "source": {
+          "default": [],
+          "description": "The provenance of this document item. Currently, it is only used for media track provenance.",
+          "items": {
+            "discriminator": {
+              "mapping": {
+                "track": "#/$defs/TrackSource"
+              },
+              "propertyName": "kind"
+            },
+            "oneOf": [
+              {
+                "$ref": "#/$defs/TrackSource"
+              }
+            ]
+          },
+          "title": "Source",
+          "type": "array"
+        },
+        "comments": {
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/FineRef"
+          },
+          "title": "Comments",
+          "type": "array"
+        },
+        "orig": {
+          "title": "Orig",
+          "type": "string"
+        },
+        "text": {
+          "title": "Text",
+          "type": "string"
+        },
+        "formatting": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Formatting"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "hyperlink": {
+          "anyOf": [
+            {
+              "format": "uri",
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "format": "path",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Hyperlink"
+        },
+        "level": {
+          "default": 1,
+          "maximum": 100,
+          "minimum": 1,
+          "title": "Level",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "self_ref",
+        "orig",
+        "text"
+      ],
+      "title": "SectionHeaderItem",
+      "type": "object"
+    },
+    "Size": {
+      "description": "Size.",
+      "properties": {
+        "width": {
+          "default": 0.0,
+          "title": "Width",
+          "type": "number"
+        },
+        "height": {
+          "default": 0.0,
+          "title": "Height",
+          "type": "number"
+        }
+      },
+      "title": "Size",
+      "type": "object"
+    },
+    "SummaryMetaField": {
+      "additionalProperties": true,
+      "description": "Summary data.",
+      "properties": {
+        "confidence": {
+          "anyOf": [
+            {
+              "maximum": 1,
+              "minimum": 0,
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The confidence of the prediction.",
+          "examples": [
+            0.9,
+            0.42
+          ],
+          "title": "Confidence"
+        },
+        "created_by": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The origin of the prediction.",
+          "examples": [
+            "ibm-granite/granite-docling-258M"
+          ],
+          "title": "Created By"
+        },
+        "text": {
+          "title": "Text",
+          "type": "string"
+        }
+      },
+      "required": [
+        "text"
+      ],
+      "title": "SummaryMetaField",
+      "type": "object"
+    },
+    "TableCell": {
+      "description": "TableCell.",
+      "properties": {
+        "bbox": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/BoundingBox"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "row_span": {
+          "default": 1,
+          "title": "Row Span",
+          "type": "integer"
+        },
+        "col_span": {
+          "default": 1,
+          "title": "Col Span",
+          "type": "integer"
+        },
+        "start_row_offset_idx": {
+          "title": "Start Row Offset Idx",
+          "type": "integer"
+        },
+        "end_row_offset_idx": {
+          "title": "End Row Offset Idx",
+          "type": "integer"
+        },
+        "start_col_offset_idx": {
+          "title": "Start Col Offset Idx",
+          "type": "integer"
+        },
+        "end_col_offset_idx": {
+          "title": "End Col Offset Idx",
+          "type": "integer"
+        },
+        "text": {
+          "title": "Text",
+          "type": "string"
+        },
+        "column_header": {
+          "default": false,
+          "title": "Column Header",
+          "type": "boolean"
+        },
+        "row_header": {
+          "default": false,
+          "title": "Row Header",
+          "type": "boolean"
+        },
+        "row_section": {
+          "default": false,
+          "title": "Row Section",
+          "type": "boolean"
+        },
+        "fillable": {
+          "default": false,
+          "title": "Fillable",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "start_row_offset_idx",
+        "end_row_offset_idx",
+        "start_col_offset_idx",
+        "end_col_offset_idx",
+        "text"
+      ],
+      "title": "TableCell",
+      "type": "object"
+    },
+    "TableData": {
+      "description": "BaseTableData.",
+      "properties": {
+        "table_cells": {
+          "default": [],
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/RichTableCell"
+              },
+              {
+                "$ref": "#/$defs/TableCell"
+              }
+            ]
+          },
+          "title": "Table Cells",
+          "type": "array"
+        },
+        "num_rows": {
+          "default": 0,
+          "title": "Num Rows",
+          "type": "integer"
+        },
+        "num_cols": {
+          "default": 0,
+          "title": "Num Cols",
+          "type": "integer"
+        },
+        "orientation": {
+          "$ref": "#/$defs/Orientation",
+          "default": "rot_0"
+        }
+      },
+      "title": "TableData",
+      "type": "object"
+    },
+    "TableItem": {
+      "additionalProperties": false,
+      "description": "TableItem.",
+      "properties": {
+        "self_ref": {
+          "pattern": "^#(?:/([\\w-]+)(?:/(\\d+))?)?$",
+          "title": "Self Ref",
+          "type": "string"
+        },
+        "parent": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RefItem"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "children": {
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/RefItem"
+          },
+          "title": "Children",
+          "type": "array"
+        },
+        "content_layer": {
+          "$ref": "#/$defs/ContentLayer",
+          "default": "body"
+        },
+        "meta": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/FloatingMeta"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "label": {
+          "default": "table",
+          "enum": [
+            "document_index",
+            "table"
+          ],
+          "title": "Label",
+          "type": "string"
+        },
+        "prov": {
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/ProvenanceItem"
+          },
+          "title": "Prov",
+          "type": "array"
+        },
+        "source": {
+          "default": [],
+          "description": "The provenance of this document item. Currently, it is only used for media track provenance.",
+          "items": {
+            "discriminator": {
+              "mapping": {
+                "track": "#/$defs/TrackSource"
+              },
+              "propertyName": "kind"
+            },
+            "oneOf": [
+              {
+                "$ref": "#/$defs/TrackSource"
+              }
+            ]
+          },
+          "title": "Source",
+          "type": "array"
+        },
+        "comments": {
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/FineRef"
+          },
+          "title": "Comments",
+          "type": "array"
+        },
+        "captions": {
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/RefItem"
+          },
+          "title": "Captions",
+          "type": "array"
+        },
+        "references": {
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/RefItem"
+          },
+          "title": "References",
+          "type": "array"
+        },
+        "footnotes": {
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/RefItem"
+          },
+          "title": "Footnotes",
+          "type": "array"
+        },
+        "image": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ImageRef"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "data": {
+          "$ref": "#/$defs/TableData"
+        },
+        "annotations": {
+          "default": [],
+          "deprecated": true,
+          "items": {
+            "discriminator": {
+              "mapping": {
+                "description": "#/$defs/DescriptionAnnotation",
+                "misc": "#/$defs/MiscAnnotation"
+              },
+              "propertyName": "kind"
+            },
+            "oneOf": [
+              {
+                "$ref": "#/$defs/DescriptionAnnotation"
+              },
+              {
+                "$ref": "#/$defs/MiscAnnotation"
+              }
+            ]
+          },
+          "title": "Annotations",
+          "type": "array"
+        }
+      },
+      "required": [
+        "self_ref",
+        "data"
+      ],
+      "title": "TableItem",
+      "type": "object"
+    },
+    "TabularChartMetaField": {
+      "additionalProperties": true,
+      "description": "Tabular chart metadata field.",
+      "properties": {
+        "confidence": {
+          "anyOf": [
+            {
+              "maximum": 1,
+              "minimum": 0,
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The confidence of the prediction.",
+          "examples": [
+            0.9,
+            0.42
+          ],
+          "title": "Confidence"
+        },
+        "created_by": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The origin of the prediction.",
+          "examples": [
+            "ibm-granite/granite-docling-258M"
+          ],
+          "title": "Created By"
+        },
+        "title": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Title"
+        },
+        "chart_data": {
+          "$ref": "#/$defs/TableData"
+        }
+      },
+      "required": [
+        "chart_data"
+      ],
+      "title": "TabularChartMetaField",
+      "type": "object"
+    },
+    "TextItem": {
+      "additionalProperties": false,
+      "description": "TextItem.",
+      "properties": {
+        "self_ref": {
+          "pattern": "^#(?:/([\\w-]+)(?:/(\\d+))?)?$",
+          "title": "Self Ref",
+          "type": "string"
+        },
+        "parent": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RefItem"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "children": {
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/RefItem"
+          },
+          "title": "Children",
+          "type": "array"
+        },
+        "content_layer": {
+          "$ref": "#/$defs/ContentLayer",
+          "default": "body"
+        },
+        "meta": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/BaseMeta"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "label": {
+          "enum": [
+            "caption",
+            "checkbox_selected",
+            "checkbox_unselected",
+            "footnote",
+            "page_footer",
+            "page_header",
+            "paragraph",
+            "reference",
+            "text",
+            "empty_value",
+            "field_key",
+            "field_hint",
+            "marker",
+            "handwritten_text"
+          ],
+          "title": "Label",
+          "type": "string"
+        },
+        "prov": {
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/ProvenanceItem"
+          },
+          "title": "Prov",
+          "type": "array"
+        },
+        "source": {
+          "default": [],
+          "description": "The provenance of this document item. Currently, it is only used for media track provenance.",
+          "items": {
+            "discriminator": {
+              "mapping": {
+                "track": "#/$defs/TrackSource"
+              },
+              "propertyName": "kind"
+            },
+            "oneOf": [
+              {
+                "$ref": "#/$defs/TrackSource"
+              }
+            ]
+          },
+          "title": "Source",
+          "type": "array"
+        },
+        "comments": {
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/FineRef"
+          },
+          "title": "Comments",
+          "type": "array"
+        },
+        "orig": {
+          "title": "Orig",
+          "type": "string"
+        },
+        "text": {
+          "title": "Text",
+          "type": "string"
+        },
+        "formatting": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Formatting"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "hyperlink": {
+          "anyOf": [
+            {
+              "format": "uri",
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "format": "path",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Hyperlink"
+        }
+      },
+      "required": [
+        "self_ref",
+        "label",
+        "orig",
+        "text"
+      ],
+      "title": "TextItem",
+      "type": "object"
+    },
+    "TitleItem": {
+      "additionalProperties": false,
+      "description": "TitleItem.",
+      "properties": {
+        "self_ref": {
+          "pattern": "^#(?:/([\\w-]+)(?:/(\\d+))?)?$",
+          "title": "Self Ref",
+          "type": "string"
+        },
+        "parent": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RefItem"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "children": {
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/RefItem"
+          },
+          "title": "Children",
+          "type": "array"
+        },
+        "content_layer": {
+          "$ref": "#/$defs/ContentLayer",
+          "default": "body"
+        },
+        "meta": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/BaseMeta"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "label": {
+          "const": "title",
+          "default": "title",
+          "title": "Label",
+          "type": "string"
+        },
+        "prov": {
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/ProvenanceItem"
+          },
+          "title": "Prov",
+          "type": "array"
+        },
+        "source": {
+          "default": [],
+          "description": "The provenance of this document item. Currently, it is only used for media track provenance.",
+          "items": {
+            "discriminator": {
+              "mapping": {
+                "track": "#/$defs/TrackSource"
+              },
+              "propertyName": "kind"
+            },
+            "oneOf": [
+              {
+                "$ref": "#/$defs/TrackSource"
+              }
+            ]
+          },
+          "title": "Source",
+          "type": "array"
+        },
+        "comments": {
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/FineRef"
+          },
+          "title": "Comments",
+          "type": "array"
+        },
+        "orig": {
+          "title": "Orig",
+          "type": "string"
+        },
+        "text": {
+          "title": "Text",
+          "type": "string"
+        },
+        "formatting": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Formatting"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "hyperlink": {
+          "anyOf": [
+            {
+              "format": "uri",
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "format": "path",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Hyperlink"
+        }
+      },
+      "required": [
+        "self_ref",
+        "orig",
+        "text"
+      ],
+      "title": "TitleItem",
+      "type": "object"
+    },
+    "TopicsMetaField": {
+      "additionalProperties": true,
+      "description": "Container for a list of unique topics / subjects.",
+      "properties": {
+        "values": {
+          "items": {
+            "type": "string"
+          },
+          "minItems": 1,
+          "title": "Values",
+          "type": "array",
+          "uniqueItems": true
+        }
+      },
+      "required": [
+        "values"
+      ],
+      "title": "TopicsMetaField",
+      "type": "object"
+    },
+    "TrackSource": {
+      "description": "Source metadata for a cue extracted from a media track.\n\nA `TrackSource` instance identifies a cue in a media track (audio, video, subtitles, screen-recording captions,\netc.). A *cue* here refers to any discrete segment that was pulled out of the original asset, e.g., a subtitle\nblock, an audio clip, or a timed marker in a screen-recording.",
+      "properties": {
+        "kind": {
+          "const": "track",
+          "default": "track",
+          "description": "Identifies this type of source.",
+          "title": "Kind",
+          "type": "string"
+        },
+        "start_time": {
+          "description": "Start time offset of the track cue in seconds",
+          "examples": [
+            11.0,
+            6.5,
+            5370.0
+          ],
+          "title": "Start Time",
+          "type": "number"
+        },
+        "end_time": {
+          "description": "End time offset of the track cue in seconds",
+          "examples": [
+            12.0,
+            8.2,
+            5370.1
+          ],
+          "title": "End Time",
+          "type": "number"
+        },
+        "identifier": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "An identifier of the cue",
+          "examples": [
+            "test",
+            "123",
+            "b72d946"
+          ],
+          "title": "Identifier"
+        },
+        "voice": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The name of the voice in this track (the speaker)",
+          "examples": [
+            "John",
+            "Mary",
+            "Speaker 1"
+          ],
+          "title": "Voice"
+        }
+      },
+      "required": [
+        "start_time",
+        "end_time"
+      ],
+      "title": "TrackSource",
+      "type": "object"
+    }
+  },
+  "description": "DoclingDocument.",
+  "properties": {
+    "schema_name": {
+      "const": "DoclingDocument",
+      "default": "DoclingDocument",
+      "title": "Schema Name",
+      "type": "string"
+    },
+    "version": {
+      "default": "1.11.0",
+      "pattern": "^(?P<major>0|[1-9]\\d*)\\.(?P<minor>0|[1-9]\\d*)\\.(?P<patch>0|[1-9]\\d*)(?:-(?P<prerelease>(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$",
+      "title": "Version",
+      "type": "string"
+    },
+    "name": {
+      "title": "Name",
+      "type": "string"
+    },
+    "origin": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/DocumentOrigin"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null
+    },
+    "furniture": {
+      "$ref": "#/$defs/GroupItem",
+      "default": {
+        "self_ref": "#/furniture",
+        "parent": null,
+        "children": [],
+        "content_layer": "furniture",
+        "meta": null,
+        "name": "_root_",
+        "label": "unspecified"
+      },
+      "deprecated": true
+    },
+    "body": {
+      "$ref": "#/$defs/GroupItem",
+      "default": {
+        "self_ref": "#/body",
+        "parent": null,
+        "children": [],
+        "content_layer": "body",
+        "meta": null,
+        "name": "_root_",
+        "label": "unspecified"
+      }
+    },
+    "groups": {
+      "default": [],
+      "items": {
+        "anyOf": [
+          {
+            "$ref": "#/$defs/ListGroup"
+          },
+          {
+            "$ref": "#/$defs/InlineGroup"
+          },
+          {
+            "$ref": "#/$defs/GroupItem"
+          }
+        ]
+      },
+      "title": "Groups",
+      "type": "array"
+    },
+    "texts": {
+      "default": [],
+      "items": {
+        "anyOf": [
+          {
+            "$ref": "#/$defs/TitleItem"
+          },
+          {
+            "$ref": "#/$defs/SectionHeaderItem"
+          },
+          {
+            "$ref": "#/$defs/ListItem"
+          },
+          {
+            "$ref": "#/$defs/CodeItem"
+          },
+          {
+            "$ref": "#/$defs/FormulaItem"
+          },
+          {
+            "$ref": "#/$defs/FieldHeadingItem"
+          },
+          {
+            "$ref": "#/$defs/FieldValueItem"
+          },
+          {
+            "$ref": "#/$defs/TextItem"
+          }
+        ]
+      },
+      "title": "Texts",
+      "type": "array"
+    },
+    "pictures": {
+      "default": [],
+      "items": {
+        "$ref": "#/$defs/PictureItem"
+      },
+      "title": "Pictures",
+      "type": "array"
+    },
+    "tables": {
+      "default": [],
+      "items": {
+        "$ref": "#/$defs/TableItem"
+      },
+      "title": "Tables",
+      "type": "array"
+    },
+    "key_value_items": {
+      "default": [],
+      "items": {
+        "$ref": "#/$defs/KeyValueItem"
+      },
+      "title": "Key Value Items",
+      "type": "array"
+    },
+    "form_items": {
+      "default": [],
+      "items": {
+        "$ref": "#/$defs/FormItem"
+      },
+      "title": "Form Items",
+      "type": "array"
+    },
+    "field_regions": {
+      "default": [],
+      "items": {
+        "$ref": "#/$defs/FieldRegionItem"
+      },
+      "title": "Field Regions",
+      "type": "array"
+    },
+    "field_items": {
+      "default": [],
+      "items": {
+        "$ref": "#/$defs/FieldItem"
+      },
+      "title": "Field Items",
+      "type": "array"
+    },
+    "pages": {
+      "additionalProperties": {
+        "$ref": "#/$defs/PageItem"
+      },
+      "default": {},
+      "title": "Pages",
+      "type": "object"
+    }
+  },
+  "required": [
+    "name"
+  ],
+  "title": "DoclingDocument",
+  "type": "object"
+}

--- a/packages/dclq/dclq/cli.py
+++ b/packages/dclq/dclq/cli.py
@@ -12,9 +12,13 @@ from pathlib import Path
 from types import SimpleNamespace
 from typing import Annotated, Any, Literal
 
-import click
 import typer
 from lxml import etree
+
+# typer >=0.25 vendors its own copy of click (typer._click) and raises those
+# exceptions rather than the external click package's, so catch the vendored ones.
+from typer._click import Parameter as _ClickParameter
+from typer._click import exceptions as _click_exc
 
 from dclq import __version__
 from dclq.document import DclqError, LoadedDocument, Unit, _canonical_xpath, _is_element
@@ -74,9 +78,9 @@ def _main_callback(
     pass
 
 
-def _record_context(ctx: typer.Context, param: click.Parameter, value: int | None) -> int | None:
+def _record_context(ctx: typer.Context, param: _ClickParameter, value: int | None) -> int | None:
     """Record context flags in command-line order, matching grep semantics."""
-    if value is not None and isinstance(param, click.Option):
+    if value is not None and getattr(param, "param_type_name", None) == "option":
         ctx.meta.setdefault("context_events", []).append((param.opts[0], value))
     return value
 
@@ -347,9 +351,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     except DclqError as exc:
         print(f"dclq: {exc}", file=sys.stderr)
         return 2
-    except click.exceptions.Exit as exc:
+    except _click_exc.Exit as exc:
         return exc.exit_code
-    except click.ClickException as exc:
+    except _click_exc.ClickException as exc:
         exc.show(file=sys.stderr)
         return exc.exit_code
 

--- a/packages/dclq/tests/test_cli.py
+++ b/packages/dclq/tests/test_cli.py
@@ -259,7 +259,7 @@ def test_text_output_collapses_formatting_and_marks_truncation(tmp_path: Path, c
 
     assert main(["show", str(path), "/formula[1]", "-B", "1", "-n"]) == 0
     output = capsys.readouterr().out
-    assert "/code[1]-public  class Main {}" in output
+    assert "/code[1]-public class Main {}" in output
     assert "/formula[1]:$$E = mc^2$$" in output
     assert "/d:" not in output
     assert "\n--\n" not in output

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,8 +70,7 @@ docling-serialize = "docling_core.cli.serialize:app"
 [project.optional-dependencies]
 dclq = [
     "doclang>=0.7,<0.8",
-    "typer>=0.15.1,<0.25.0",
-    "click>=8.0.0",
+    "typer>=0.25.0,<0.27.0",
     "lxml>=6.0.2",
 ]
 chunking = [

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -208,7 +208,7 @@ def _construct_doc_impl() -> DoclingDocument:
     inline1 = doc.add_inline_group(parent=g2_subgroup_li_1)
     doc.add_text(
         label=DocItemLabel.TEXT,
-        text="Here a code snippet:",
+        text="Here a code snippet: ",
         parent=inline1,
     )
     doc.add_code(
@@ -216,17 +216,17 @@ def _construct_doc_impl() -> DoclingDocument:
         parent=inline1,
         code_language=CodeLanguageLabel.PYTHON,
     )
-    doc.add_text(label=DocItemLabel.TEXT, text="(to be displayed inline)", parent=inline1)
+    doc.add_text(label=DocItemLabel.TEXT, text=" (to be displayed inline)", parent=inline1)
 
     g2_subgroup_li_2 = doc.add_list_item(text="", parent=g2_subgroup, marker="□")
     inline2 = doc.add_inline_group(parent=g2_subgroup_li_2)
     doc.add_text(
         label=DocItemLabel.TEXT,
-        text="Here a formula:",
+        text="Here a formula: ",
         parent=inline2,
     )
     doc.add_text(label=DocItemLabel.FORMULA, text="E=mc^2", parent=inline2)
-    doc.add_text(label=DocItemLabel.TEXT, text="(to be displayed inline)", parent=inline2)
+    doc.add_text(label=DocItemLabel.TEXT, text=" (to be displayed inline)", parent=inline2)
 
     doc.add_text(label=DocItemLabel.TEXT, text="Here a code block:", parent=None)
     doc.add_code(text='print("Hello world")', parent=None, code_language=CodeLanguageLabel.PYTHON)
@@ -264,52 +264,52 @@ def _construct_doc_impl() -> DoclingDocument:
     doc.add_form(graph=graph)
 
     inline_fmt = doc.add_inline_group()
-    doc.add_text(label=DocItemLabel.TEXT, text="Some formatting chops:", parent=inline_fmt)
+    doc.add_text(label=DocItemLabel.TEXT, text="Some formatting chops: ", parent=inline_fmt)
     doc.add_text(
         label=DocItemLabel.TEXT,
-        text="bold",
+        text="bold ",
         parent=inline_fmt,
         formatting=Formatting(bold=True),
     )
     doc.add_text(
         label=DocItemLabel.TEXT,
-        text="italic",
+        text="italic ",
         parent=inline_fmt,
         formatting=Formatting(italic=True),
     )
     doc.add_text(
         label=DocItemLabel.TEXT,
-        text="underline",
+        text="underline ",
         parent=inline_fmt,
         formatting=Formatting(underline=True),
     )
     doc.add_text(
         label=DocItemLabel.TEXT,
-        text="strikethrough",
+        text="strikethrough ",
         parent=inline_fmt,
         formatting=Formatting(strikethrough=True),
     )
     doc.add_text(
         label=DocItemLabel.TEXT,
-        text="subscript",
-        orig="subscript",
+        text="subscript ",
+        orig="subscript ",
         formatting=Formatting(script=Script.SUB),
         parent=inline_fmt,
     )
     doc.add_text(
         label=DocItemLabel.TEXT,
-        text="superscript",
-        orig="superscript",
+        text="superscript ",
+        orig="superscript ",
         formatting=Formatting(script=Script.SUPER),
         parent=inline_fmt,
     )
     doc.add_text(
         label=DocItemLabel.TEXT,
-        text="hyperlink",
+        text="hyperlink ",
         parent=inline_fmt,
         hyperlink=Path("."),
     )
-    doc.add_text(label=DocItemLabel.TEXT, text="&", parent=inline_fmt)
+    doc.add_text(label=DocItemLabel.TEXT, text="& ", parent=inline_fmt)
     doc.add_text(
         label=DocItemLabel.TEXT,
         text="everything at the same time.",

--- a/test/data/doc/2206.01062.yaml.dt.json
+++ b/test/data/doc/2206.01062.yaml.dt.json
@@ -1,6 +1,6 @@
 {
   "schema_name": "DoclingDocument",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "name": "Document",
   "furniture": {
     "self_ref": "#/furniture",

--- a/test/data/doc/2408.09869v3_enriched.out.dt.json
+++ b/test/data/doc/2408.09869v3_enriched.out.dt.json
@@ -1,6 +1,6 @@
 {
   "schema_name": "DoclingDocument",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "name": "Document",
   "furniture": {
     "self_ref": "#/furniture",

--- a/test/data/doc/2408.09869v3_enriched_p2_p3_p5.gt.json
+++ b/test/data/doc/2408.09869v3_enriched_p2_p3_p5.gt.json
@@ -1,6 +1,6 @@
 {
   "schema_name": "DoclingDocument",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "name": "2408.09869v3",
   "furniture": {
     "self_ref": "#/furniture",
@@ -497,7 +497,7 @@
         }
       ],
       "orig": "To use Docling, you can simply install the docling package from PyPI. Documentation and examples are available in our GitHub repository at ",
-      "text": "To use Docling, you can simply install the docling package from PyPI. Documentation and examples are available in our GitHub repository at "
+      "text": "To use Docling, you can simply install the docling package from PyPI. Documentation and examples are available in our GitHub repository at  "
     },
     {
       "self_ref": "#/texts/9",
@@ -524,7 +524,7 @@
         }
       ],
       "orig": "github.com/DS4SD/docling",
-      "text": "github.com/DS4SD/docling",
+      "text": "github.com/DS4SD/docling ",
       "hyperlink": "https://github.com/DS4SD/docling"
     },
     {

--- a/test/data/doc/barchart.dt.out.json
+++ b/test/data/doc/barchart.dt.out.json
@@ -1,6 +1,6 @@
 {
   "schema_name": "DoclingDocument",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "name": "Document",
   "furniture": {
     "self_ref": "#/furniture",

--- a/test/data/doc/cdata_always.gt.dclg.xml
+++ b/test/data/doc/cdata_always.gt.dclg.xml
@@ -99,17 +99,17 @@ Affiliation 2]]></content>
       <ldiv>
         <marker><![CDATA[□]]></marker>
       </ldiv>
-<![CDATA[Here a code snippet:]]>      
+      <content><![CDATA[Here a code snippet: ]]></content>
       <code>
         <label value="Python"/>
 <![CDATA[print("Hello world")]]>      </code>
-<![CDATA[(to be displayed inline)]]>      
+      <content><![CDATA[ (to be displayed inline)]]></content>
       <ldiv>
         <marker><![CDATA[□]]></marker>
       </ldiv>
-<![CDATA[Here a formula:]]>      
+      <content><![CDATA[Here a formula: ]]></content>
       <formula><![CDATA[E=mc^2]]></formula>
-<![CDATA[(to be displayed inline)]]>      
+      <content><![CDATA[ (to be displayed inline)]]></content>
     </list>
   </list>
   <text><![CDATA[Here a code block:]]></text>
@@ -119,15 +119,27 @@ Affiliation 2]]></content>
   <text><![CDATA[Here a formula block:]]></text>
   <formula><![CDATA[E=mc^2]]></formula>
   <text>
-<![CDATA[Some formatting chops:]]>    
-    <bold><![CDATA[bold]]></bold>
-    <italic><![CDATA[italic]]></italic>
-    <underline><![CDATA[underline]]></underline>
-    <strikethrough><![CDATA[strikethrough]]></strikethrough>
-    <subscript><![CDATA[subscript]]></subscript>
-    <superscript><![CDATA[superscript]]></superscript>
-<![CDATA[hyperlink]]>    
-<![CDATA[&]]>    
+    <content><![CDATA[Some formatting chops: ]]></content>
+    <bold>
+      <content><![CDATA[bold ]]></content>
+    </bold>
+    <italic>
+      <content><![CDATA[italic ]]></content>
+    </italic>
+    <underline>
+      <content><![CDATA[underline ]]></content>
+    </underline>
+    <strikethrough>
+      <content><![CDATA[strikethrough ]]></content>
+    </strikethrough>
+    <subscript>
+      <content><![CDATA[subscript ]]></content>
+    </subscript>
+    <superscript>
+      <content><![CDATA[superscript ]]></content>
+    </superscript>
+    <content><![CDATA[hyperlink ]]></content>
+    <content><![CDATA[& ]]></content>
     <strikethrough>
       <underline>
         <italic>

--- a/test/data/doc/cdata_when_needed.gt.dclg.xml
+++ b/test/data/doc/cdata_when_needed.gt.dclg.xml
@@ -106,17 +106,17 @@ Affiliation 2</content>
       <ldiv>
         <marker>□</marker>
       </ldiv>
-      Here a code snippet:
+      <content>Here a code snippet: </content>
       <code>
         <label value="Python"/>
 <![CDATA[print("Hello world")]]>      </code>
-(to be displayed inline)
+      <content> (to be displayed inline)</content>
       <ldiv>
         <marker>□</marker>
       </ldiv>
-      Here a formula:
+      <content>Here a formula: </content>
       <formula>E=mc^2</formula>
-(to be displayed inline)
+      <content> (to be displayed inline)</content>
     </list>
   </list>
   <text>Here a code block:</text>
@@ -126,15 +126,27 @@ Affiliation 2</content>
   <text>Here a formula block:</text>
   <formula>E=mc^2</formula>
   <text>
-    Some formatting chops:
-    <bold>bold</bold>
-    <italic>italic</italic>
-    <underline>underline</underline>
-    <strikethrough>strikethrough</strikethrough>
-    <subscript>subscript</subscript>
-    <superscript>superscript</superscript>
-hyperlink
-<![CDATA[&]]>    
+    <content>Some formatting chops: </content>
+    <bold>
+      <content>bold </content>
+    </bold>
+    <italic>
+      <content>italic </content>
+    </italic>
+    <underline>
+      <content>underline </content>
+    </underline>
+    <strikethrough>
+      <content>strikethrough </content>
+    </strikethrough>
+    <subscript>
+      <content>subscript </content>
+    </subscript>
+    <superscript>
+      <content>superscript </content>
+    </superscript>
+    <content>hyperlink </content>
+    <content><![CDATA[& ]]></content>
     <strikethrough>
       <underline>
         <italic>

--- a/test/data/doc/concatenated.json
+++ b/test/data/doc/concatenated.json
@@ -1,6 +1,6 @@
 {
   "schema_name": "DoclingDocument",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "name": "2501.17887v1 + Untitled 1 + 2311.18481v1",
   "furniture": {
     "self_ref": "#/furniture",
@@ -9335,8 +9335,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "Here a code snippet:",
-      "text": "Here a code snippet:"
+      "orig": "Here a code snippet: ",
+      "text": "Here a code snippet: "
     },
     {
       "self_ref": "#/texts/313",
@@ -9363,8 +9363,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "(to be displayed inline)",
-      "text": "(to be displayed inline)"
+      "orig": " (to be displayed inline)",
+      "text": " (to be displayed inline)"
     },
     {
       "self_ref": "#/texts/315",
@@ -9393,8 +9393,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "Here a formula:",
-      "text": "Here a formula:"
+      "orig": "Here a formula: ",
+      "text": "Here a formula: "
     },
     {
       "self_ref": "#/texts/317",
@@ -9417,8 +9417,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "(to be displayed inline)",
-      "text": "(to be displayed inline)"
+      "orig": " (to be displayed inline)",
+      "text": " (to be displayed inline)"
     },
     {
       "self_ref": "#/texts/319",
@@ -9481,8 +9481,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "Some formatting chops:",
-      "text": "Some formatting chops:"
+      "orig": "Some formatting chops: ",
+      "text": "Some formatting chops: "
     },
     {
       "self_ref": "#/texts/324",
@@ -9493,8 +9493,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "bold",
-      "text": "bold",
+      "orig": "bold ",
+      "text": "bold ",
       "formatting": {
         "bold": true,
         "italic": false,
@@ -9512,8 +9512,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "italic",
-      "text": "italic",
+      "orig": "italic ",
+      "text": "italic ",
       "formatting": {
         "bold": false,
         "italic": true,
@@ -9531,8 +9531,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "underline",
-      "text": "underline",
+      "orig": "underline ",
+      "text": "underline ",
       "formatting": {
         "bold": false,
         "italic": false,
@@ -9550,8 +9550,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "strikethrough",
-      "text": "strikethrough",
+      "orig": "strikethrough ",
+      "text": "strikethrough ",
       "formatting": {
         "bold": false,
         "italic": false,
@@ -9569,8 +9569,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "subscript",
-      "text": "subscript",
+      "orig": "subscript ",
+      "text": "subscript ",
       "formatting": {
         "bold": false,
         "italic": false,
@@ -9588,8 +9588,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "superscript",
-      "text": "superscript",
+      "orig": "superscript ",
+      "text": "superscript ",
       "formatting": {
         "bold": false,
         "italic": false,
@@ -9607,8 +9607,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "hyperlink",
-      "text": "hyperlink",
+      "orig": "hyperlink ",
+      "text": "hyperlink ",
       "hyperlink": "."
     },
     {
@@ -9620,8 +9620,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "&",
-      "text": "&"
+      "orig": "& ",
+      "text": "& "
     },
     {
       "self_ref": "#/texts/332",

--- a/test/data/doc/constr_doc_reserialized.dclg.xml
+++ b/test/data/doc/constr_doc_reserialized.dclg.xml
@@ -105,17 +105,17 @@ Affiliation 2</content>
       <ldiv>
         <marker>□</marker>
       </ldiv>
-      Here a code snippet:
+      <content>Here a code snippet: </content>
       <code>
         <label value="Python"/>
 <![CDATA[print("Hello world")]]>      </code>
-(to be displayed inline)
+      <content> (to be displayed inline)</content>
       <ldiv>
         <marker>□</marker>
       </ldiv>
-      Here a formula:
+      <content>Here a formula: </content>
       <formula>E=mc^2</formula>
-(to be displayed inline)
+      <content> (to be displayed inline)</content>
     </list>
   </list>
   <text>Here a code block:</text>
@@ -125,15 +125,27 @@ Affiliation 2</content>
   <text>Here a formula block:</text>
   <formula>E=mc^2</formula>
   <text>
-    Some formatting chops:
-    <bold>bold</bold>
-    <italic>italic</italic>
-    <underline>underline</underline>
-    <strikethrough>strikethrough</strikethrough>
-    <subscript>subscript</subscript>
-    <superscript>superscript</superscript>
-hyperlink
-<![CDATA[&]]>    
+    <content>Some formatting chops: </content>
+    <bold>
+      <content>bold </content>
+    </bold>
+    <italic>
+      <content>italic </content>
+    </italic>
+    <underline>
+      <content>underline </content>
+    </underline>
+    <strikethrough>
+      <content>strikethrough </content>
+    </strikethrough>
+    <subscript>
+      <content>subscript </content>
+    </subscript>
+    <superscript>
+      <content>superscript </content>
+    </superscript>
+    <content>hyperlink </content>
+    <content><![CDATA[& ]]></content>
     <strikethrough>
       <underline>
         <italic>

--- a/test/data/doc/constructed_doc.added_extracted_doc.json.gt
+++ b/test/data/doc/constructed_doc.added_extracted_doc.json.gt
@@ -1,6 +1,6 @@
 {
   "schema_name": "DoclingDocument",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "name": "Untitled 1",
   "furniture": {
     "self_ref": "#/furniture",
@@ -715,8 +715,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "Here a code snippet:",
-      "text": "Here a code snippet:"
+      "orig": "Here a code snippet: ",
+      "text": "Here a code snippet: "
     },
     {
       "self_ref": "#/texts/15",
@@ -743,8 +743,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "(to be displayed inline)",
-      "text": "(to be displayed inline)"
+      "orig": " (to be displayed inline)",
+      "text": " (to be displayed inline)"
     },
     {
       "self_ref": "#/texts/17",
@@ -773,8 +773,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "Here a formula:",
-      "text": "Here a formula:"
+      "orig": "Here a formula: ",
+      "text": "Here a formula: "
     },
     {
       "self_ref": "#/texts/19",
@@ -797,8 +797,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "(to be displayed inline)",
-      "text": "(to be displayed inline)"
+      "orig": " (to be displayed inline)",
+      "text": " (to be displayed inline)"
     },
     {
       "self_ref": "#/texts/21",
@@ -861,8 +861,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "Some formatting chops:",
-      "text": "Some formatting chops:"
+      "orig": "Some formatting chops: ",
+      "text": "Some formatting chops: "
     },
     {
       "self_ref": "#/texts/26",
@@ -873,8 +873,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "bold",
-      "text": "bold",
+      "orig": "bold ",
+      "text": "bold ",
       "formatting": {
         "bold": true,
         "italic": false,
@@ -892,8 +892,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "italic",
-      "text": "italic",
+      "orig": "italic ",
+      "text": "italic ",
       "formatting": {
         "bold": false,
         "italic": true,
@@ -911,8 +911,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "underline",
-      "text": "underline",
+      "orig": "underline ",
+      "text": "underline ",
       "formatting": {
         "bold": false,
         "italic": false,
@@ -930,8 +930,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "strikethrough",
-      "text": "strikethrough",
+      "orig": "strikethrough ",
+      "text": "strikethrough ",
       "formatting": {
         "bold": false,
         "italic": false,
@@ -949,8 +949,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "subscript",
-      "text": "subscript",
+      "orig": "subscript ",
+      "text": "subscript ",
       "formatting": {
         "bold": false,
         "italic": false,
@@ -968,8 +968,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "superscript",
-      "text": "superscript",
+      "orig": "superscript ",
+      "text": "superscript ",
       "formatting": {
         "bold": false,
         "italic": false,
@@ -987,8 +987,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "hyperlink",
-      "text": "hyperlink",
+      "orig": "hyperlink ",
+      "text": "hyperlink ",
       "hyperlink": "."
     },
     {
@@ -1000,8 +1000,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "&",
-      "text": "&"
+      "orig": "& ",
+      "text": "& "
     },
     {
       "self_ref": "#/texts/34",

--- a/test/data/doc/constructed_doc.appended_child.json.gt
+++ b/test/data/doc/constructed_doc.appended_child.json.gt
@@ -1,6 +1,6 @@
 {
   "schema_name": "DoclingDocument",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "name": "Untitled 1",
   "furniture": {
     "self_ref": "#/furniture",
@@ -544,8 +544,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "Here a code snippet:",
-      "text": "Here a code snippet:"
+      "orig": "Here a code snippet: ",
+      "text": "Here a code snippet: "
     },
     {
       "self_ref": "#/texts/15",
@@ -572,8 +572,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "(to be displayed inline)",
-      "text": "(to be displayed inline)"
+      "orig": " (to be displayed inline)",
+      "text": " (to be displayed inline)"
     },
     {
       "self_ref": "#/texts/17",
@@ -602,8 +602,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "Here a formula:",
-      "text": "Here a formula:"
+      "orig": "Here a formula: ",
+      "text": "Here a formula: "
     },
     {
       "self_ref": "#/texts/19",
@@ -626,8 +626,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "(to be displayed inline)",
-      "text": "(to be displayed inline)"
+      "orig": " (to be displayed inline)",
+      "text": " (to be displayed inline)"
     },
     {
       "self_ref": "#/texts/21",
@@ -690,8 +690,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "Some formatting chops:",
-      "text": "Some formatting chops:"
+      "orig": "Some formatting chops: ",
+      "text": "Some formatting chops: "
     },
     {
       "self_ref": "#/texts/26",
@@ -702,8 +702,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "bold",
-      "text": "bold",
+      "orig": "bold ",
+      "text": "bold ",
       "formatting": {
         "bold": true,
         "italic": false,
@@ -721,8 +721,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "italic",
-      "text": "italic",
+      "orig": "italic ",
+      "text": "italic ",
       "formatting": {
         "bold": false,
         "italic": true,
@@ -740,8 +740,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "underline",
-      "text": "underline",
+      "orig": "underline ",
+      "text": "underline ",
       "formatting": {
         "bold": false,
         "italic": false,
@@ -759,8 +759,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "strikethrough",
-      "text": "strikethrough",
+      "orig": "strikethrough ",
+      "text": "strikethrough ",
       "formatting": {
         "bold": false,
         "italic": false,
@@ -778,8 +778,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "subscript",
-      "text": "subscript",
+      "orig": "subscript ",
+      "text": "subscript ",
       "formatting": {
         "bold": false,
         "italic": false,
@@ -797,8 +797,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "superscript",
-      "text": "superscript",
+      "orig": "superscript ",
+      "text": "superscript ",
       "formatting": {
         "bold": false,
         "italic": false,
@@ -816,8 +816,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "hyperlink",
-      "text": "hyperlink",
+      "orig": "hyperlink ",
+      "text": "hyperlink ",
       "hyperlink": "."
     },
     {
@@ -829,8 +829,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "&",
-      "text": "&"
+      "orig": "& ",
+      "text": "& "
     },
     {
       "self_ref": "#/texts/34",

--- a/test/data/doc/constructed_doc.bulk_item_addition.json.gt
+++ b/test/data/doc/constructed_doc.bulk_item_addition.json.gt
@@ -1,6 +1,6 @@
 {
   "schema_name": "DoclingDocument",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "name": "Untitled 1",
   "furniture": {
     "self_ref": "#/furniture",
@@ -708,8 +708,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "Here a code snippet:",
-      "text": "Here a code snippet:"
+      "orig": "Here a code snippet: ",
+      "text": "Here a code snippet: "
     },
     {
       "self_ref": "#/texts/15",
@@ -736,8 +736,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "(to be displayed inline)",
-      "text": "(to be displayed inline)"
+      "orig": " (to be displayed inline)",
+      "text": " (to be displayed inline)"
     },
     {
       "self_ref": "#/texts/17",
@@ -766,8 +766,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "Here a formula:",
-      "text": "Here a formula:"
+      "orig": "Here a formula: ",
+      "text": "Here a formula: "
     },
     {
       "self_ref": "#/texts/19",
@@ -790,8 +790,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "(to be displayed inline)",
-      "text": "(to be displayed inline)"
+      "orig": " (to be displayed inline)",
+      "text": " (to be displayed inline)"
     },
     {
       "self_ref": "#/texts/21",
@@ -854,8 +854,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "Some formatting chops:",
-      "text": "Some formatting chops:"
+      "orig": "Some formatting chops: ",
+      "text": "Some formatting chops: "
     },
     {
       "self_ref": "#/texts/26",
@@ -866,8 +866,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "bold",
-      "text": "bold",
+      "orig": "bold ",
+      "text": "bold ",
       "formatting": {
         "bold": true,
         "italic": false,
@@ -885,8 +885,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "italic",
-      "text": "italic",
+      "orig": "italic ",
+      "text": "italic ",
       "formatting": {
         "bold": false,
         "italic": true,
@@ -904,8 +904,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "underline",
-      "text": "underline",
+      "orig": "underline ",
+      "text": "underline ",
       "formatting": {
         "bold": false,
         "italic": false,
@@ -923,8 +923,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "strikethrough",
-      "text": "strikethrough",
+      "orig": "strikethrough ",
+      "text": "strikethrough ",
       "formatting": {
         "bold": false,
         "italic": false,
@@ -942,8 +942,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "subscript",
-      "text": "subscript",
+      "orig": "subscript ",
+      "text": "subscript ",
       "formatting": {
         "bold": false,
         "italic": false,
@@ -961,8 +961,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "superscript",
-      "text": "superscript",
+      "orig": "superscript ",
+      "text": "superscript ",
       "formatting": {
         "bold": false,
         "italic": false,
@@ -980,8 +980,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "hyperlink",
-      "text": "hyperlink",
+      "orig": "hyperlink ",
+      "text": "hyperlink ",
       "hyperlink": "."
     },
     {
@@ -993,8 +993,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "&",
-      "text": "&"
+      "orig": "& ",
+      "text": "& "
     },
     {
       "self_ref": "#/texts/34",

--- a/test/data/doc/constructed_doc.bulk_item_insertion.json.gt
+++ b/test/data/doc/constructed_doc.bulk_item_insertion.json.gt
@@ -1,6 +1,6 @@
 {
   "schema_name": "DoclingDocument",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "name": "Untitled 1",
   "furniture": {
     "self_ref": "#/furniture",
@@ -714,8 +714,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "Here a code snippet:",
-      "text": "Here a code snippet:"
+      "orig": "Here a code snippet: ",
+      "text": "Here a code snippet: "
     },
     {
       "self_ref": "#/texts/15",
@@ -742,8 +742,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "(to be displayed inline)",
-      "text": "(to be displayed inline)"
+      "orig": " (to be displayed inline)",
+      "text": " (to be displayed inline)"
     },
     {
       "self_ref": "#/texts/17",
@@ -772,8 +772,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "Here a formula:",
-      "text": "Here a formula:"
+      "orig": "Here a formula: ",
+      "text": "Here a formula: "
     },
     {
       "self_ref": "#/texts/19",
@@ -796,8 +796,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "(to be displayed inline)",
-      "text": "(to be displayed inline)"
+      "orig": " (to be displayed inline)",
+      "text": " (to be displayed inline)"
     },
     {
       "self_ref": "#/texts/21",
@@ -860,8 +860,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "Some formatting chops:",
-      "text": "Some formatting chops:"
+      "orig": "Some formatting chops: ",
+      "text": "Some formatting chops: "
     },
     {
       "self_ref": "#/texts/26",
@@ -872,8 +872,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "bold",
-      "text": "bold",
+      "orig": "bold ",
+      "text": "bold ",
       "formatting": {
         "bold": true,
         "italic": false,
@@ -891,8 +891,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "italic",
-      "text": "italic",
+      "orig": "italic ",
+      "text": "italic ",
       "formatting": {
         "bold": false,
         "italic": true,
@@ -910,8 +910,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "underline",
-      "text": "underline",
+      "orig": "underline ",
+      "text": "underline ",
       "formatting": {
         "bold": false,
         "italic": false,
@@ -929,8 +929,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "strikethrough",
-      "text": "strikethrough",
+      "orig": "strikethrough ",
+      "text": "strikethrough ",
       "formatting": {
         "bold": false,
         "italic": false,
@@ -948,8 +948,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "subscript",
-      "text": "subscript",
+      "orig": "subscript ",
+      "text": "subscript ",
       "formatting": {
         "bold": false,
         "italic": false,
@@ -967,8 +967,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "superscript",
-      "text": "superscript",
+      "orig": "superscript ",
+      "text": "superscript ",
       "formatting": {
         "bold": false,
         "italic": false,
@@ -986,8 +986,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "hyperlink",
-      "text": "hyperlink",
+      "orig": "hyperlink ",
+      "text": "hyperlink ",
       "hyperlink": "."
     },
     {
@@ -999,8 +999,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "&",
-      "text": "&"
+      "orig": "& ",
+      "text": "& "
     },
     {
       "self_ref": "#/texts/34",

--- a/test/data/doc/constructed_doc.deleted_group.json.gt
+++ b/test/data/doc/constructed_doc.deleted_group.json.gt
@@ -1,6 +1,6 @@
 {
   "schema_name": "DoclingDocument",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "name": "Untitled 1",
   "furniture": {
     "self_ref": "#/furniture",
@@ -541,8 +541,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "Here a code snippet:",
-      "text": "Here a code snippet:"
+      "orig": "Here a code snippet: ",
+      "text": "Here a code snippet: "
     },
     {
       "self_ref": "#/texts/15",
@@ -569,8 +569,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "(to be displayed inline)",
-      "text": "(to be displayed inline)"
+      "orig": " (to be displayed inline)",
+      "text": " (to be displayed inline)"
     },
     {
       "self_ref": "#/texts/17",
@@ -599,8 +599,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "Here a formula:",
-      "text": "Here a formula:"
+      "orig": "Here a formula: ",
+      "text": "Here a formula: "
     },
     {
       "self_ref": "#/texts/19",
@@ -623,8 +623,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "(to be displayed inline)",
-      "text": "(to be displayed inline)"
+      "orig": " (to be displayed inline)",
+      "text": " (to be displayed inline)"
     },
     {
       "self_ref": "#/texts/21",
@@ -687,8 +687,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "Some formatting chops:",
-      "text": "Some formatting chops:"
+      "orig": "Some formatting chops: ",
+      "text": "Some formatting chops: "
     },
     {
       "self_ref": "#/texts/26",
@@ -699,8 +699,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "bold",
-      "text": "bold",
+      "orig": "bold ",
+      "text": "bold ",
       "formatting": {
         "bold": true,
         "italic": false,
@@ -718,8 +718,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "italic",
-      "text": "italic",
+      "orig": "italic ",
+      "text": "italic ",
       "formatting": {
         "bold": false,
         "italic": true,
@@ -737,8 +737,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "underline",
-      "text": "underline",
+      "orig": "underline ",
+      "text": "underline ",
       "formatting": {
         "bold": false,
         "italic": false,
@@ -756,8 +756,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "strikethrough",
-      "text": "strikethrough",
+      "orig": "strikethrough ",
+      "text": "strikethrough ",
       "formatting": {
         "bold": false,
         "italic": false,
@@ -775,8 +775,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "subscript",
-      "text": "subscript",
+      "orig": "subscript ",
+      "text": "subscript ",
       "formatting": {
         "bold": false,
         "italic": false,
@@ -794,8 +794,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "superscript",
-      "text": "superscript",
+      "orig": "superscript ",
+      "text": "superscript ",
       "formatting": {
         "bold": false,
         "italic": false,
@@ -813,8 +813,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "hyperlink",
-      "text": "hyperlink",
+      "orig": "hyperlink ",
+      "text": "hyperlink ",
       "hyperlink": "."
     },
     {
@@ -826,8 +826,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "&",
-      "text": "&"
+      "orig": "& ",
+      "text": "& "
     },
     {
       "self_ref": "#/texts/34",

--- a/test/data/doc/constructed_doc.deleted_items_range.json.gt
+++ b/test/data/doc/constructed_doc.deleted_items_range.json.gt
@@ -1,6 +1,6 @@
 {
   "schema_name": "DoclingDocument",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "name": "Untitled 1",
   "furniture": {
     "self_ref": "#/furniture",
@@ -544,8 +544,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "Here a code snippet:",
-      "text": "Here a code snippet:"
+      "orig": "Here a code snippet: ",
+      "text": "Here a code snippet: "
     },
     {
       "self_ref": "#/texts/15",
@@ -572,8 +572,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "(to be displayed inline)",
-      "text": "(to be displayed inline)"
+      "orig": " (to be displayed inline)",
+      "text": " (to be displayed inline)"
     },
     {
       "self_ref": "#/texts/17",
@@ -602,8 +602,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "Here a formula:",
-      "text": "Here a formula:"
+      "orig": "Here a formula: ",
+      "text": "Here a formula: "
     },
     {
       "self_ref": "#/texts/19",
@@ -626,8 +626,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "(to be displayed inline)",
-      "text": "(to be displayed inline)"
+      "orig": " (to be displayed inline)",
+      "text": " (to be displayed inline)"
     },
     {
       "self_ref": "#/texts/21",
@@ -690,8 +690,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "Some formatting chops:",
-      "text": "Some formatting chops:"
+      "orig": "Some formatting chops: ",
+      "text": "Some formatting chops: "
     },
     {
       "self_ref": "#/texts/26",
@@ -702,8 +702,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "bold",
-      "text": "bold",
+      "orig": "bold ",
+      "text": "bold ",
       "formatting": {
         "bold": true,
         "italic": false,
@@ -721,8 +721,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "italic",
-      "text": "italic",
+      "orig": "italic ",
+      "text": "italic ",
       "formatting": {
         "bold": false,
         "italic": true,
@@ -740,8 +740,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "underline",
-      "text": "underline",
+      "orig": "underline ",
+      "text": "underline ",
       "formatting": {
         "bold": false,
         "italic": false,
@@ -759,8 +759,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "strikethrough",
-      "text": "strikethrough",
+      "orig": "strikethrough ",
+      "text": "strikethrough ",
       "formatting": {
         "bold": false,
         "italic": false,
@@ -778,8 +778,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "subscript",
-      "text": "subscript",
+      "orig": "subscript ",
+      "text": "subscript ",
       "formatting": {
         "bold": false,
         "italic": false,
@@ -797,8 +797,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "superscript",
-      "text": "superscript",
+      "orig": "superscript ",
+      "text": "superscript ",
       "formatting": {
         "bold": false,
         "italic": false,
@@ -816,8 +816,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "hyperlink",
-      "text": "hyperlink",
+      "orig": "hyperlink ",
+      "text": "hyperlink ",
       "hyperlink": "."
     },
     {
@@ -829,8 +829,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "&",
-      "text": "&"
+      "orig": "& ",
+      "text": "& "
     },
     {
       "self_ref": "#/texts/34",

--- a/test/data/doc/constructed_doc.deleted_picture.json.gt
+++ b/test/data/doc/constructed_doc.deleted_picture.json.gt
@@ -1,6 +1,6 @@
 {
   "schema_name": "DoclingDocument",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "name": "Untitled 1",
   "furniture": {
     "self_ref": "#/furniture",
@@ -538,8 +538,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "Here a code snippet:",
-      "text": "Here a code snippet:"
+      "orig": "Here a code snippet: ",
+      "text": "Here a code snippet: "
     },
     {
       "self_ref": "#/texts/15",
@@ -566,8 +566,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "(to be displayed inline)",
-      "text": "(to be displayed inline)"
+      "orig": " (to be displayed inline)",
+      "text": " (to be displayed inline)"
     },
     {
       "self_ref": "#/texts/17",
@@ -596,8 +596,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "Here a formula:",
-      "text": "Here a formula:"
+      "orig": "Here a formula: ",
+      "text": "Here a formula: "
     },
     {
       "self_ref": "#/texts/19",
@@ -620,8 +620,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "(to be displayed inline)",
-      "text": "(to be displayed inline)"
+      "orig": " (to be displayed inline)",
+      "text": " (to be displayed inline)"
     },
     {
       "self_ref": "#/texts/21",
@@ -684,8 +684,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "Some formatting chops:",
-      "text": "Some formatting chops:"
+      "orig": "Some formatting chops: ",
+      "text": "Some formatting chops: "
     },
     {
       "self_ref": "#/texts/26",
@@ -696,8 +696,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "bold",
-      "text": "bold",
+      "orig": "bold ",
+      "text": "bold ",
       "formatting": {
         "bold": true,
         "italic": false,
@@ -715,8 +715,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "italic",
-      "text": "italic",
+      "orig": "italic ",
+      "text": "italic ",
       "formatting": {
         "bold": false,
         "italic": true,
@@ -734,8 +734,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "underline",
-      "text": "underline",
+      "orig": "underline ",
+      "text": "underline ",
       "formatting": {
         "bold": false,
         "italic": false,
@@ -753,8 +753,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "strikethrough",
-      "text": "strikethrough",
+      "orig": "strikethrough ",
+      "text": "strikethrough ",
       "formatting": {
         "bold": false,
         "italic": false,
@@ -772,8 +772,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "subscript",
-      "text": "subscript",
+      "orig": "subscript ",
+      "text": "subscript ",
       "formatting": {
         "bold": false,
         "italic": false,
@@ -791,8 +791,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "superscript",
-      "text": "superscript",
+      "orig": "superscript ",
+      "text": "superscript ",
       "formatting": {
         "bold": false,
         "italic": false,
@@ -810,8 +810,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "hyperlink",
-      "text": "hyperlink",
+      "orig": "hyperlink ",
+      "text": "hyperlink ",
       "hyperlink": "."
     },
     {
@@ -823,8 +823,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "&",
-      "text": "&"
+      "orig": "& ",
+      "text": "& "
     },
     {
       "self_ref": "#/texts/34",

--- a/test/data/doc/constructed_doc.deleted_text.json.gt
+++ b/test/data/doc/constructed_doc.deleted_text.json.gt
@@ -1,6 +1,6 @@
 {
   "schema_name": "DoclingDocument",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "name": "Untitled 1",
   "furniture": {
     "self_ref": "#/furniture",
@@ -755,8 +755,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "Here a code snippet:",
-      "text": "Here a code snippet:"
+      "orig": "Here a code snippet: ",
+      "text": "Here a code snippet: "
     },
     {
       "self_ref": "#/texts/24",
@@ -783,8 +783,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "(to be displayed inline)",
-      "text": "(to be displayed inline)"
+      "orig": " (to be displayed inline)",
+      "text": " (to be displayed inline)"
     },
     {
       "self_ref": "#/texts/26",
@@ -813,8 +813,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "Here a formula:",
-      "text": "Here a formula:"
+      "orig": "Here a formula: ",
+      "text": "Here a formula: "
     },
     {
       "self_ref": "#/texts/28",
@@ -837,8 +837,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "(to be displayed inline)",
-      "text": "(to be displayed inline)"
+      "orig": " (to be displayed inline)",
+      "text": " (to be displayed inline)"
     },
     {
       "self_ref": "#/texts/30",
@@ -901,8 +901,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "Some formatting chops:",
-      "text": "Some formatting chops:"
+      "orig": "Some formatting chops: ",
+      "text": "Some formatting chops: "
     },
     {
       "self_ref": "#/texts/35",
@@ -913,8 +913,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "bold",
-      "text": "bold",
+      "orig": "bold ",
+      "text": "bold ",
       "formatting": {
         "bold": true,
         "italic": false,
@@ -932,8 +932,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "italic",
-      "text": "italic",
+      "orig": "italic ",
+      "text": "italic ",
       "formatting": {
         "bold": false,
         "italic": true,
@@ -951,8 +951,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "underline",
-      "text": "underline",
+      "orig": "underline ",
+      "text": "underline ",
       "formatting": {
         "bold": false,
         "italic": false,
@@ -970,8 +970,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "strikethrough",
-      "text": "strikethrough",
+      "orig": "strikethrough ",
+      "text": "strikethrough ",
       "formatting": {
         "bold": false,
         "italic": false,
@@ -989,8 +989,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "subscript",
-      "text": "subscript",
+      "orig": "subscript ",
+      "text": "subscript ",
       "formatting": {
         "bold": false,
         "italic": false,
@@ -1008,8 +1008,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "superscript",
-      "text": "superscript",
+      "orig": "superscript ",
+      "text": "superscript ",
       "formatting": {
         "bold": false,
         "italic": false,
@@ -1027,8 +1027,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "hyperlink",
-      "text": "hyperlink",
+      "orig": "hyperlink ",
+      "text": "hyperlink ",
       "hyperlink": "."
     },
     {
@@ -1040,8 +1040,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "&",
-      "text": "&"
+      "orig": "& ",
+      "text": "& "
     },
     {
       "self_ref": "#/texts/43",

--- a/test/data/doc/constructed_doc.embedded.json.gt
+++ b/test/data/doc/constructed_doc.embedded.json.gt
@@ -1,6 +1,6 @@
 {
   "schema_name": "DoclingDocument",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "name": "Untitled 1",
   "furniture": {
     "self_ref": "#/furniture",
@@ -766,8 +766,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "Here a code snippet:",
-      "text": "Here a code snippet:"
+      "orig": "Here a code snippet: ",
+      "text": "Here a code snippet: "
     },
     {
       "self_ref": "#/texts/25",
@@ -794,8 +794,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "(to be displayed inline)",
-      "text": "(to be displayed inline)"
+      "orig": " (to be displayed inline)",
+      "text": " (to be displayed inline)"
     },
     {
       "self_ref": "#/texts/27",
@@ -824,8 +824,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "Here a formula:",
-      "text": "Here a formula:"
+      "orig": "Here a formula: ",
+      "text": "Here a formula: "
     },
     {
       "self_ref": "#/texts/29",
@@ -848,8 +848,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "(to be displayed inline)",
-      "text": "(to be displayed inline)"
+      "orig": " (to be displayed inline)",
+      "text": " (to be displayed inline)"
     },
     {
       "self_ref": "#/texts/31",
@@ -912,8 +912,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "Some formatting chops:",
-      "text": "Some formatting chops:"
+      "orig": "Some formatting chops: ",
+      "text": "Some formatting chops: "
     },
     {
       "self_ref": "#/texts/36",
@@ -924,8 +924,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "bold",
-      "text": "bold",
+      "orig": "bold ",
+      "text": "bold ",
       "formatting": {
         "bold": true,
         "italic": false,
@@ -943,8 +943,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "italic",
-      "text": "italic",
+      "orig": "italic ",
+      "text": "italic ",
       "formatting": {
         "bold": false,
         "italic": true,
@@ -962,8 +962,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "underline",
-      "text": "underline",
+      "orig": "underline ",
+      "text": "underline ",
       "formatting": {
         "bold": false,
         "italic": false,
@@ -981,8 +981,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "strikethrough",
-      "text": "strikethrough",
+      "orig": "strikethrough ",
+      "text": "strikethrough ",
       "formatting": {
         "bold": false,
         "italic": false,
@@ -1000,8 +1000,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "subscript",
-      "text": "subscript",
+      "orig": "subscript ",
+      "text": "subscript ",
       "formatting": {
         "bold": false,
         "italic": false,
@@ -1019,8 +1019,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "superscript",
-      "text": "superscript",
+      "orig": "superscript ",
+      "text": "superscript ",
       "formatting": {
         "bold": false,
         "italic": false,
@@ -1038,8 +1038,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "hyperlink",
-      "text": "hyperlink",
+      "orig": "hyperlink ",
+      "text": "hyperlink ",
       "hyperlink": "."
     },
     {
@@ -1051,8 +1051,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "&",
-      "text": "&"
+      "orig": "& ",
+      "text": "& "
     },
     {
       "self_ref": "#/texts/44",

--- a/test/data/doc/constructed_doc.embedded.yaml.gt
+++ b/test/data/doc/constructed_doc.embedded.yaml.gt
@@ -752,12 +752,12 @@ texts:
 - children: []
   content_layer: body
   label: text
-  orig: 'Here a code snippet:'
+  orig: 'Here a code snippet: '
   parent:
     $ref: '#/groups/10'
   prov: []
   self_ref: '#/texts/24'
-  text: 'Here a code snippet:'
+  text: 'Here a code snippet: '
 - captions: []
   children: []
   code_language: Python
@@ -774,12 +774,12 @@ texts:
 - children: []
   content_layer: body
   label: text
-  orig: (to be displayed inline)
+  orig: ' (to be displayed inline)'
   parent:
     $ref: '#/groups/10'
   prov: []
   self_ref: '#/texts/26'
-  text: (to be displayed inline)
+  text: ' (to be displayed inline)'
 - children:
   - $ref: '#/groups/11'
   content_layer: body
@@ -795,12 +795,12 @@ texts:
 - children: []
   content_layer: body
   label: text
-  orig: 'Here a formula:'
+  orig: 'Here a formula: '
   parent:
     $ref: '#/groups/11'
   prov: []
   self_ref: '#/texts/28'
-  text: 'Here a formula:'
+  text: 'Here a formula: '
 - children: []
   content_layer: body
   label: formula
@@ -813,12 +813,12 @@ texts:
 - children: []
   content_layer: body
   label: text
-  orig: (to be displayed inline)
+  orig: ' (to be displayed inline)'
   parent:
     $ref: '#/groups/11'
   prov: []
   self_ref: '#/texts/30'
-  text: (to be displayed inline)
+  text: ' (to be displayed inline)'
 - children: []
   content_layer: body
   label: text
@@ -862,12 +862,12 @@ texts:
 - children: []
   content_layer: body
   label: text
-  orig: 'Some formatting chops:'
+  orig: 'Some formatting chops: '
   parent:
     $ref: '#/groups/12'
   prov: []
   self_ref: '#/texts/35'
-  text: 'Some formatting chops:'
+  text: 'Some formatting chops: '
 - children: []
   content_layer: body
   formatting:
@@ -877,12 +877,12 @@ texts:
     strikethrough: false
     underline: false
   label: text
-  orig: bold
+  orig: 'bold '
   parent:
     $ref: '#/groups/12'
   prov: []
   self_ref: '#/texts/36'
-  text: bold
+  text: 'bold '
 - children: []
   content_layer: body
   formatting:
@@ -892,12 +892,12 @@ texts:
     strikethrough: false
     underline: false
   label: text
-  orig: italic
+  orig: 'italic '
   parent:
     $ref: '#/groups/12'
   prov: []
   self_ref: '#/texts/37'
-  text: italic
+  text: 'italic '
 - children: []
   content_layer: body
   formatting:
@@ -907,12 +907,12 @@ texts:
     strikethrough: false
     underline: true
   label: text
-  orig: underline
+  orig: 'underline '
   parent:
     $ref: '#/groups/12'
   prov: []
   self_ref: '#/texts/38'
-  text: underline
+  text: 'underline '
 - children: []
   content_layer: body
   formatting:
@@ -922,12 +922,12 @@ texts:
     strikethrough: true
     underline: false
   label: text
-  orig: strikethrough
+  orig: 'strikethrough '
   parent:
     $ref: '#/groups/12'
   prov: []
   self_ref: '#/texts/39'
-  text: strikethrough
+  text: 'strikethrough '
 - children: []
   content_layer: body
   formatting:
@@ -937,12 +937,12 @@ texts:
     strikethrough: false
     underline: false
   label: text
-  orig: subscript
+  orig: 'subscript '
   parent:
     $ref: '#/groups/12'
   prov: []
   self_ref: '#/texts/40'
-  text: subscript
+  text: 'subscript '
 - children: []
   content_layer: body
   formatting:
@@ -952,31 +952,31 @@ texts:
     strikethrough: false
     underline: false
   label: text
-  orig: superscript
+  orig: 'superscript '
   parent:
     $ref: '#/groups/12'
   prov: []
   self_ref: '#/texts/41'
-  text: superscript
+  text: 'superscript '
 - children: []
   content_layer: body
   hyperlink: .
   label: text
-  orig: hyperlink
+  orig: 'hyperlink '
   parent:
     $ref: '#/groups/12'
   prov: []
   self_ref: '#/texts/42'
-  text: hyperlink
+  text: 'hyperlink '
 - children: []
   content_layer: body
   label: text
-  orig: '&'
+  orig: '& '
   parent:
     $ref: '#/groups/12'
   prov: []
   self_ref: '#/texts/43'
-  text: '&'
+  text: '& '
 - children: []
   content_layer: body
   formatting:
@@ -1114,4 +1114,4 @@ texts:
   prov: []
   self_ref: '#/texts/55'
   text: The end.
-version: 1.10.0
+version: 1.11.0

--- a/test/data/doc/constructed_doc.extracted_with_deletion.json.gt
+++ b/test/data/doc/constructed_doc.extracted_with_deletion.json.gt
@@ -1,6 +1,6 @@
 {
   "schema_name": "DoclingDocument",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "name": "Untitled 1",
   "furniture": {
     "self_ref": "#/furniture",
@@ -621,8 +621,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "Here a code snippet:",
-      "text": "Here a code snippet:"
+      "orig": "Here a code snippet: ",
+      "text": "Here a code snippet: "
     },
     {
       "self_ref": "#/texts/15",
@@ -649,8 +649,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "(to be displayed inline)",
-      "text": "(to be displayed inline)"
+      "orig": " (to be displayed inline)",
+      "text": " (to be displayed inline)"
     },
     {
       "self_ref": "#/texts/17",
@@ -679,8 +679,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "Here a formula:",
-      "text": "Here a formula:"
+      "orig": "Here a formula: ",
+      "text": "Here a formula: "
     },
     {
       "self_ref": "#/texts/19",
@@ -703,8 +703,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "(to be displayed inline)",
-      "text": "(to be displayed inline)"
+      "orig": " (to be displayed inline)",
+      "text": " (to be displayed inline)"
     },
     {
       "self_ref": "#/texts/21",
@@ -767,8 +767,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "Some formatting chops:",
-      "text": "Some formatting chops:"
+      "orig": "Some formatting chops: ",
+      "text": "Some formatting chops: "
     },
     {
       "self_ref": "#/texts/26",
@@ -779,8 +779,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "bold",
-      "text": "bold",
+      "orig": "bold ",
+      "text": "bold ",
       "formatting": {
         "bold": true,
         "italic": false,
@@ -798,8 +798,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "italic",
-      "text": "italic",
+      "orig": "italic ",
+      "text": "italic ",
       "formatting": {
         "bold": false,
         "italic": true,
@@ -817,8 +817,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "underline",
-      "text": "underline",
+      "orig": "underline ",
+      "text": "underline ",
       "formatting": {
         "bold": false,
         "italic": false,
@@ -836,8 +836,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "strikethrough",
-      "text": "strikethrough",
+      "orig": "strikethrough ",
+      "text": "strikethrough ",
       "formatting": {
         "bold": false,
         "italic": false,
@@ -855,8 +855,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "subscript",
-      "text": "subscript",
+      "orig": "subscript ",
+      "text": "subscript ",
       "formatting": {
         "bold": false,
         "italic": false,
@@ -874,8 +874,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "superscript",
-      "text": "superscript",
+      "orig": "superscript ",
+      "text": "superscript ",
       "formatting": {
         "bold": false,
         "italic": false,
@@ -893,8 +893,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "hyperlink",
-      "text": "hyperlink",
+      "orig": "hyperlink ",
+      "text": "hyperlink ",
       "hyperlink": "."
     },
     {
@@ -906,8 +906,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "&",
-      "text": "&"
+      "orig": "& ",
+      "text": "& "
     },
     {
       "self_ref": "#/texts/34",

--- a/test/data/doc/constructed_doc.inserted_extracted_doc.json.gt
+++ b/test/data/doc/constructed_doc.inserted_extracted_doc.json.gt
@@ -1,6 +1,6 @@
 {
   "schema_name": "DoclingDocument",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "name": "Untitled 1",
   "furniture": {
     "self_ref": "#/furniture",
@@ -808,8 +808,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "Here a code snippet:",
-      "text": "Here a code snippet:"
+      "orig": "Here a code snippet: ",
+      "text": "Here a code snippet: "
     },
     {
       "self_ref": "#/texts/15",
@@ -836,8 +836,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "(to be displayed inline)",
-      "text": "(to be displayed inline)"
+      "orig": " (to be displayed inline)",
+      "text": " (to be displayed inline)"
     },
     {
       "self_ref": "#/texts/17",
@@ -866,8 +866,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "Here a formula:",
-      "text": "Here a formula:"
+      "orig": "Here a formula: ",
+      "text": "Here a formula: "
     },
     {
       "self_ref": "#/texts/19",
@@ -890,8 +890,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "(to be displayed inline)",
-      "text": "(to be displayed inline)"
+      "orig": " (to be displayed inline)",
+      "text": " (to be displayed inline)"
     },
     {
       "self_ref": "#/texts/21",
@@ -954,8 +954,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "Some formatting chops:",
-      "text": "Some formatting chops:"
+      "orig": "Some formatting chops: ",
+      "text": "Some formatting chops: "
     },
     {
       "self_ref": "#/texts/26",
@@ -966,8 +966,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "bold",
-      "text": "bold",
+      "orig": "bold ",
+      "text": "bold ",
       "formatting": {
         "bold": true,
         "italic": false,
@@ -985,8 +985,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "italic",
-      "text": "italic",
+      "orig": "italic ",
+      "text": "italic ",
       "formatting": {
         "bold": false,
         "italic": true,
@@ -1004,8 +1004,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "underline",
-      "text": "underline",
+      "orig": "underline ",
+      "text": "underline ",
       "formatting": {
         "bold": false,
         "italic": false,
@@ -1023,8 +1023,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "strikethrough",
-      "text": "strikethrough",
+      "orig": "strikethrough ",
+      "text": "strikethrough ",
       "formatting": {
         "bold": false,
         "italic": false,
@@ -1042,8 +1042,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "subscript",
-      "text": "subscript",
+      "orig": "subscript ",
+      "text": "subscript ",
       "formatting": {
         "bold": false,
         "italic": false,
@@ -1061,8 +1061,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "superscript",
-      "text": "superscript",
+      "orig": "superscript ",
+      "text": "superscript ",
       "formatting": {
         "bold": false,
         "italic": false,
@@ -1080,8 +1080,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "hyperlink",
-      "text": "hyperlink",
+      "orig": "hyperlink ",
+      "text": "hyperlink ",
       "hyperlink": "."
     },
     {
@@ -1093,8 +1093,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "&",
-      "text": "&"
+      "orig": "& ",
+      "text": "& "
     },
     {
       "self_ref": "#/texts/34",

--- a/test/data/doc/constructed_doc.inserted_items.json.gt
+++ b/test/data/doc/constructed_doc.inserted_items.json.gt
@@ -1,6 +1,6 @@
 {
   "schema_name": "DoclingDocument",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "name": "Untitled 1",
   "furniture": {
     "self_ref": "#/furniture",
@@ -661,8 +661,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "Here a code snippet:",
-      "text": "Here a code snippet:"
+      "orig": "Here a code snippet: ",
+      "text": "Here a code snippet: "
     },
     {
       "self_ref": "#/texts/15",
@@ -689,8 +689,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "(to be displayed inline)",
-      "text": "(to be displayed inline)"
+      "orig": " (to be displayed inline)",
+      "text": " (to be displayed inline)"
     },
     {
       "self_ref": "#/texts/17",
@@ -719,8 +719,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "Here a formula:",
-      "text": "Here a formula:"
+      "orig": "Here a formula: ",
+      "text": "Here a formula: "
     },
     {
       "self_ref": "#/texts/19",
@@ -743,8 +743,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "(to be displayed inline)",
-      "text": "(to be displayed inline)"
+      "orig": " (to be displayed inline)",
+      "text": " (to be displayed inline)"
     },
     {
       "self_ref": "#/texts/21",
@@ -807,8 +807,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "Some formatting chops:",
-      "text": "Some formatting chops:"
+      "orig": "Some formatting chops: ",
+      "text": "Some formatting chops: "
     },
     {
       "self_ref": "#/texts/26",
@@ -819,8 +819,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "bold",
-      "text": "bold",
+      "orig": "bold ",
+      "text": "bold ",
       "formatting": {
         "bold": true,
         "italic": false,
@@ -838,8 +838,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "italic",
-      "text": "italic",
+      "orig": "italic ",
+      "text": "italic ",
       "formatting": {
         "bold": false,
         "italic": true,
@@ -857,8 +857,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "underline",
-      "text": "underline",
+      "orig": "underline ",
+      "text": "underline ",
       "formatting": {
         "bold": false,
         "italic": false,
@@ -876,8 +876,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "strikethrough",
-      "text": "strikethrough",
+      "orig": "strikethrough ",
+      "text": "strikethrough ",
       "formatting": {
         "bold": false,
         "italic": false,
@@ -895,8 +895,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "subscript",
-      "text": "subscript",
+      "orig": "subscript ",
+      "text": "subscript ",
       "formatting": {
         "bold": false,
         "italic": false,
@@ -914,8 +914,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "superscript",
-      "text": "superscript",
+      "orig": "superscript ",
+      "text": "superscript ",
       "formatting": {
         "bold": false,
         "italic": false,
@@ -933,8 +933,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "hyperlink",
-      "text": "hyperlink",
+      "orig": "hyperlink ",
+      "text": "hyperlink ",
       "hyperlink": "."
     },
     {
@@ -946,8 +946,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "&",
-      "text": "&"
+      "orig": "& ",
+      "text": "& "
     },
     {
       "self_ref": "#/texts/34",

--- a/test/data/doc/constructed_doc.inserted_list_items.json.gt
+++ b/test/data/doc/constructed_doc.inserted_list_items.json.gt
@@ -1,6 +1,6 @@
 {
   "schema_name": "DoclingDocument",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "name": "Untitled 1",
   "furniture": {
     "self_ref": "#/furniture",
@@ -701,8 +701,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "Here a code snippet:",
-      "text": "Here a code snippet:"
+      "orig": "Here a code snippet: ",
+      "text": "Here a code snippet: "
     },
     {
       "self_ref": "#/texts/15",
@@ -729,8 +729,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "(to be displayed inline)",
-      "text": "(to be displayed inline)"
+      "orig": " (to be displayed inline)",
+      "text": " (to be displayed inline)"
     },
     {
       "self_ref": "#/texts/17",
@@ -759,8 +759,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "Here a formula:",
-      "text": "Here a formula:"
+      "orig": "Here a formula: ",
+      "text": "Here a formula: "
     },
     {
       "self_ref": "#/texts/19",
@@ -783,8 +783,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "(to be displayed inline)",
-      "text": "(to be displayed inline)"
+      "orig": " (to be displayed inline)",
+      "text": " (to be displayed inline)"
     },
     {
       "self_ref": "#/texts/21",
@@ -847,8 +847,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "Some formatting chops:",
-      "text": "Some formatting chops:"
+      "orig": "Some formatting chops: ",
+      "text": "Some formatting chops: "
     },
     {
       "self_ref": "#/texts/26",
@@ -859,8 +859,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "bold",
-      "text": "bold",
+      "orig": "bold ",
+      "text": "bold ",
       "formatting": {
         "bold": true,
         "italic": false,
@@ -878,8 +878,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "italic",
-      "text": "italic",
+      "orig": "italic ",
+      "text": "italic ",
       "formatting": {
         "bold": false,
         "italic": true,
@@ -897,8 +897,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "underline",
-      "text": "underline",
+      "orig": "underline ",
+      "text": "underline ",
       "formatting": {
         "bold": false,
         "italic": false,
@@ -916,8 +916,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "strikethrough",
-      "text": "strikethrough",
+      "orig": "strikethrough ",
+      "text": "strikethrough ",
       "formatting": {
         "bold": false,
         "italic": false,
@@ -935,8 +935,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "subscript",
-      "text": "subscript",
+      "orig": "subscript ",
+      "text": "subscript ",
       "formatting": {
         "bold": false,
         "italic": false,
@@ -954,8 +954,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "superscript",
-      "text": "superscript",
+      "orig": "superscript ",
+      "text": "superscript ",
       "formatting": {
         "bold": false,
         "italic": false,
@@ -973,8 +973,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "hyperlink",
-      "text": "hyperlink",
+      "orig": "hyperlink ",
+      "text": "hyperlink ",
       "hyperlink": "."
     },
     {
@@ -986,8 +986,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "&",
-      "text": "&"
+      "orig": "& ",
+      "text": "& "
     },
     {
       "self_ref": "#/texts/34",

--- a/test/data/doc/constructed_doc.inserted_text.json.gt
+++ b/test/data/doc/constructed_doc.inserted_text.json.gt
@@ -1,6 +1,6 @@
 {
   "schema_name": "DoclingDocument",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "name": "Untitled 1",
   "furniture": {
     "self_ref": "#/furniture",
@@ -772,8 +772,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "Here a code snippet:",
-      "text": "Here a code snippet:"
+      "orig": "Here a code snippet: ",
+      "text": "Here a code snippet: "
     },
     {
       "self_ref": "#/texts/25",
@@ -800,8 +800,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "(to be displayed inline)",
-      "text": "(to be displayed inline)"
+      "orig": " (to be displayed inline)",
+      "text": " (to be displayed inline)"
     },
     {
       "self_ref": "#/texts/27",
@@ -830,8 +830,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "Here a formula:",
-      "text": "Here a formula:"
+      "orig": "Here a formula: ",
+      "text": "Here a formula: "
     },
     {
       "self_ref": "#/texts/29",
@@ -854,8 +854,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "(to be displayed inline)",
-      "text": "(to be displayed inline)"
+      "orig": " (to be displayed inline)",
+      "text": " (to be displayed inline)"
     },
     {
       "self_ref": "#/texts/31",
@@ -918,8 +918,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "Some formatting chops:",
-      "text": "Some formatting chops:"
+      "orig": "Some formatting chops: ",
+      "text": "Some formatting chops: "
     },
     {
       "self_ref": "#/texts/36",
@@ -930,8 +930,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "bold",
-      "text": "bold",
+      "orig": "bold ",
+      "text": "bold ",
       "formatting": {
         "bold": true,
         "italic": false,
@@ -949,8 +949,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "italic",
-      "text": "italic",
+      "orig": "italic ",
+      "text": "italic ",
       "formatting": {
         "bold": false,
         "italic": true,
@@ -968,8 +968,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "underline",
-      "text": "underline",
+      "orig": "underline ",
+      "text": "underline ",
       "formatting": {
         "bold": false,
         "italic": false,
@@ -987,8 +987,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "strikethrough",
-      "text": "strikethrough",
+      "orig": "strikethrough ",
+      "text": "strikethrough ",
       "formatting": {
         "bold": false,
         "italic": false,
@@ -1006,8 +1006,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "subscript",
-      "text": "subscript",
+      "orig": "subscript ",
+      "text": "subscript ",
       "formatting": {
         "bold": false,
         "italic": false,
@@ -1025,8 +1025,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "superscript",
-      "text": "superscript",
+      "orig": "superscript ",
+      "text": "superscript ",
       "formatting": {
         "bold": false,
         "italic": false,
@@ -1044,8 +1044,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "hyperlink",
-      "text": "hyperlink",
+      "orig": "hyperlink ",
+      "text": "hyperlink ",
       "hyperlink": "."
     },
     {
@@ -1057,8 +1057,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "&",
-      "text": "&"
+      "orig": "& ",
+      "text": "& "
     },
     {
       "self_ref": "#/texts/44",

--- a/test/data/doc/constructed_doc.manipulated_table.json.gt
+++ b/test/data/doc/constructed_doc.manipulated_table.json.gt
@@ -1,6 +1,6 @@
 {
   "schema_name": "DoclingDocument",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "name": "Untitled 1",
   "furniture": {
     "self_ref": "#/furniture",
@@ -714,8 +714,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "Here a code snippet:",
-      "text": "Here a code snippet:"
+      "orig": "Here a code snippet: ",
+      "text": "Here a code snippet: "
     },
     {
       "self_ref": "#/texts/15",
@@ -742,8 +742,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "(to be displayed inline)",
-      "text": "(to be displayed inline)"
+      "orig": " (to be displayed inline)",
+      "text": " (to be displayed inline)"
     },
     {
       "self_ref": "#/texts/17",
@@ -772,8 +772,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "Here a formula:",
-      "text": "Here a formula:"
+      "orig": "Here a formula: ",
+      "text": "Here a formula: "
     },
     {
       "self_ref": "#/texts/19",
@@ -796,8 +796,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "(to be displayed inline)",
-      "text": "(to be displayed inline)"
+      "orig": " (to be displayed inline)",
+      "text": " (to be displayed inline)"
     },
     {
       "self_ref": "#/texts/21",
@@ -860,8 +860,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "Some formatting chops:",
-      "text": "Some formatting chops:"
+      "orig": "Some formatting chops: ",
+      "text": "Some formatting chops: "
     },
     {
       "self_ref": "#/texts/26",
@@ -872,8 +872,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "bold",
-      "text": "bold",
+      "orig": "bold ",
+      "text": "bold ",
       "formatting": {
         "bold": true,
         "italic": false,
@@ -891,8 +891,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "italic",
-      "text": "italic",
+      "orig": "italic ",
+      "text": "italic ",
       "formatting": {
         "bold": false,
         "italic": true,
@@ -910,8 +910,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "underline",
-      "text": "underline",
+      "orig": "underline ",
+      "text": "underline ",
       "formatting": {
         "bold": false,
         "italic": false,
@@ -929,8 +929,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "strikethrough",
-      "text": "strikethrough",
+      "orig": "strikethrough ",
+      "text": "strikethrough ",
       "formatting": {
         "bold": false,
         "italic": false,
@@ -948,8 +948,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "subscript",
-      "text": "subscript",
+      "orig": "subscript ",
+      "text": "subscript ",
       "formatting": {
         "bold": false,
         "italic": false,
@@ -967,8 +967,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "superscript",
-      "text": "superscript",
+      "orig": "superscript ",
+      "text": "superscript ",
       "formatting": {
         "bold": false,
         "italic": false,
@@ -986,8 +986,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "hyperlink",
-      "text": "hyperlink",
+      "orig": "hyperlink ",
+      "text": "hyperlink ",
       "hyperlink": "."
     },
     {
@@ -999,8 +999,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "&",
-      "text": "&"
+      "orig": "& ",
+      "text": "& "
     },
     {
       "self_ref": "#/texts/34",

--- a/test/data/doc/constructed_doc.referenced.json.gt
+++ b/test/data/doc/constructed_doc.referenced.json.gt
@@ -1,6 +1,6 @@
 {
   "schema_name": "DoclingDocument",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "name": "Untitled 1",
   "furniture": {
     "self_ref": "#/furniture",
@@ -766,8 +766,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "Here a code snippet:",
-      "text": "Here a code snippet:"
+      "orig": "Here a code snippet: ",
+      "text": "Here a code snippet: "
     },
     {
       "self_ref": "#/texts/25",
@@ -794,8 +794,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "(to be displayed inline)",
-      "text": "(to be displayed inline)"
+      "orig": " (to be displayed inline)",
+      "text": " (to be displayed inline)"
     },
     {
       "self_ref": "#/texts/27",
@@ -824,8 +824,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "Here a formula:",
-      "text": "Here a formula:"
+      "orig": "Here a formula: ",
+      "text": "Here a formula: "
     },
     {
       "self_ref": "#/texts/29",
@@ -848,8 +848,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "(to be displayed inline)",
-      "text": "(to be displayed inline)"
+      "orig": " (to be displayed inline)",
+      "text": " (to be displayed inline)"
     },
     {
       "self_ref": "#/texts/31",
@@ -912,8 +912,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "Some formatting chops:",
-      "text": "Some formatting chops:"
+      "orig": "Some formatting chops: ",
+      "text": "Some formatting chops: "
     },
     {
       "self_ref": "#/texts/36",
@@ -924,8 +924,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "bold",
-      "text": "bold",
+      "orig": "bold ",
+      "text": "bold ",
       "formatting": {
         "bold": true,
         "italic": false,
@@ -943,8 +943,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "italic",
-      "text": "italic",
+      "orig": "italic ",
+      "text": "italic ",
       "formatting": {
         "bold": false,
         "italic": true,
@@ -962,8 +962,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "underline",
-      "text": "underline",
+      "orig": "underline ",
+      "text": "underline ",
       "formatting": {
         "bold": false,
         "italic": false,
@@ -981,8 +981,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "strikethrough",
-      "text": "strikethrough",
+      "orig": "strikethrough ",
+      "text": "strikethrough ",
       "formatting": {
         "bold": false,
         "italic": false,
@@ -1000,8 +1000,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "subscript",
-      "text": "subscript",
+      "orig": "subscript ",
+      "text": "subscript ",
       "formatting": {
         "bold": false,
         "italic": false,
@@ -1019,8 +1019,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "superscript",
-      "text": "superscript",
+      "orig": "superscript ",
+      "text": "superscript ",
       "formatting": {
         "bold": false,
         "italic": false,
@@ -1038,8 +1038,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "hyperlink",
-      "text": "hyperlink",
+      "orig": "hyperlink ",
+      "text": "hyperlink ",
       "hyperlink": "."
     },
     {
@@ -1051,8 +1051,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "&",
-      "text": "&"
+      "orig": "& ",
+      "text": "& "
     },
     {
       "self_ref": "#/texts/44",

--- a/test/data/doc/constructed_doc.referenced.yaml.gt
+++ b/test/data/doc/constructed_doc.referenced.yaml.gt
@@ -752,12 +752,12 @@ texts:
 - children: []
   content_layer: body
   label: text
-  orig: 'Here a code snippet:'
+  orig: 'Here a code snippet: '
   parent:
     $ref: '#/groups/10'
   prov: []
   self_ref: '#/texts/24'
-  text: 'Here a code snippet:'
+  text: 'Here a code snippet: '
 - captions: []
   children: []
   code_language: Python
@@ -774,12 +774,12 @@ texts:
 - children: []
   content_layer: body
   label: text
-  orig: (to be displayed inline)
+  orig: ' (to be displayed inline)'
   parent:
     $ref: '#/groups/10'
   prov: []
   self_ref: '#/texts/26'
-  text: (to be displayed inline)
+  text: ' (to be displayed inline)'
 - children:
   - $ref: '#/groups/11'
   content_layer: body
@@ -795,12 +795,12 @@ texts:
 - children: []
   content_layer: body
   label: text
-  orig: 'Here a formula:'
+  orig: 'Here a formula: '
   parent:
     $ref: '#/groups/11'
   prov: []
   self_ref: '#/texts/28'
-  text: 'Here a formula:'
+  text: 'Here a formula: '
 - children: []
   content_layer: body
   label: formula
@@ -813,12 +813,12 @@ texts:
 - children: []
   content_layer: body
   label: text
-  orig: (to be displayed inline)
+  orig: ' (to be displayed inline)'
   parent:
     $ref: '#/groups/11'
   prov: []
   self_ref: '#/texts/30'
-  text: (to be displayed inline)
+  text: ' (to be displayed inline)'
 - children: []
   content_layer: body
   label: text
@@ -862,12 +862,12 @@ texts:
 - children: []
   content_layer: body
   label: text
-  orig: 'Some formatting chops:'
+  orig: 'Some formatting chops: '
   parent:
     $ref: '#/groups/12'
   prov: []
   self_ref: '#/texts/35'
-  text: 'Some formatting chops:'
+  text: 'Some formatting chops: '
 - children: []
   content_layer: body
   formatting:
@@ -877,12 +877,12 @@ texts:
     strikethrough: false
     underline: false
   label: text
-  orig: bold
+  orig: 'bold '
   parent:
     $ref: '#/groups/12'
   prov: []
   self_ref: '#/texts/36'
-  text: bold
+  text: 'bold '
 - children: []
   content_layer: body
   formatting:
@@ -892,12 +892,12 @@ texts:
     strikethrough: false
     underline: false
   label: text
-  orig: italic
+  orig: 'italic '
   parent:
     $ref: '#/groups/12'
   prov: []
   self_ref: '#/texts/37'
-  text: italic
+  text: 'italic '
 - children: []
   content_layer: body
   formatting:
@@ -907,12 +907,12 @@ texts:
     strikethrough: false
     underline: true
   label: text
-  orig: underline
+  orig: 'underline '
   parent:
     $ref: '#/groups/12'
   prov: []
   self_ref: '#/texts/38'
-  text: underline
+  text: 'underline '
 - children: []
   content_layer: body
   formatting:
@@ -922,12 +922,12 @@ texts:
     strikethrough: true
     underline: false
   label: text
-  orig: strikethrough
+  orig: 'strikethrough '
   parent:
     $ref: '#/groups/12'
   prov: []
   self_ref: '#/texts/39'
-  text: strikethrough
+  text: 'strikethrough '
 - children: []
   content_layer: body
   formatting:
@@ -937,12 +937,12 @@ texts:
     strikethrough: false
     underline: false
   label: text
-  orig: subscript
+  orig: 'subscript '
   parent:
     $ref: '#/groups/12'
   prov: []
   self_ref: '#/texts/40'
-  text: subscript
+  text: 'subscript '
 - children: []
   content_layer: body
   formatting:
@@ -952,31 +952,31 @@ texts:
     strikethrough: false
     underline: false
   label: text
-  orig: superscript
+  orig: 'superscript '
   parent:
     $ref: '#/groups/12'
   prov: []
   self_ref: '#/texts/41'
-  text: superscript
+  text: 'superscript '
 - children: []
   content_layer: body
   hyperlink: .
   label: text
-  orig: hyperlink
+  orig: 'hyperlink '
   parent:
     $ref: '#/groups/12'
   prov: []
   self_ref: '#/texts/42'
-  text: hyperlink
+  text: 'hyperlink '
 - children: []
   content_layer: body
   label: text
-  orig: '&'
+  orig: '& '
   parent:
     $ref: '#/groups/12'
   prov: []
   self_ref: '#/texts/43'
-  text: '&'
+  text: '& '
 - children: []
   content_layer: body
   formatting:
@@ -1114,4 +1114,4 @@ texts:
   prov: []
   self_ref: '#/texts/55'
   text: The end.
-version: 1.10.0
+version: 1.11.0

--- a/test/data/doc/constructed_doc.replaced_item.json.gt
+++ b/test/data/doc/constructed_doc.replaced_item.json.gt
@@ -1,6 +1,6 @@
 {
   "schema_name": "DoclingDocument",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "name": "Untitled 1",
   "furniture": {
     "self_ref": "#/furniture",
@@ -544,8 +544,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "Here a code snippet:",
-      "text": "Here a code snippet:"
+      "orig": "Here a code snippet: ",
+      "text": "Here a code snippet: "
     },
     {
       "self_ref": "#/texts/15",
@@ -572,8 +572,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "(to be displayed inline)",
-      "text": "(to be displayed inline)"
+      "orig": " (to be displayed inline)",
+      "text": " (to be displayed inline)"
     },
     {
       "self_ref": "#/texts/17",
@@ -602,8 +602,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "Here a formula:",
-      "text": "Here a formula:"
+      "orig": "Here a formula: ",
+      "text": "Here a formula: "
     },
     {
       "self_ref": "#/texts/19",
@@ -626,8 +626,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "(to be displayed inline)",
-      "text": "(to be displayed inline)"
+      "orig": " (to be displayed inline)",
+      "text": " (to be displayed inline)"
     },
     {
       "self_ref": "#/texts/21",
@@ -690,8 +690,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "Some formatting chops:",
-      "text": "Some formatting chops:"
+      "orig": "Some formatting chops: ",
+      "text": "Some formatting chops: "
     },
     {
       "self_ref": "#/texts/26",
@@ -702,8 +702,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "bold",
-      "text": "bold",
+      "orig": "bold ",
+      "text": "bold ",
       "formatting": {
         "bold": true,
         "italic": false,
@@ -721,8 +721,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "italic",
-      "text": "italic",
+      "orig": "italic ",
+      "text": "italic ",
       "formatting": {
         "bold": false,
         "italic": true,
@@ -740,8 +740,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "underline",
-      "text": "underline",
+      "orig": "underline ",
+      "text": "underline ",
       "formatting": {
         "bold": false,
         "italic": false,
@@ -759,8 +759,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "strikethrough",
-      "text": "strikethrough",
+      "orig": "strikethrough ",
+      "text": "strikethrough ",
       "formatting": {
         "bold": false,
         "italic": false,
@@ -778,8 +778,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "subscript",
-      "text": "subscript",
+      "orig": "subscript ",
+      "text": "subscript ",
       "formatting": {
         "bold": false,
         "italic": false,
@@ -797,8 +797,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "superscript",
-      "text": "superscript",
+      "orig": "superscript ",
+      "text": "superscript ",
       "formatting": {
         "bold": false,
         "italic": false,
@@ -816,8 +816,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "hyperlink",
-      "text": "hyperlink",
+      "orig": "hyperlink ",
+      "text": "hyperlink ",
       "hyperlink": "."
     },
     {
@@ -829,8 +829,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "&",
-      "text": "&"
+      "orig": "& ",
+      "text": "& "
     },
     {
       "self_ref": "#/texts/34",

--- a/test/data/doc/constructed_document.yaml.et
+++ b/test/data/doc/constructed_document.yaml.et
@@ -39,14 +39,14 @@ Affiliation 2
     36: list_item: item 1 of sub list
     37: list_item: 
      38: inline with name=group
-      39: text: Here a code snippet:
+      39: text: Here a code snippet: 
       40: code: print("Hello world")
-      41: text: (to be displayed inline)
+      41: text:  (to be displayed inline)
     42: list_item: 
      43: inline with name=group
-      44: text: Here a formula:
+      44: text: Here a formula: 
       45: formula: E=mc^2
-      46: text: (to be displayed inline)
+      46: text:  (to be displayed inline)
  47: text: Here a code block:
  48: code: print("Hello world")
  49: text: Here a formula block:
@@ -54,15 +54,15 @@ Affiliation 2
  51: key_value_region
  52: form
  53: inline with name=group
-  54: text: Some formatting chops:
-  55: text: bold
-  56: text: italic
-  57: text: underline
-  58: text: strikethrough
-  59: text: subscript
-  60: text: superscript
-  61: text: hyperlink
-  62: text: &
+  54: text: Some formatting chops: 
+  55: text: bold 
+  56: text: italic 
+  57: text: underline 
+  58: text: strikethrough 
+  59: text: subscript 
+  60: text: superscript 
+  61: text: hyperlink 
+  62: text: & 
   63: text: everything at the same time.
  64: list with name=list A
   65: list_item: Item 1 in A

--- a/test/data/doc/content_all.gt.dclg.xml
+++ b/test/data/doc/content_all.gt.dclg.xml
@@ -106,17 +106,17 @@ Affiliation 2</content>
       <ldiv>
         <marker>□</marker>
       </ldiv>
-      Here a code snippet:
+      <content>Here a code snippet: </content>
       <code>
         <label value="Python"/>
 <![CDATA[print("Hello world")]]>      </code>
-(to be displayed inline)
+      <content> (to be displayed inline)</content>
       <ldiv>
         <marker>□</marker>
       </ldiv>
-      Here a formula:
+      <content>Here a formula: </content>
       <formula>E=mc^2</formula>
-(to be displayed inline)
+      <content> (to be displayed inline)</content>
     </list>
   </list>
   <text>Here a code block:</text>
@@ -126,15 +126,27 @@ Affiliation 2</content>
   <text>Here a formula block:</text>
   <formula>E=mc^2</formula>
   <text>
-    Some formatting chops:
-    <bold>bold</bold>
-    <italic>italic</italic>
-    <underline>underline</underline>
-    <strikethrough>strikethrough</strikethrough>
-    <subscript>subscript</subscript>
-    <superscript>superscript</superscript>
-hyperlink
-<![CDATA[&]]>    
+    <content>Some formatting chops: </content>
+    <bold>
+      <content>bold </content>
+    </bold>
+    <italic>
+      <content>italic </content>
+    </italic>
+    <underline>
+      <content>underline </content>
+    </underline>
+    <strikethrough>
+      <content>strikethrough </content>
+    </strikethrough>
+    <subscript>
+      <content>subscript </content>
+    </subscript>
+    <superscript>
+      <content>superscript </content>
+    </superscript>
+    <content>hyperlink </content>
+    <content><![CDATA[& ]]></content>
     <strikethrough>
       <underline>
         <italic>

--- a/test/data/doc/content_block_specific.gt.dclg.xml
+++ b/test/data/doc/content_block_specific.gt.dclg.xml
@@ -87,17 +87,17 @@ Affiliation 2</content>
       <ldiv>
         <marker>□</marker>
       </ldiv>
-      Here a code snippet:
+      <content>Here a code snippet: </content>
       <code>
         <label value="Python"/>
       </code>
-(to be displayed inline)
+      <content> (to be displayed inline)</content>
       <ldiv>
         <marker>□</marker>
       </ldiv>
-      Here a formula:
+      <content>Here a formula: </content>
       <formula>E=mc^2</formula>
-(to be displayed inline)
+      <content> (to be displayed inline)</content>
     </list>
   </list>
   <text>Here a code block:</text>
@@ -107,15 +107,27 @@ Affiliation 2</content>
   <text>Here a formula block:</text>
   <formula>E=mc^2</formula>
   <text>
-    Some formatting chops:
-    <bold>bold</bold>
-    <italic>italic</italic>
-    <underline>underline</underline>
-    <strikethrough>strikethrough</strikethrough>
-    <subscript>subscript</subscript>
-    <superscript>superscript</superscript>
-hyperlink
-<![CDATA[&]]>    
+    <content>Some formatting chops: </content>
+    <bold>
+      <content>bold </content>
+    </bold>
+    <italic>
+      <content>italic </content>
+    </italic>
+    <underline>
+      <content>underline </content>
+    </underline>
+    <strikethrough>
+      <content>strikethrough </content>
+    </strikethrough>
+    <subscript>
+      <content>subscript </content>
+    </subscript>
+    <superscript>
+      <content>superscript </content>
+    </superscript>
+    <content>hyperlink </content>
+    <content><![CDATA[& ]]></content>
     <strikethrough>
       <underline>
         <italic>

--- a/test/data/doc/cross_column_list/deserialized.json
+++ b/test/data/doc/cross_column_list/deserialized.json
@@ -1,6 +1,6 @@
 {
   "schema_name": "DoclingDocument",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "name": "Document",
   "furniture": {
     "self_ref": "#/furniture",

--- a/test/data/doc/cross_column_list/input.json
+++ b/test/data/doc/cross_column_list/input.json
@@ -1,6 +1,6 @@
 {
   "schema_name": "DoclingDocument",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "name": "cross_column_list",
   "furniture": {
     "self_ref": "#/furniture",

--- a/test/data/doc/cross_page_list/deserialized.json
+++ b/test/data/doc/cross_page_list/deserialized.json
@@ -1,6 +1,6 @@
 {
   "schema_name": "DoclingDocument",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "name": "Document",
   "furniture": {
     "self_ref": "#/furniture",

--- a/test/data/doc/cross_page_list/input.json
+++ b/test/data/doc/cross_page_list/input.json
@@ -1,6 +1,6 @@
 {
   "schema_name": "DoclingDocument",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "name": "cross_page_list",
   "furniture": {
     "self_ref": "#/furniture",

--- a/test/data/doc/cross_page_paragraph/deserialized.json
+++ b/test/data/doc/cross_page_paragraph/deserialized.json
@@ -1,6 +1,6 @@
 {
   "schema_name": "DoclingDocument",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "name": "Document",
   "furniture": {
     "self_ref": "#/furniture",

--- a/test/data/doc/cross_page_paragraph/input.json
+++ b/test/data/doc/cross_page_paragraph/input.json
@@ -1,6 +1,6 @@
 {
   "schema_name": "DoclingDocument",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "name": "cross_page_paragraph",
   "furniture": {
     "self_ref": "#/furniture",

--- a/test/data/doc/cross_page_table/deserialized.json
+++ b/test/data/doc/cross_page_table/deserialized.json
@@ -1,6 +1,6 @@
 {
   "schema_name": "DoclingDocument",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "name": "Document",
   "furniture": {
     "self_ref": "#/furniture",

--- a/test/data/doc/cross_page_table/input.json
+++ b/test/data/doc/cross_page_table/input.json
@@ -1,6 +1,6 @@
 {
   "schema_name": "DoclingDocument",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "name": "cross_page_table",
   "furniture": {
     "self_ref": "#/furniture",

--- a/test/data/doc/default_mode.gt.dclg.xml
+++ b/test/data/doc/default_mode.gt.dclg.xml
@@ -18,7 +18,7 @@
     <formula>
       <content>E=mc^2 </content>
     </formula>
-in line
+    in line
     <ldiv/>
     <content>Here a </content>
     <bold>bold</bold>

--- a/test/data/doc/doc_with_kv.dt.json
+++ b/test/data/doc/doc_with_kv.dt.json
@@ -1,6 +1,6 @@
 {
   "schema_name": "DoclingDocument",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "name": "Document",
   "furniture": {
     "self_ref": "#/furniture",

--- a/test/data/doc/docitem_comments_field.out.yaml
+++ b/test/data/doc/docitem_comments_field.out.yaml
@@ -51,4 +51,4 @@ texts:
   prov: []
   self_ref: '#/texts/2'
   text: '[John Reviewer]: This is a reviewer comment.'
-version: 1.10.0
+version: 1.11.0

--- a/test/data/doc/docitem_comments_multiple.out.yaml
+++ b/test/data/doc/docitem_comments_multiple.out.yaml
@@ -79,4 +79,4 @@ texts:
   prov: []
   self_ref: '#/texts/4'
   text: '[Reviewer B]: This is a comment on texts 2 (range [0,6)) and 3.'
-version: 1.10.0
+version: 1.11.0

--- a/test/data/doc/doclang_archive/load/two_pages.gt.json
+++ b/test/data/doc/doclang_archive/load/two_pages.gt.json
@@ -1,6 +1,6 @@
 {
   "schema_name": "DoclingDocument",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "name": "two_pages",
   "furniture": {
     "self_ref": "#/furniture",

--- a/test/data/doc/doclang_archive/save/two_pages.json
+++ b/test/data/doc/doclang_archive/save/two_pages.json
@@ -1,6 +1,6 @@
 {
   "schema_name": "DoclingDocument",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "name": "2408.09869v3",
   "furniture": {
     "self_ref": "#/furniture",

--- a/test/data/doc/doclang_ref/002a_table_order/output.json
+++ b/test/data/doc/doclang_ref/002a_table_order/output.json
@@ -1,6 +1,6 @@
 {
   "schema_name": "DoclingDocument",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "name": "input",
   "furniture": {
     "self_ref": "#/furniture",

--- a/test/data/doc/dummy_doc_2_prec.yaml
+++ b/test/data/doc/dummy_doc_2_prec.yaml
@@ -272,4 +272,4 @@ texts:
   self_ref: '#/texts/3'
   text: 'Figure 1: Four examples of complex page layouts across different document
     categories'
-version: 1.10.0
+version: 1.11.0

--- a/test/data/doc/dummy_doc_with_meta_modified.yaml
+++ b/test/data/doc/dummy_doc_with_meta_modified.yaml
@@ -290,4 +290,4 @@ texts:
   self_ref: '#/texts/3'
   text: 'Figure 1: Four examples of complex page layouts across different document
     categories'
-version: 1.10.0
+version: 1.11.0

--- a/test/data/doc/field_region_kv/deserialized.json
+++ b/test/data/doc/field_region_kv/deserialized.json
@@ -1,6 +1,6 @@
 {
   "schema_name": "DoclingDocument",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "name": "Document",
   "furniture": {
     "self_ref": "#/furniture",
@@ -283,8 +283,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "Clark ",
-      "text": "Clark "
+      "orig": "Clark  ",
+      "text": "Clark  "
     },
     {
       "self_ref": "#/texts/12",
@@ -295,8 +295,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "Kent",
-      "text": "Kent",
+      "orig": "Kent ",
+      "text": "Kent ",
       "formatting": {
         "bold": true,
         "italic": false,
@@ -339,8 +339,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "My first input ",
-      "text": "My first input "
+      "orig": "My first input  ",
+      "text": "My first input  "
     },
     {
       "self_ref": "#/texts/16",
@@ -364,8 +364,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": " and my second input ",
-      "text": " and my second input "
+      "orig": " and my second input  ",
+      "text": " and my second input  "
     },
     {
       "self_ref": "#/texts/18",

--- a/test/data/doc/field_region_kv/input.json
+++ b/test/data/doc/field_region_kv/input.json
@@ -1,6 +1,6 @@
 {
   "schema_name": "DoclingDocument",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "name": "",
   "furniture": {
     "self_ref": "#/furniture",
@@ -284,7 +284,7 @@
       "label": "text",
       "prov": [],
       "orig": "Clark ",
-      "text": "Clark "
+      "text": "Clark  "
     },
     {
       "self_ref": "#/texts/12",
@@ -296,7 +296,7 @@
       "label": "text",
       "prov": [],
       "orig": "Kent",
-      "text": "Kent",
+      "text": "Kent ",
       "formatting": {
         "bold": true,
         "italic": false,
@@ -340,7 +340,7 @@
       "label": "text",
       "prov": [],
       "orig": "My first input ",
-      "text": "My first input "
+      "text": "My first input  "
     },
     {
       "self_ref": "#/texts/16",
@@ -365,7 +365,7 @@
       "label": "text",
       "prov": [],
       "orig": " and my second input ",
-      "text": " and my second input "
+      "text": " and my second input  "
     },
     {
       "self_ref": "#/texts/18",

--- a/test/data/doc/field_region_kv/reserialized.dclg.xml
+++ b/test/data/doc/field_region_kv/reserialized.dclg.xml
@@ -20,15 +20,17 @@
       <value class="fillable">Max Mustermann</value>
       <value class="fillable">
         <checkbox class="unselected"/>
-        <content>Clark </content>
-        <bold>Kent</bold>
+        <content>Clark  </content>
+        <bold>
+          <content>Kent </content>
+        </bold>
         <hint>Select this if you are a Superman fan</hint>
       </value>
       <value></value>
       <text>
-        <content>My first input </content>
+        <content>My first input  </content>
         <value class="fillable"></value>
-        <content> and my second input </content>
+        <content> and my second input  </content>
         <value class="fillable">m</value>
       </text>
     </field_item>

--- a/test/data/doc/field_region_kv/serialized.dclg.xml
+++ b/test/data/doc/field_region_kv/serialized.dclg.xml
@@ -20,15 +20,17 @@
       <value class="fillable">Max Mustermann</value>
       <value class="fillable">
         <checkbox class="unselected"/>
-        <content>Clark </content>
-        <bold>Kent</bold>
+        <content>Clark  </content>
+        <bold>
+          <content>Kent </content>
+        </bold>
         <hint>Select this if you are a Superman fan</hint>
       </value>
       <value></value>
       <text>
-        <content>My first input </content>
+        <content>My first input  </content>
         <value class="fillable"></value>
-        <content> and my second input </content>
+        <content> and my second input  </content>
         <value class="fillable">m</value>
       </text>
     </field_item>

--- a/test/data/doc/field_region_kv_invoice/deserialized.json
+++ b/test/data/doc/field_region_kv_invoice/deserialized.json
@@ -1,6 +1,6 @@
 {
   "schema_name": "DoclingDocument",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "name": "Document",
   "furniture": {
     "self_ref": "#/furniture",

--- a/test/data/doc/field_region_kv_invoice/input.json
+++ b/test/data/doc/field_region_kv_invoice/input.json
@@ -1,6 +1,6 @@
 {
   "schema_name": "DoclingDocument",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "name": "",
   "furniture": {
     "self_ref": "#/furniture",

--- a/test/data/doc/field_region_kv_migration/deserialized.json
+++ b/test/data/doc/field_region_kv_migration/deserialized.json
@@ -1,6 +1,6 @@
 {
   "schema_name": "DoclingDocument",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "name": "Document",
   "furniture": {
     "self_ref": "#/furniture",

--- a/test/data/doc/field_region_kv_migration/input.json
+++ b/test/data/doc/field_region_kv_migration/input.json
@@ -1,6 +1,6 @@
 {
   "schema_name": "DoclingDocument",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "name": "",
   "furniture": {
     "self_ref": "#/furniture",

--- a/test/data/doc/flattened.dclg.xml
+++ b/test/data/doc/flattened.dclg.xml
@@ -9,7 +9,7 @@
   <heading level="2">
     Rich heading
     <italic>without</italic>
-other children besides the inline
+    other children besides the inline
   </heading>
   <text>Section content as sibling of the heading.</text>
   <heading level="3">Subheading</heading>
@@ -17,7 +17,7 @@ other children besides the inline
   <heading level="2">
     Rich heading
     <italic>with</italic>
-other children besides the inline
+    other children besides the inline
   </heading>
   <text>Section content as child of the heading.</text>
   <text>Section content as sibling of the heading.</text>

--- a/test/data/doc/flattened.json
+++ b/test/data/doc/flattened.json
@@ -1,6 +1,6 @@
 {
   "schema_name": "DoclingDocument",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "name": "",
   "furniture": {
     "self_ref": "#/furniture",

--- a/test/data/doc/group_with_metadata.yaml
+++ b/test/data/doc/group_with_metadata.yaml
@@ -125,4 +125,4 @@ texts:
   prov: []
   self_ref: '#/texts/4'
   text: Regarding bar...
-version: 1.10.0
+version: 1.11.0

--- a/test/data/doc/hierarchized.dclg.xml
+++ b/test/data/doc/hierarchized.dclg.xml
@@ -9,7 +9,7 @@
   <heading level="2">
     Rich heading
     <italic>without</italic>
-other children besides the inline
+    other children besides the inline
   </heading>
   <text>Section content as sibling of the heading.</text>
   <heading level="3">Subheading</heading>
@@ -17,7 +17,7 @@ other children besides the inline
   <heading level="2">
     Rich heading
     <italic>with</italic>
-other children besides the inline
+    other children besides the inline
   </heading>
   <text>Section content as child of the heading.</text>
   <text>Section content as sibling of the heading.</text>

--- a/test/data/doc/hierarchized.json
+++ b/test/data/doc/hierarchized.json
@@ -1,6 +1,6 @@
 {
   "schema_name": "DoclingDocument",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "name": "",
   "furniture": {
     "self_ref": "#/furniture",

--- a/test/data/doc/inline_and_formatting.gt.dt
+++ b/test/data/doc/inline_and_formatting.gt.dt
@@ -40,6 +40,7 @@
 <section_header_level_1><inline><text>Partially formatted</text>
 <text>heading to_escape</text>
 <code><_unknown_>not_to_escape</code>
+<text></text>
 <formula>E=mc^2</formula>
 <text>& ampersand</text>
 </inline></section_header_level_1>

--- a/test/data/doc/inline_group.gt.dclg.xml
+++ b/test/data/doc/inline_group.gt.dclg.xml
@@ -6,7 +6,7 @@
     <location value="502"/>
     One
     <bold>Two</bold>
-Three
+    Three
   </text>
   <list>
     <ldiv/>
@@ -14,6 +14,6 @@ Three
     <ldiv/>
     Four
     <bold>Five</bold>
-Six
+    Six
   </list>
 </doclang>

--- a/test/data/doc/kv.out.json
+++ b/test/data/doc/kv.out.json
@@ -1,6 +1,6 @@
 {
   "schema_name": "DoclingDocument",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "name": "",
   "furniture": {
     "self_ref": "#/furniture",

--- a/test/data/doc/kv/01d07afe1cb54ecd23eedfe4d91b81dd88e61bf4e0dbe2467784db4177a6c691/deserialized.json
+++ b/test/data/doc/kv/01d07afe1cb54ecd23eedfe4d91b81dd88e61bf4e0dbe2467784db4177a6c691/deserialized.json
@@ -1,6 +1,6 @@
 {
   "schema_name": "DoclingDocument",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "name": "Document",
   "furniture": {
     "self_ref": "#/furniture",

--- a/test/data/doc/kv/01d07afe1cb54ecd23eedfe4d91b81dd88e61bf4e0dbe2467784db4177a6c691/output.json
+++ b/test/data/doc/kv/01d07afe1cb54ecd23eedfe4d91b81dd88e61bf4e0dbe2467784db4177a6c691/output.json
@@ -1,6 +1,6 @@
 {
   "schema_name": "DoclingDocument",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "name": "01d07afe1cb54ecd23eedfe4d91b81dd88e61bf4e0dbe2467784db4177a6c691",
   "furniture": {
     "self_ref": "#/furniture",

--- a/test/data/doc/kv/08212053e2db1a70dd60a4f85650ceb33d7519af34f502e3ac894389d76663d6/deserialized.json
+++ b/test/data/doc/kv/08212053e2db1a70dd60a4f85650ceb33d7519af34f502e3ac894389d76663d6/deserialized.json
@@ -1,6 +1,6 @@
 {
   "schema_name": "DoclingDocument",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "name": "Document",
   "furniture": {
     "self_ref": "#/furniture",

--- a/test/data/doc/kv/08212053e2db1a70dd60a4f85650ceb33d7519af34f502e3ac894389d76663d6/output.json
+++ b/test/data/doc/kv/08212053e2db1a70dd60a4f85650ceb33d7519af34f502e3ac894389d76663d6/output.json
@@ -1,6 +1,6 @@
 {
   "schema_name": "DoclingDocument",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "name": "08212053e2db1a70dd60a4f85650ceb33d7519af34f502e3ac894389d76663d6",
   "furniture": {
     "self_ref": "#/furniture",

--- a/test/data/doc/kv/0cb12d33b02867dc8708f4877480743533f1248683091188000d25456ba12d73/deserialized.json
+++ b/test/data/doc/kv/0cb12d33b02867dc8708f4877480743533f1248683091188000d25456ba12d73/deserialized.json
@@ -1,6 +1,6 @@
 {
   "schema_name": "DoclingDocument",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "name": "Document",
   "furniture": {
     "self_ref": "#/furniture",

--- a/test/data/doc/kv/0cb12d33b02867dc8708f4877480743533f1248683091188000d25456ba12d73/output.json
+++ b/test/data/doc/kv/0cb12d33b02867dc8708f4877480743533f1248683091188000d25456ba12d73/output.json
@@ -1,6 +1,6 @@
 {
   "schema_name": "DoclingDocument",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "name": "0cb12d33b02867dc8708f4877480743533f1248683091188000d25456ba12d73",
   "furniture": {
     "self_ref": "#/furniture",

--- a/test/data/doc/kv/167f6658cd410df8d4d14acc53e8c8f509e94c44b8005e6b76de8d17329363a7/deserialized.json
+++ b/test/data/doc/kv/167f6658cd410df8d4d14acc53e8c8f509e94c44b8005e6b76de8d17329363a7/deserialized.json
@@ -1,6 +1,6 @@
 {
   "schema_name": "DoclingDocument",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "name": "Document",
   "furniture": {
     "self_ref": "#/furniture",

--- a/test/data/doc/kv/167f6658cd410df8d4d14acc53e8c8f509e94c44b8005e6b76de8d17329363a7/output.json
+++ b/test/data/doc/kv/167f6658cd410df8d4d14acc53e8c8f509e94c44b8005e6b76de8d17329363a7/output.json
@@ -1,6 +1,6 @@
 {
   "schema_name": "DoclingDocument",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "name": "167f6658cd410df8d4d14acc53e8c8f509e94c44b8005e6b76de8d17329363a7",
   "furniture": {
     "self_ref": "#/furniture",

--- a/test/data/doc/kv/1eac20e5ac5fac655a611343f86927d6a76277e170430c1eba741585437a2e90/deserialized.json
+++ b/test/data/doc/kv/1eac20e5ac5fac655a611343f86927d6a76277e170430c1eba741585437a2e90/deserialized.json
@@ -1,6 +1,6 @@
 {
   "schema_name": "DoclingDocument",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "name": "Document",
   "furniture": {
     "self_ref": "#/furniture",

--- a/test/data/doc/kv/1eac20e5ac5fac655a611343f86927d6a76277e170430c1eba741585437a2e90/output.json
+++ b/test/data/doc/kv/1eac20e5ac5fac655a611343f86927d6a76277e170430c1eba741585437a2e90/output.json
@@ -1,6 +1,6 @@
 {
   "schema_name": "DoclingDocument",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "name": "1eac20e5ac5fac655a611343f86927d6a76277e170430c1eba741585437a2e90",
   "furniture": {
     "self_ref": "#/furniture",

--- a/test/data/doc/kv/587558a074858891bdf1d625a9e9fce4ea116ac61bd276d86a069697744b62a4/deserialized.json
+++ b/test/data/doc/kv/587558a074858891bdf1d625a9e9fce4ea116ac61bd276d86a069697744b62a4/deserialized.json
@@ -1,6 +1,6 @@
 {
   "schema_name": "DoclingDocument",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "name": "Document",
   "furniture": {
     "self_ref": "#/furniture",

--- a/test/data/doc/kv/587558a074858891bdf1d625a9e9fce4ea116ac61bd276d86a069697744b62a4/output.json
+++ b/test/data/doc/kv/587558a074858891bdf1d625a9e9fce4ea116ac61bd276d86a069697744b62a4/output.json
@@ -1,6 +1,6 @@
 {
   "schema_name": "DoclingDocument",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "name": "587558a074858891bdf1d625a9e9fce4ea116ac61bd276d86a069697744b62a4",
   "furniture": {
     "self_ref": "#/furniture",

--- a/test/data/doc/kv/ba4120cada21304563625490e9ad13911e96114d3f07df056a6bf62397a859e1/deserialized.json
+++ b/test/data/doc/kv/ba4120cada21304563625490e9ad13911e96114d3f07df056a6bf62397a859e1/deserialized.json
@@ -1,6 +1,6 @@
 {
   "schema_name": "DoclingDocument",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "name": "Document",
   "furniture": {
     "self_ref": "#/furniture",

--- a/test/data/doc/kv/ba4120cada21304563625490e9ad13911e96114d3f07df056a6bf62397a859e1/output.json
+++ b/test/data/doc/kv/ba4120cada21304563625490e9ad13911e96114d3f07df056a6bf62397a859e1/output.json
@@ -1,6 +1,6 @@
 {
   "schema_name": "DoclingDocument",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "name": "ba4120cada21304563625490e9ad13911e96114d3f07df056a6bf62397a859e1",
   "furniture": {
     "self_ref": "#/furniture",

--- a/test/data/doc/kv/fedf68d45c1acd279f7c34fd5b4cbae80677138bdc1d03b2869466e0cf4e89e9/deserialized.json
+++ b/test/data/doc/kv/fedf68d45c1acd279f7c34fd5b4cbae80677138bdc1d03b2869466e0cf4e89e9/deserialized.json
@@ -1,6 +1,6 @@
 {
   "schema_name": "DoclingDocument",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "name": "Document",
   "furniture": {
     "self_ref": "#/furniture",

--- a/test/data/doc/kv/fedf68d45c1acd279f7c34fd5b4cbae80677138bdc1d03b2869466e0cf4e89e9/output.json
+++ b/test/data/doc/kv/fedf68d45c1acd279f7c34fd5b4cbae80677138bdc1d03b2869466e0cf4e89e9/output.json
@@ -1,6 +1,6 @@
 {
   "schema_name": "DoclingDocument",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "name": "fedf68d45c1acd279f7c34fd5b4cbae80677138bdc1d03b2869466e0cf4e89e9",
   "furniture": {
     "self_ref": "#/furniture",

--- a/test/data/doc/kv/non_seq_cell_ids_587558a074858891bdf1d625a9e9fce4ea116ac61bd276d86a069697744b62a4/deserialized.json
+++ b/test/data/doc/kv/non_seq_cell_ids_587558a074858891bdf1d625a9e9fce4ea116ac61bd276d86a069697744b62a4/deserialized.json
@@ -1,6 +1,6 @@
 {
   "schema_name": "DoclingDocument",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "name": "Document",
   "furniture": {
     "self_ref": "#/furniture",

--- a/test/data/doc/kv/non_seq_cell_ids_587558a074858891bdf1d625a9e9fce4ea116ac61bd276d86a069697744b62a4/output.json
+++ b/test/data/doc/kv/non_seq_cell_ids_587558a074858891bdf1d625a9e9fce4ea116ac61bd276d86a069697744b62a4/output.json
@@ -1,6 +1,6 @@
 {
   "schema_name": "DoclingDocument",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "name": "587558a074858891bdf1d625a9e9fce4ea116ac61bd276d86a069697744b62a4",
   "furniture": {
     "self_ref": "#/furniture",

--- a/test/data/doc/kv_advanced_inline.out.dclg.xml
+++ b/test/data/doc/kv_advanced_inline.out.dclg.xml
@@ -13,7 +13,7 @@
       <field_item>
         <value class="fillable"></value>
       </field_item>
-.
+      .
     </text>
   </field_region>
 </doclang>

--- a/test/data/doc/kv_advanced_inline.out.json
+++ b/test/data/doc/kv_advanced_inline.out.json
@@ -1,6 +1,6 @@
 {
   "schema_name": "DoclingDocument",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "name": "",
   "furniture": {
     "self_ref": "#/furniture",

--- a/test/data/doc/kv_form_with_table.out.json
+++ b/test/data/doc/kv_form_with_table.out.json
@@ -1,6 +1,6 @@
 {
   "schema_name": "DoclingDocument",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "name": "",
   "furniture": {
     "self_ref": "#/furniture",

--- a/test/data/doc/kv_invoice.out.json
+++ b/test/data/doc/kv_invoice.out.json
@@ -1,6 +1,6 @@
 {
   "schema_name": "DoclingDocument",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "name": "",
   "furniture": {
     "self_ref": "#/furniture",

--- a/test/data/doc/kv_nested.out.json
+++ b/test/data/doc/kv_nested.out.json
@@ -1,6 +1,6 @@
 {
   "schema_name": "DoclingDocument",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "name": "",
   "furniture": {
     "self_ref": "#/furniture",

--- a/test/data/doc/kv_post_migration.out.json
+++ b/test/data/doc/kv_post_migration.out.json
@@ -1,6 +1,6 @@
 {
   "schema_name": "DoclingDocument",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "name": "",
   "furniture": {
     "self_ref": "#/furniture",

--- a/test/data/doc/kv_pre_migration.out.json
+++ b/test/data/doc/kv_pre_migration.out.json
@@ -1,6 +1,6 @@
 {
   "schema_name": "DoclingDocument",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "name": "",
   "furniture": {
     "self_ref": "#/furniture",

--- a/test/data/doc/misplaced_list_items.norm.out.yaml
+++ b/test/data/doc/misplaced_list_items.norm.out.yaml
@@ -81,4 +81,4 @@ texts:
   prov: []
   self_ref: '#/texts/3'
   text: there
-version: 1.10.0
+version: 1.11.0

--- a/test/data/doc/misplaced_list_items.out.yaml
+++ b/test/data/doc/misplaced_list_items.out.yaml
@@ -81,4 +81,4 @@ texts:
   prov: []
   self_ref: '#/texts/3'
   text: foo
-version: 1.10.0
+version: 1.11.0

--- a/test/data/doc/multi_page_roundtrip/deserialized.json
+++ b/test/data/doc/multi_page_roundtrip/deserialized.json
@@ -1,6 +1,6 @@
 {
   "schema_name": "DoclingDocument",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "name": "Document",
   "furniture": {
     "self_ref": "#/furniture",

--- a/test/data/doc/multi_page_roundtrip/input.json
+++ b/test/data/doc/multi_page_roundtrip/input.json
@@ -1,6 +1,6 @@
 {
   "schema_name": "DoclingDocument",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "name": "multi_page_roundtrip",
   "furniture": {
     "self_ref": "#/furniture",

--- a/test/data/doc/multi_prov_thread/deserialized.json
+++ b/test/data/doc/multi_prov_thread/deserialized.json
@@ -1,6 +1,6 @@
 {
   "schema_name": "DoclingDocument",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "name": "Document",
   "furniture": {
     "self_ref": "#/furniture",

--- a/test/data/doc/multi_prov_thread/input.json
+++ b/test/data/doc/multi_prov_thread/input.json
@@ -1,6 +1,6 @@
 {
   "schema_name": "DoclingDocument",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "name": "multi_prov_thread",
   "furniture": {
     "self_ref": "#/furniture",

--- a/test/data/doc/page_with_pic.dt.json
+++ b/test/data/doc/page_with_pic.dt.json
@@ -1,6 +1,6 @@
 {
   "schema_name": "DoclingDocument",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "name": "Document",
   "furniture": {
     "self_ref": "#/furniture",

--- a/test/data/doc/page_with_pic_from_files.dt.json
+++ b/test/data/doc/page_with_pic_from_files.dt.json
@@ -1,6 +1,6 @@
 {
   "schema_name": "DoclingDocument",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "name": "Document",
   "furniture": {
     "self_ref": "#/furniture",

--- a/test/data/doc/page_without_pic.dt.json
+++ b/test/data/doc/page_without_pic.dt.json
@@ -1,6 +1,6 @@
 {
   "schema_name": "DoclingDocument",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "name": "Document",
   "furniture": {
     "self_ref": "#/furniture",

--- a/test/data/doc/picture_molecule_meta/deserialized.json
+++ b/test/data/doc/picture_molecule_meta/deserialized.json
@@ -1,6 +1,6 @@
 {
   "schema_name": "DoclingDocument",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "name": "Document",
   "furniture": {
     "self_ref": "#/furniture",

--- a/test/data/doc/picture_molecule_meta/input.json
+++ b/test/data/doc/picture_molecule_meta/input.json
@@ -1,6 +1,6 @@
 {
   "schema_name": "DoclingDocument",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "name": "picture_molecule_meta",
   "furniture": {
     "self_ref": "#/furniture",

--- a/test/data/doc/referenced_caption/deserialized.json
+++ b/test/data/doc/referenced_caption/deserialized.json
@@ -1,6 +1,6 @@
 {
   "schema_name": "DoclingDocument",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "name": "Document",
   "furniture": {
     "self_ref": "#/furniture",

--- a/test/data/doc/referenced_caption/input.json
+++ b/test/data/doc/referenced_caption/input.json
@@ -1,6 +1,6 @@
 {
   "schema_name": "DoclingDocument",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "name": "referenced_caption",
   "furniture": {
     "self_ref": "#/furniture",

--- a/test/data/doc/rich_table.out.yaml
+++ b/test/data/doc/rich_table.out.yaml
@@ -501,4 +501,4 @@ texts:
   prov: []
   self_ref: '#/texts/5'
   text: More text in the group.
-version: 1.10.0
+version: 1.11.0

--- a/test/data/doc/rich_table_item_ins_norm_1.out.yaml
+++ b/test/data/doc/rich_table_item_ins_norm_1.out.yaml
@@ -241,4 +241,4 @@ texts:
   prov: []
   self_ref: '#/texts/1'
   text: text in italic
-version: 1.10.0
+version: 1.11.0

--- a/test/data/doc/rich_table_item_ins_norm_2.out.yaml
+++ b/test/data/doc/rich_table_item_ins_norm_2.out.yaml
@@ -251,4 +251,4 @@ texts:
   prov: []
   self_ref: '#/texts/2'
   text: text before
-version: 1.10.0
+version: 1.11.0

--- a/test/data/doc/rich_table_item_ins_norm_3.out.yaml
+++ b/test/data/doc/rich_table_item_ins_norm_3.out.yaml
@@ -251,4 +251,4 @@ texts:
   prov: []
   self_ref: '#/texts/2'
   text: text in italic
-version: 1.10.0
+version: 1.11.0

--- a/test/data/doc/rich_table_post_text_del.out.yaml
+++ b/test/data/doc/rich_table_post_text_del.out.yaml
@@ -491,4 +491,4 @@ texts:
   prov: []
   self_ref: '#/texts/4'
   text: More text in the group.
-version: 1.10.0
+version: 1.11.0

--- a/test/data/doc/roundtrip_list_item_with_inline_deserialized.yaml
+++ b/test/data/doc/roundtrip_list_item_with_inline_deserialized.yaml
@@ -358,4 +358,4 @@ texts:
   prov: []
   self_ref: '#/texts/23'
   text: final element
-version: 1.10.0
+version: 1.11.0

--- a/test/data/doc/roundtrip_list_item_with_inline_reserialized.dclg.xml
+++ b/test/data/doc/roundtrip_list_item_with_inline_reserialized.dclg.xml
@@ -20,7 +20,7 @@
     <formula>
       <content>E=mc^2 </content>
     </formula>
-in line
+    in line
     <ldiv/>
     <content>Here a </content>
     <bold>bold</bold>

--- a/test/data/doc/roundtrip_list_item_with_inline_serialized.dclg.xml
+++ b/test/data/doc/roundtrip_list_item_with_inline_serialized.dclg.xml
@@ -18,7 +18,7 @@
     <formula>
       <content>E=mc^2 </content>
     </formula>
-in line
+    in line
     <ldiv/>
     <content>Here a </content>
     <bold>bold</bold>

--- a/test/data/doc/virtual_text_index/deserialized.json
+++ b/test/data/doc/virtual_text_index/deserialized.json
@@ -1,6 +1,6 @@
 {
   "schema_name": "DoclingDocument",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "name": "Document",
   "furniture": {
     "self_ref": "#/furniture",

--- a/test/data/doc/virtual_text_index/input.json
+++ b/test/data/doc/virtual_text_index/input.json
@@ -1,6 +1,6 @@
 {
   "schema_name": "DoclingDocument",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "name": "virtual_text_index",
   "furniture": {
     "self_ref": "#/furniture",

--- a/test/data/doc/virtual_text_list/deserialized.json
+++ b/test/data/doc/virtual_text_list/deserialized.json
@@ -1,6 +1,6 @@
 {
   "schema_name": "DoclingDocument",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "name": "Document",
   "furniture": {
     "self_ref": "#/furniture",

--- a/test/data/doc/virtual_text_list/input.json
+++ b/test/data/doc/virtual_text_list/input.json
@@ -1,6 +1,6 @@
 {
   "schema_name": "DoclingDocument",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "name": "virtual_text_list",
   "furniture": {
     "self_ref": "#/furniture",

--- a/test/data/doc/virtual_text_table/deserialized.json
+++ b/test/data/doc/virtual_text_table/deserialized.json
@@ -1,6 +1,6 @@
 {
   "schema_name": "DoclingDocument",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "name": "Document",
   "furniture": {
     "self_ref": "#/furniture",

--- a/test/data/doc/virtual_text_table/input.json
+++ b/test/data/doc/virtual_text_table/input.json
@@ -1,6 +1,6 @@
 {
   "schema_name": "DoclingDocument",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "name": "virtual_text_table",
   "furniture": {
     "self_ref": "#/furniture",

--- a/test/data/doc/webvtt_example_02.json
+++ b/test/data/doc/webvtt_example_02.json
@@ -1,6 +1,6 @@
 {
   "schema_name": "DoclingDocument",
-  "version": "1.8.0",
+  "version": "1.11.0",
   "name": "webvtt_example_02",
   "origin": {
     "mimetype": "text/vtt",

--- a/test/data/doc/webvtt_example_04.json
+++ b/test/data/doc/webvtt_example_04.json
@@ -1,6 +1,6 @@
 {
   "schema_name": "DoclingDocument",
-  "version": "1.8.0",
+  "version": "1.11.0",
   "name": "webvtt_example_04",
   "origin": {
     "mimetype": "text/vtt",

--- a/test/data/doc/webvtt_example_05.json
+++ b/test/data/doc/webvtt_example_05.json
@@ -1,6 +1,6 @@
 {
   "schema_name": "DoclingDocument",
-  "version": "1.8.0",
+  "version": "1.11.0",
   "name": "webvtt_example_04",
   "origin": {
     "mimetype": "text/vtt",

--- a/test/test_compat.py
+++ b/test/test_compat.py
@@ -243,6 +243,45 @@ class TestProjectorCoverage:
 # ---------------------------------------------------------------------------
 
 
+class TestProjector_1_11_to_1_10:
+    """Tests for the 1.11 → 1.10 downgrade projector."""
+
+    def _apply(self, data: dict) -> dict:
+        from docling_core.compat import _project_1_11_to_1_10
+
+        return _project_1_11_to_1_10(data)
+
+    def test_version_set_to_1_10(self):
+        result = self._apply(_minimal_doc_dict("1.11.0"))
+        assert result["version"] == "1.10.0"
+
+    def test_inline_run_whitespace_is_preserved_verbatim(self):
+        """The projector must not touch run text: 1.11 runs own their boundary
+        whitespace, and a 1.10 client relies on that text being intact (it adds
+        its own join space on top). Stripping here would re-introduce word-merge.
+        """
+        data = _minimal_doc_dict("1.11.0")
+        data["texts"] = [
+            {
+                "self_ref": "#/texts/0",
+                "parent": None,
+                "children": [],
+                "content_layer": "body",
+                "label": "text",
+                "orig": "bold ",
+                "text": "bold ",
+                "prov": [],
+            }
+        ]
+        result = self._apply(data)
+        assert result["texts"][0]["text"] == "bold "
+
+    def test_does_not_mutate_caller_input(self):
+        data = _minimal_doc_dict("1.11.0")
+        self._apply(data)
+        assert data["version"] == "1.11.0"
+
+
 class TestProjector_1_10_to_1_9:
     """Tests for the 1.10 → 1.9 downgrade projector."""
 

--- a/test/test_deserializer_doclang.py
+++ b/test/test_deserializer_doclang.py
@@ -2286,3 +2286,18 @@ def test_deserialize_accepts_document_within_budgets() -> None:
     )
     assert len(doc.texts) == 1
     assert doc.texts[0].text == "hello"
+
+
+def test_leading_text_before_lone_formatting_tag_is_preserved() -> None:
+    """Regression: the leading run was silently dropped for text + one formatting child."""
+    cases = {
+        "<text>2<superscript>nd</superscript></text>": ["2", "nd"],
+        "<text>plain <bold>b</bold></text>": ["plain", "b"],
+        "<footnote>see <italic>ibid</italic></footnote>": ["see", "ibid"],
+        # guards for the shapes that already worked
+        "<text><superscript>nd</superscript> place</text>": ["nd", "place"],
+        "<text>H<subscript>2</subscript>O</text>": ["H", "2", "O"],
+    }
+    for frag, expected in cases.items():
+        doc = DocLangDocDeserializer().deserialize_str(f'<doclang version="0.7">{frag}</doclang>')
+        assert [t.text.strip() for t in doc.texts] == expected, frag

--- a/test/test_deserializer_doclang.py
+++ b/test/test_deserializer_doclang.py
@@ -1867,7 +1867,9 @@ def test_otsl_xml_sensitive_virtual_and_explicit_text_cells():
     doc = _deserialize(doclang)
 
     assert doc.tables[0].data.grid[0][0].text == "virtual & <cell> \"quoted\" 'apostrophe'"
-    assert doc.tables[0].data.grid[0][1].text == "nested & <cell>bold & styled"
+    # The source writes `<bold> bold &amp; styled</bold>`; that leading space is a significant
+    # run boundary under the inline whitespace contract, so it survives.
+    assert doc.tables[0].data.grid[0][1].text == "nested & <cell> bold & styled"
     assert isinstance(doc.tables[0].data.grid[0][1], RichTableCell)
 
 

--- a/test/test_deserializer_doclang.py
+++ b/test/test_deserializer_doclang.py
@@ -2257,3 +2257,18 @@ def test_deserialize_accepts_document_within_budgets() -> None:
     )
     assert len(doc.texts) == 1
     assert doc.texts[0].text == "hello"
+
+
+def test_leading_text_before_lone_formatting_tag_is_preserved() -> None:
+    """Regression: the leading run was silently dropped for text + one formatting child."""
+    cases = {
+        "<text>2<superscript>nd</superscript></text>": ["2", "nd"],
+        "<text>plain <bold>b</bold></text>": ["plain", "b"],
+        "<footnote>see <italic>ibid</italic></footnote>": ["see", "ibid"],
+        # guards for the shapes that already worked
+        "<text><superscript>nd</superscript> place</text>": ["nd", "place"],
+        "<text>H<subscript>2</subscript>O</text>": ["H", "2", "O"],
+    }
+    for frag, expected in cases.items():
+        doc = DocLangDocDeserializer().deserialize_str(f'<doclang version="0.7">{frag}</doclang>')
+        assert [t.text.strip() for t in doc.texts] == expected, frag

--- a/test/test_inline_whitespace_contract.py
+++ b/test/test_inline_whitespace_contract.py
@@ -1,0 +1,390 @@
+"""The InlineGroup whitespace contract.
+
+Runs carry their own significant whitespace; serializers concatenate them faithfully and never
+insert a separator of their own. This module is the contract table: one set of inline-run
+sequences checked against every text format, plus a DocLang round-trip identity check and the
+load-time normalization that keeps pre-contract documents rendering as they used to.
+"""
+
+import copy
+import json
+import re
+import warnings
+from typing import Optional
+
+import pytest
+from pydantic import AnyUrl
+
+from docling_core.transforms.deserializer.doclang import DocLangDocDeserializer
+from docling_core.transforms.serializer.doclang import DocLangDocSerializer, DocLangParams
+from docling_core.transforms.serializer.latex import LaTeXDocSerializer
+from docling_core.types.doc.document import (
+    CURRENT_VERSION,
+    DocItemLabel,
+    DoclingDocument,
+    Formatting,
+)
+
+# (name, runs) where a run is (text, formatting, hyperlink)
+Run = tuple[str, Optional[Formatting], Optional[str]]
+
+_BOLD = Formatting(bold=True)
+_ITALIC = Formatting(italic=True)
+_SUB = Formatting(script="sub")
+_SUPER = Formatting(script="super")
+
+# Expected output per format. `html` is the inline-group span only, `latex`/`doclang` the body.
+CONTRACT_TABLE: list[tuple[str, list[Run], dict[str, str]]] = [
+    (
+        "ordinal",
+        [("2", None, None), ("nd", _SUPER, None)],
+        {
+            "md": "2nd",
+            "itxt": "2nd",
+            "html": "2<sup>nd</sup>",
+            "latex": "2$^{nd}$",
+            "doclang": "<doclang><text>2<superscript>nd</superscript></text></doclang>",
+        },
+    ),
+    (
+        "formula_unit",
+        [("O", None, None), ("2", _SUB, None), (".", None, None)],
+        {
+            "md": "O2.",
+            "itxt": "O2.",
+            "html": "O<sub>2</sub>.",
+            "latex": "O$_{2}$.",
+            "doclang": "<doclang><text>O<subscript>2</subscript>.</text></doclang>",
+        },
+    ),
+    (
+        "water",
+        [("H", None, None), ("2", _SUB, None), ("O", None, None)],
+        {
+            "md": "H2O",
+            "itxt": "H2O",
+            "html": "H<sub>2</sub>O",
+            "latex": "H$_{2}$O",
+            "doclang": "<doclang><text>H<subscript>2</subscript>O</text></doclang>",
+        },
+    ),
+    (
+        "spaced_emphasis",
+        [("Advanced Topics", _BOLD, None), (" in ", None, None), ("Machine Learning", _ITALIC, None)],
+        {
+            "md": "**Advanced Topics** in *Machine Learning*",
+            "itxt": "Advanced Topics in Machine Learning",
+            "html": "<strong>Advanced Topics</strong> in <em>Machine Learning</em>",
+            "latex": "\\textbf{Advanced Topics} in \\textit{Machine Learning}",
+            "doclang": (
+                "<doclang><text><bold>Advanced Topics</bold><content> in </content>"
+                "<italic>Machine Learning</italic></text></doclang>"
+            ),
+        },
+    ),
+    (
+        "trailing_period",
+        [("This is ", None, None), ("italic text", _ITALIC, None), (".", None, None)],
+        {
+            "md": "This is *italic text*.",
+            "itxt": "This is italic text.",
+            "html": "This is <em>italic text</em>.",
+            "latex": "This is \\textit{italic text}.",
+            "doclang": "<doclang><text><content>This is </content><italic>italic text</italic>.</text></doclang>",
+        },
+    ),
+    (
+        # Whitespace *inside* a formatted run: it must end up outside the emphasis markers,
+        # otherwise CommonMark renders `**bold **` as literal asterisks.
+        "whitespace_inside_bold",
+        [("bold ", _BOLD, None), ("tail", None, None)],
+        {
+            "md": "**bold** tail",
+            "itxt": "bold tail",
+            "html": "<strong>bold</strong> tail",
+            "latex": "\\textbf{bold} tail",
+            "doclang": "<doclang><text><bold><content>bold </content></bold>tail</text></doclang>",
+        },
+    ),
+    (
+        # ... and outside the *complete* decoration stack, hyperlink included.
+        "whitespace_inside_bold_link",
+        [("bold ", _BOLD, "https://example.com/x"), ("tail", None, None)],
+        {
+            "md": "[**bold**](https://example.com/x) tail",
+            "itxt": "bold tail",
+            "html": '<a href="https://example.com/x"><strong>bold</strong></a> tail',
+            "latex": "\\href{https://example.com/x}{\\textbf{bold}} tail",
+            # DocLang has no place for a hyperlink on an inline run (pre-existing gap, not
+            # part of this contract): the href is dropped. The whitespace still hoists.
+            "doclang": "<doclang><text><bold><content>bold </content></bold>tail</text></doclang>",
+        },
+    ),
+    (
+        # A whitespace-only run survives as one space, with no empty markers.
+        "whitespace_only_run",
+        [("a", None, None), (" ", _BOLD, None), ("b", None, None)],
+        {
+            "md": "a b",
+            "itxt": "a b",
+            "html": "a b",
+            "latex": "a b",
+            "doclang": "<doclang><text>a<bold><content> </content></bold>b</text></doclang>",
+        },
+    ),
+]
+
+
+def _build(runs: list[Run]) -> DoclingDocument:
+    doc = DoclingDocument(name="contract")
+    group = doc.add_inline_group()
+    for text, formatting, hyperlink in runs:
+        doc.add_text(
+            label=DocItemLabel.TEXT,
+            text=text,
+            parent=group,
+            formatting=formatting,
+            hyperlink=AnyUrl(hyperlink) if hyperlink else None,
+        )
+    return doc
+
+
+def _inline_span(doc: DoclingDocument) -> str:
+    html = doc.export_to_html(split_page_view=False)
+    match = re.search(r"<span class='inline-group'>(.*?)</span>\s*$", html, re.DOTALL | re.MULTILINE)
+    if match is None:
+        match = re.search(r"<span class='inline-group'>(.*)</span>", html, re.DOTALL)
+    assert match is not None, html
+    return match.group(1)
+
+
+def _latex_body(doc: DoclingDocument) -> str:
+    text = LaTeXDocSerializer(doc=doc).serialize().text
+    body = text.split("\\begin{document}", 1)[1].split("\\end{document}", 1)[0]
+    return body.strip()
+
+
+def _doclang_compact(doc: DoclingDocument) -> str:
+    """Serialize to DocLang without pretty-printing, so whitespace is unambiguous."""
+    params = DocLangParams(include_version=False, pretty_indentation=None)
+    return DocLangDocSerializer(doc=doc, params=params).serialize().text.strip()
+
+
+@pytest.mark.parametrize(("name", "runs", "expected"), CONTRACT_TABLE, ids=[c[0] for c in CONTRACT_TABLE])
+def test_contract_table(name: str, runs: list[Run], expected: dict[str, str]) -> None:
+    """Inline runs are concatenated faithfully in every text format."""
+    doc = _build(runs)
+    actual = {
+        "md": doc.export_to_markdown(),
+        "itxt": doc.export_to_text(),
+        "html": _inline_span(doc),
+        "latex": _latex_body(doc),
+        "doclang": _doclang_compact(doc),
+    }
+    assert actual == expected
+
+
+@pytest.mark.parametrize(("name", "runs", "expected"), CONTRACT_TABLE, ids=[c[0] for c in CONTRACT_TABLE])
+def test_doclang_roundtrip_is_lossless(name: str, runs: list[Run], expected: dict[str, str]) -> None:
+    """DocLang carries the run whitespace losslessly, via `<content>`.
+
+    Checked both pretty-printed (the default, where bare text nodes pick up indentation) and
+    compact, since the whitespace channel must survive the pretty printer.
+    """
+    doc = _build(runs)
+    # DocLang drops hyperlinks on inline runs (pre-existing, see the table), so compare the
+    # whitespace rather than the full markdown for that one case.
+    expected_md = expected["md"] if not any(link for _, _, link in runs) else "**bold** tail"
+    for params in (DocLangParams(), DocLangParams(pretty_indentation=None)):
+        xml = DocLangDocSerializer(doc=doc, params=params).serialize().text
+        roundtripped = DocLangDocDeserializer().deserialize_str(xml)
+        assert roundtripped.export_to_markdown() == expected_md, (name, params.pretty_indentation)
+        assert roundtripped.export_to_text() == doc.export_to_text(), (name, params.pretty_indentation)
+
+
+def test_no_separator_is_invented_between_runs() -> None:
+    """The serializers add nothing of their own: joined run text == the plain text export."""
+    for name, runs, _ in CONTRACT_TABLE:
+        doc = _build(runs)
+        assert doc.export_to_text() == "".join(text for text, _, _ in runs), name
+
+
+# --------------------------------------------------------------------------------------------
+# Load normalization for pre-contract documents
+# --------------------------------------------------------------------------------------------
+
+_LEGACY_VERSION = "1.8.0"
+
+
+def _legacy_doc_dict(runs: list[str], *, version: str = _LEGACY_VERSION, label: str = "text") -> dict:
+    return {
+        "schema_name": "DoclingDocument",
+        "version": version,
+        "name": "legacy",
+        "body": {
+            "name": "_root_",
+            "self_ref": "#/body",
+            "label": "unspecified",
+            "children": [{"$ref": "#/groups/0"}],
+        },
+        "furniture": {"name": "_root_", "self_ref": "#/furniture", "label": "unspecified", "children": []},
+        "groups": [
+            {
+                "self_ref": "#/groups/0",
+                "parent": {"$ref": "#/body"},
+                "label": "inline",
+                "name": "group",
+                "content_layer": "body",
+                "children": [{"$ref": f"#/texts/{i}"} for i in range(len(runs))],
+            }
+        ],
+        "texts": [
+            {
+                "self_ref": f"#/texts/{i}",
+                "parent": {"$ref": "#/groups/0"},
+                "label": label,
+                "prov": [],
+                "orig": text,
+                "text": text,
+                "children": [],
+                "content_layer": "body",
+            }
+            for i, text in enumerate(runs)
+        ],
+        "pictures": [],
+        "tables": [],
+        "key_value_items": [],
+        "form_items": [],
+        "pages": {},
+    }
+
+
+def _load(data: dict) -> DoclingDocument:
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UserWarning)
+        return DoclingDocument.model_validate(json.loads(json.dumps(data)))
+
+
+@pytest.mark.parametrize(
+    ("runs", "expected_runs", "expected_md"),
+    [
+        # Space-less DOCX-style runs stay spaced, as the old `" "` join rendered them.
+        (["Normal", "italic"], ["Normal ", "italic"], "Normal italic"),
+        # The legacy extra-space bug is retained: this used to render `H 2 O`.
+        (["H", "2", "O"], ["H ", "2 ", "O"], "H 2 O"),
+        # An existing boundary keeps its legacy double space -- the old serializer added one too.
+        (["left ", "right"], ["left  ", "right"], "left  right"),
+    ],
+)
+def test_legacy_documents_keep_their_separators(runs: list[str], expected_runs: list[str], expected_md: str) -> None:
+    doc = _load(_legacy_doc_dict(runs))
+    assert [t.text for t in doc.texts] == expected_runs
+    assert doc.export_to_markdown() == expected_md
+
+
+def test_current_version_documents_are_not_normalized() -> None:
+    doc = _load(_legacy_doc_dict(["H", "2", "O"], version=CURRENT_VERSION))
+    assert [t.text for t in doc.texts] == ["H", "2", "O"]
+    assert doc.export_to_markdown() == "H2O"
+
+
+def test_versionless_input_is_not_guessed_at() -> None:
+    data = _legacy_doc_dict(["H", "2", "O"])
+    del data["version"]
+    assert [t.text for t in _load(data).texts] == ["H", "2", "O"]
+
+
+def test_migration_is_one_way() -> None:
+    """Loading stamps CURRENT_VERSION, so a re-save cannot pick up a second separator."""
+    once = _load(_legacy_doc_dict(["H", "2"]))
+    assert once.version == CURRENT_VERSION
+    twice = _load(json.loads(once.model_dump_json()))
+    assert [t.text for t in twice.texts] == [t.text for t in once.texts] == ["H ", "2"]
+
+
+@pytest.mark.parametrize(
+    ("labels", "expected_md", "expected_txt"),
+    [
+        # The separator goes on whichever neighbour is not delimiter-wrapped ...
+        (("text", "code"), "a `b`", "a b"),
+        (("code", "text"), "`a` b", "a b"),
+        (("text", "formula"), "a $b$", "a $b$"),
+        (("formula", "text"), "$a$ b", "$a$ b"),
+        # ... and when both are, it becomes a plain run of its own, because appending to
+        # either side would produce `a``b` or $a$$b$.
+        (("code", "code"), "`a` `b`", "a b"),
+        (("formula", "formula"), "$a$ $b$", "$a$ $b$"),
+        (("code", "formula"), "`a` $b$", "a $b$"),
+        (("formula", "code"), "$a$ `b`", "$a$ b"),
+    ],
+)
+def test_legacy_separator_never_lands_inside_a_delimiter(
+    labels: tuple[str, str], expected_md: str, expected_txt: str
+) -> None:
+    data = _legacy_doc_dict(["a", "b"])
+    for item, label in zip(data["texts"], labels):
+        item["label"] = label
+    doc = _load(data)
+    assert doc.export_to_markdown() == expected_md
+    assert doc.export_to_text() == expected_txt
+
+
+def test_legacy_migration_does_not_touch_caller_input() -> None:
+    """The caller owns the dict it passes in, and repeated validation must be stable.
+
+    The migration inserts a standalone separator run for adjacent delimited runs, so an
+    in-place edit would both corrupt the caller's value and compound on every re-validation.
+    """
+    data = _legacy_doc_dict(["a", "b"])
+    data["texts"][0]["label"] = "code"
+    data["texts"][1]["label"] = "code"
+    pristine = copy.deepcopy(data)
+
+    rendered = [_load(data).export_to_markdown() for _ in range(3)]
+
+    assert rendered == ["`a` `b`"] * 3
+    assert data == pristine
+
+
+def test_legacy_load_warns_once() -> None:
+    import docling_core.types.doc.document as document_module
+
+    original = document_module._warned_legacy_inline_separators
+    document_module._warned_legacy_inline_separators = False
+    try:
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            DoclingDocument.model_validate(_legacy_doc_dict(["a", "b"]))
+            DoclingDocument.model_validate(_legacy_doc_dict(["c", "d"]))
+        messages = [str(w.message) for w in caught if w.category is UserWarning]
+        assert len(messages) == 1, messages
+        assert _LEGACY_VERSION in messages[0]
+    finally:
+        document_module._warned_legacy_inline_separators = original
+
+
+def test_chunk_text_follows_the_contract() -> None:
+    """The chunker has no inline serializer, so it inherits the Markdown join.
+
+    That makes chunk text -- and therefore embeddings -- change with this contract. Pinned
+    here because the drift is otherwise invisible: nothing in a chunker golden fails, but a
+    persisted vector index silently stops matching.
+    """
+    from docling_core.transforms.chunker.hierarchical_chunker import HierarchicalChunker
+
+    doc = DoclingDocument(name="chunk")
+    doc.add_heading(text="Chemistry")
+    group = doc.add_inline_group()
+    for text, formatting in [
+        ("Water is ", None),
+        ("H", None),
+        ("2", _SUB),
+        ("O", None),
+        (" and the ", None),
+        ("melting point", _BOLD),
+        (" is 0 C.", None),
+    ]:
+        doc.add_text(label=DocItemLabel.TEXT, text=text, parent=group, formatting=formatting)
+
+    chunks = list(HierarchicalChunker().chunk(doc))
+    assert [c.text for c in chunks] == ["Water is H2O and the **melting point** is 0 C."]

--- a/uv.lock
+++ b/uv.lock
@@ -1048,7 +1048,6 @@ chunking-openai = [
     { name = "tree-sitter-typescript" },
 ]
 dclq = [
-    { name = "click" },
     { name = "doclang" },
     { name = "lxml" },
     { name = "typer" },
@@ -1089,7 +1088,6 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "click", marker = "extra == 'dclq'", specifier = ">=8.0.0" },
     { name = "datasets", marker = "extra == 'examples'", specifier = ">=4.0.0" },
     { name = "defusedxml", specifier = ">=0.7.1,<0.8.0" },
     { name = "doclang", specifier = ">=0.7,<0.8" },
@@ -1122,7 +1120,7 @@ requires-dist = [
     { name = "tree-sitter-typescript", marker = "extra == 'chunking'", specifier = ">=0.23.2" },
     { name = "tree-sitter-typescript", marker = "extra == 'chunking-openai'", specifier = ">=0.23.2" },
     { name = "typer", specifier = ">=0.12.5,<0.27.0" },
-    { name = "typer", marker = "extra == 'dclq'", specifier = ">=0.15.1,<0.25.0" },
+    { name = "typer", marker = "extra == 'dclq'", specifier = ">=0.25.0,<0.27.0" },
     { name = "typing-extensions", specifier = ">=4.12.2,<5.0.0" },
 ]
 provides-extras = ["dclq", "chunking", "chunking-openai", "examples"]


### PR DESCRIPTION
## Rebased onto `main`

Rebased onto latest `main`. Upstream landed schema **1.10.0** and, in #703, a **downgrade-projector framework** (`docling_core/compat.py`) with CI enforcement (`test_compat.py::TestProjectorCoverage`, `scripts/check_compat_projectors.py`) that requires a registered projector for every `CURRENT_VERSION` bump — built precisely to make a bump like this one landable. This PR's **1.11.0** bump is that framework's first customer:

- Registers `@register_projector(from_minor=11, to_minor=10)`. 1.11 and 1.10 are structurally identical — the only difference is that 1.11 runs own their boundary whitespace — so the projector re-stamps the version; a 1.10 client re-applies its own `" "` join, yielding the documented harmless double space. Adds `TestProjector_1_11_to_1_10` and the auto-generated `docs/schemas/DoclingDocument_1_11.json` snapshot.
- The only merge conflict was `constants.py` (the version-history table), resolved by keeping upstream's machinery and appending the `1.11.0` row.
- One stale expectation in the newly-upstreamed `dclq` CLI updated: the old join produced `public  class`, the faithful join yields `public class`.

---

## Summary

`InlineGroup` runs now carry their own significant whitespace, and the serializers concatenate them faithfully instead of joining with a hard `" "`.

The join was the defect. It invented spaces the model never asked for, and while the separator lived in the serializer those artifacts could never be removed by fixing a producer:

| source | before | after |
| --- | --- | --- |
| `2<sup>nd</sup>` | `2 nd` | `2nd` |
| `O<sub>2</sub>.` | `O 2 .` | `O2.` |
| `**Advanced Topics** in *Machine Learning*` | `**Advanced Topics**  in  *Machine Learning*` | `**Advanced Topics** in *Machine Learning*` |
| `This is *italic text*.` | `This is *italic text* .` | `This is *italic text*.` |

The ODF backend already emitted contract-honouring runs, so its committed Markdown goldens carried the mirror-image artifact — `X 2  + Y 2  = Z` — which is the shortest proof that the serializer, not the producer, was wrong.

## What changed

**Serializers.** Markdown, HTML, LaTeX and DocLang join inline parts with `""`. DocLang keeps its delimiter between the element head and the body only; `<content>` remains its whitespace channel.

**Whitespace hoisting.** In DOCX and HTML the boundary space frequently lives *inside* a formatted run. Emitting it verbatim produces `**bold ** tail`, which CommonMark renders as literal asterisks. Markdown, HTML and LaTeX now split leading/core/trailing whitespace, apply the *complete* decoration stack to the core, and restore the edges. Doing this inside an individual formatter would not work — the hyperlink would immediately recapture the space (`[**bold** ](url)`). DocLang deliberately opts out and keeps the whitespace inside the markup, in `<content>`.

**DocLang deserializer.**
- `_get_text` stripped every fragment before joining, collapsing `Advanced <bold>Topics</bold>` into `AdvancedTopics`. It now trims the outer block boundary only, and never trims whitespace delivered by `<content>`.
- Bare text nodes use the standard XML heuristic: a whitespace run containing a newline is pretty-print indentation, one without it is content. Serialized DocLang uses `<content>` for whitespace-bearing runs, so this only governs hand-written and VLM-emitted input.
- Element-head children (`<caption>`, `<description>`, `<summary>`, `<custom>`) no longer bleed into visible body text, where they were also being double-modelled in `item.meta`.

Also fixed as a prerequisite (first commit, independently releasable): `<text>2<superscript>nd</superscript></text>` deserialized to a single item `"nd"` — the leading `2` was silently discarded. That is data loss, not a whitespace artifact.

## Compatibility

Space-less runs are in users' saved `.json` files, and release coordination cannot fix a file on disk. The schema minor is bumped to **1.11.0** and a `model_validator(mode="before")` re-injects the legacy separator for documents stamped below it.

The goal is narrow and exact: **preserve the old serializer's visible output, including its existing extra-space bugs.** The old document does not contain enough information to recover semantic whitespace — `["H", "2", "O"]` and `["Normal", "italic"]` have the same shape but need different boundaries.

```
["Normal", "italic"] -> ["Normal ", "italic"] -> "Normal italic"
["H", "2", "O"]      -> ["H ", "2 ", "O"]     -> "H 2 O"        # legacy bug retained
["left ", "right"]   -> ["left  ", "right"]   -> "left  right"  # legacy double space retained
```

- It must run `mode="before"`, because `check_version_is_compatible` rewrites `version` to `CURRENT_VERSION` and destroys the evidence.
- Versionless input is left alone rather than guessed at.
- The validator works on a copy, so the caller's dict is never mutated and re-validating the same raw value cannot compound separators.
- A separator never lands inside a delimiter: code and formula runs are wrapped in `` ` ``/`$`, so the space goes to the plain neighbour, and when both neighbours are delimited it becomes a plain run of its own — `` `a``b` `` and `$a$$b$` are both corrupt.
- One-way and idempotent; warns once per process.

This does **not** cover live conversion against an old docling backend, which builds the document in memory at the current version with no old stamp to key on. That remains an accepted, documented risk, mitigated by the paired docling change.

## Behavioural changes to expect

- **Chunk text changes.** `ChunkingDocSerializer` defines no inline serializer, so it inherits the Markdown join. This is not golden-file cosmetics: it changes embeddings, so anyone with a persisted vector index gets silent retrieval drift on upgrade. It needs its own line in the release notes.
- Markdown / plaintext / HTML / LaTeX / DocLang exports are re-baselined.
- **DocTags is untouched** and explicitly out of scope. Its golden gains one empty `<text></text>` for the legacy fixture, because that document now carries an extra whitespace run and DocTags renders every run stripped — pre-existing behaviour, reproducible without any migration.

## The failure mode inverts

Worth flagging for reviewers: today a producer that omits boundary whitespace yields extra spaces — ugly, harmless, unnoticed for as long as it has existed. After this change the same omission yields **merged words**. The cost of getting it wrong goes from cosmetic to severe, and it lands on third-party backends and on anything constructing `DoclingDocument`s by hand. `add_inline_group`'s docstring now states the contract so the next backend author sees it.

## Testing

`685 passed, 6 skipped` on the rebased branch, plus the compat-coverage gate (`6 projectors registered`), mypy, and ruff.

New `test/test_inline_whitespace_contract.py` holds the contract as a table — one set of inline-run sequences checked against `md` / `itxt` / `html` / `latex` / `doclang`, including whitespace inside a formatted run and inside a formatted run *with* a hyperlink, plus a whitespace-only run. It also covers:

- DocLang round-trip identity over the same table, both pretty-printed and compact;
- load normalization for old-schema documents, including the full plain/code/formula pair matrix;
- that the migration does not mutate caller-owned input and is stable across repeated validation;
- chunk text, pinned so the embedding drift cannot recur silently.

Pre-contract fixtures deliberately keep their old version stamp, so their goldens are byte-identical to before this PR and act as the regression test for the migration.

## Release notes

- Ships as a **minor**, not a major. A 3.0 is not affordable on either package, so the commits deliberately avoid `feat!:` / `BREAKING CHANGE:` — python-semantic-release 7.34.6 would otherwise bump to 3.0.
- Paired with docling-project/docling#3891, which fixes the producers. Merge this first: the dangerous combination is a new docling-core under old backends, which merges words.
- Downstream repos pinning `docling-core` independently (docling-serve, docling-eval, docling-mcp, docling-jobkit) need a floor bump in the same wave.

