### PR TITLE
fix: html serialization of lists with mixed markers

### DIFF
--- a/docling_core/transforms/serializer/html.py
+++ b/docling_core/transforms/serializer/html.py
@@ -219,8 +219,8 @@ class HTMLTextSerializer(BaseModel, BaseTextSerializer):
                     html_tag="li",
                     text=text,
                     attrs=(
-                        {"style": f"list-style-type: '{item.marker} ';"}
-                        if params.show_original_list_item_marker and item.marker
+                        {"style": (f"list-style-type: '{item.marker} ';" if item.marker else "list-style-type: none;")}
+                        if params.show_original_list_item_marker
                         else {}
                     ),
                 )

--- a/test/data/chunker/0c_out_chunks.json
+++ b/test/data/chunker/0c_out_chunks.json
@@ -1,7 +1,7 @@
 {
     "root": [
         {
-            "text": "cell 0,0, 1 = cell 0,1. cell 1,0, 1 = <em><p>text in italic</p></em>. <ul>\n<li>list item 1</li>\n<li>list item 2</li>\n</ul>, 1 = cell 2,1. cell 3,0, 1 = inner cell 0,0, 1 = inner cell 0,1. inner cell 0,0, 2 = inner cell 0,2. inner cell 1,0, 1 = inner cell 1,1. inner cell 1,0, 2 = inner cell 1,2. <p>Some text in a generic group.</p>\n<p>More text in the group.</p>, 1 = cell 4,1",
+            "text": "cell 0,0, 1 = cell 0,1. cell 1,0, 1 = <em><p>text in italic</p></em>. <ul>\n<li style=\"list-style-type: none;\">list item 1</li>\n<li style=\"list-style-type: none;\">list item 2</li>\n</ul>, 1 = cell 2,1. cell 3,0, 1 = inner cell 0,0, 1 = inner cell 0,1. inner cell 0,0, 2 = inner cell 0,2. inner cell 1,0, 1 = inner cell 1,1. inner cell 1,0, 2 = inner cell 1,2. <p>Some text in a generic group.</p>\n<p>More text in the group.</p>, 1 = cell 4,1",
             "meta": {
                 "schema_name": "docling_core.transforms.chunker.DocMeta",
                 "version": "1.0.0",

--- a/test/data/doc/concatenated.html
+++ b/test/data/doc/concatenated.html
@@ -383,12 +383,12 @@
 <li style="list-style-type: '■ ';">
 list item 3
 <ol>
-<li>list item 3.a</li>
-<li>list item 3.b</li>
-<li>
+<li style="list-style-type: none;">list item 3.a</li>
+<li style="list-style-type: none;">list item 3.b</li>
+<li style="list-style-type: none;">
 list item 3.c
 <ol>
-<li>list item 3.c.i</li>
+<li style="list-style-type: none;">list item 3.c.i</li>
 </ol>
 </li>
 </ol>
@@ -403,7 +403,7 @@ list item 3.c
 </ul>
 <ul>
 <li style="list-style-type: '* ';">item 1 of list after empty list</li>
-<li>item 2 of list after empty list</li>
+<li style="list-style-type: none;">item 2 of list after empty list</li>
 </ul>
 <ul>
 <li style="list-style-type: '■ ';">item 1 of neighboring list</li>
@@ -443,21 +443,21 @@ item 2 of neighboring list
 <li style="list-style-type: '(iii) ';">
 Item 3 in A
 <ol>
-<li>Item 1 in B</li>
+<li style="list-style-type: none;">Item 1 in B</li>
 <li style="list-style-type: '42. ';">
 Item 2 in B
 <ol>
-<li>Item 1 in C</li>
-<li>Item 2 in C</li>
+<li style="list-style-type: none;">Item 1 in C</li>
+<li style="list-style-type: none;">Item 2 in C</li>
 </ol>
 </li>
-<li>Item 3 in B</li>
+<li style="list-style-type: none;">Item 3 in B</li>
 </ol>
 </li>
 <li style="list-style-type: '(iv) ';">Item 4 in A</li>
 </ol>
 <ul>
-<li>List item without parent list group</li>
+<li style="list-style-type: none;">List item without parent list group</li>
 </ul>
 <p>The end.</p>
 

--- a/test/data/doc/constructed_doc.embedded.html.gt
+++ b/test/data/doc/constructed_doc.embedded.html.gt
@@ -187,12 +187,12 @@
 <li style="list-style-type: '■ ';">
 list item 3
 <ol>
-<li>list item 3.a</li>
-<li>list item 3.b</li>
-<li>
+<li style="list-style-type: none;">list item 3.a</li>
+<li style="list-style-type: none;">list item 3.b</li>
+<li style="list-style-type: none;">
 list item 3.c
 <ol>
-<li>list item 3.c.i</li>
+<li style="list-style-type: none;">list item 3.c.i</li>
 </ol>
 </li>
 </ol>
@@ -207,7 +207,7 @@ list item 3.c
 </ul>
 <ul>
 <li style="list-style-type: '* ';">item 1 of list after empty list</li>
-<li>item 2 of list after empty list</li>
+<li style="list-style-type: none;">item 2 of list after empty list</li>
 </ul>
 <ul>
 <li style="list-style-type: '■ ';">item 1 of neighboring list</li>
@@ -247,21 +247,21 @@ item 2 of neighboring list
 <li style="list-style-type: '(iii) ';">
 Item 3 in A
 <ol>
-<li>Item 1 in B</li>
+<li style="list-style-type: none;">Item 1 in B</li>
 <li style="list-style-type: '42. ';">
 Item 2 in B
 <ol>
-<li>Item 1 in C</li>
-<li>Item 2 in C</li>
+<li style="list-style-type: none;">Item 1 in C</li>
+<li style="list-style-type: none;">Item 2 in C</li>
 </ol>
 </li>
-<li>Item 3 in B</li>
+<li style="list-style-type: none;">Item 3 in B</li>
 </ol>
 </li>
 <li style="list-style-type: '(iv) ';">Item 4 in A</li>
 </ol>
 <ul>
-<li>List item without parent list group</li>
+<li style="list-style-type: none;">List item without parent list group</li>
 </ul>
 <p>The end.</p>
 </div>

--- a/test/data/doc/constructed_doc.placeholder.html.gt
+++ b/test/data/doc/constructed_doc.placeholder.html.gt
@@ -187,12 +187,12 @@
 <li style="list-style-type: '■ ';">
 list item 3
 <ol>
-<li>list item 3.a</li>
-<li>list item 3.b</li>
-<li>
+<li style="list-style-type: none;">list item 3.a</li>
+<li style="list-style-type: none;">list item 3.b</li>
+<li style="list-style-type: none;">
 list item 3.c
 <ol>
-<li>list item 3.c.i</li>
+<li style="list-style-type: none;">list item 3.c.i</li>
 </ol>
 </li>
 </ol>
@@ -207,7 +207,7 @@ list item 3.c
 </ul>
 <ul>
 <li style="list-style-type: '* ';">item 1 of list after empty list</li>
-<li>item 2 of list after empty list</li>
+<li style="list-style-type: none;">item 2 of list after empty list</li>
 </ul>
 <ul>
 <li style="list-style-type: '■ ';">item 1 of neighboring list</li>
@@ -247,21 +247,21 @@ item 2 of neighboring list
 <li style="list-style-type: '(iii) ';">
 Item 3 in A
 <ol>
-<li>Item 1 in B</li>
+<li style="list-style-type: none;">Item 1 in B</li>
 <li style="list-style-type: '42. ';">
 Item 2 in B
 <ol>
-<li>Item 1 in C</li>
-<li>Item 2 in C</li>
+<li style="list-style-type: none;">Item 1 in C</li>
+<li style="list-style-type: none;">Item 2 in C</li>
 </ol>
 </li>
-<li>Item 3 in B</li>
+<li style="list-style-type: none;">Item 3 in B</li>
 </ol>
 </li>
 <li style="list-style-type: '(iv) ';">Item 4 in A</li>
 </ol>
 <ul>
-<li>List item without parent list group</li>
+<li style="list-style-type: none;">List item without parent list group</li>
 </ul>
 <p>The end.</p>
 </div>

--- a/test/data/doc/constructed_doc.referenced.html.gt
+++ b/test/data/doc/constructed_doc.referenced.html.gt
@@ -187,12 +187,12 @@
 <li style="list-style-type: '■ ';">
 list item 3
 <ol>
-<li>list item 3.a</li>
-<li>list item 3.b</li>
-<li>
+<li style="list-style-type: none;">list item 3.a</li>
+<li style="list-style-type: none;">list item 3.b</li>
+<li style="list-style-type: none;">
 list item 3.c
 <ol>
-<li>list item 3.c.i</li>
+<li style="list-style-type: none;">list item 3.c.i</li>
 </ol>
 </li>
 </ol>
@@ -207,7 +207,7 @@ list item 3.c
 </ul>
 <ul>
 <li style="list-style-type: '* ';">item 1 of list after empty list</li>
-<li>item 2 of list after empty list</li>
+<li style="list-style-type: none;">item 2 of list after empty list</li>
 </ul>
 <ul>
 <li style="list-style-type: '■ ';">item 1 of neighboring list</li>
@@ -247,21 +247,21 @@ item 2 of neighboring list
 <li style="list-style-type: '(iii) ';">
 Item 3 in A
 <ol>
-<li>Item 1 in B</li>
+<li style="list-style-type: none;">Item 1 in B</li>
 <li style="list-style-type: '42. ';">
 Item 2 in B
 <ol>
-<li>Item 1 in C</li>
-<li>Item 2 in C</li>
+<li style="list-style-type: none;">Item 1 in C</li>
+<li style="list-style-type: none;">Item 2 in C</li>
 </ol>
 </li>
-<li>Item 3 in B</li>
+<li style="list-style-type: none;">Item 3 in B</li>
 </ol>
 </li>
 <li style="list-style-type: '(iv) ';">Item 4 in A</li>
 </ol>
 <ul>
-<li>List item without parent list group</li>
+<li style="list-style-type: none;">List item without parent list group</li>
 </ul>
 <p>The end.</p>
 </div>

--- a/test/data/doc/constructed_document.yaml.html
+++ b/test/data/doc/constructed_document.yaml.html
@@ -187,12 +187,12 @@
 <li style="list-style-type: '■ ';">
 list item 3
 <ol>
-<li>list item 3.a</li>
-<li>list item 3.b</li>
-<li>
+<li style="list-style-type: none;">list item 3.a</li>
+<li style="list-style-type: none;">list item 3.b</li>
+<li style="list-style-type: none;">
 list item 3.c
 <ol>
-<li>list item 3.c.i</li>
+<li style="list-style-type: none;">list item 3.c.i</li>
 </ol>
 </li>
 </ol>
@@ -207,7 +207,7 @@ list item 3.c
 </ul>
 <ul>
 <li style="list-style-type: '* ';">item 1 of list after empty list</li>
-<li>item 2 of list after empty list</li>
+<li style="list-style-type: none;">item 2 of list after empty list</li>
 </ul>
 <ul>
 <li style="list-style-type: '■ ';">item 1 of neighboring list</li>
@@ -247,21 +247,21 @@ item 2 of neighboring list
 <li style="list-style-type: '(iii) ';">
 Item 3 in A
 <ol>
-<li>Item 1 in B</li>
+<li style="list-style-type: none;">Item 1 in B</li>
 <li style="list-style-type: '42. ';">
 Item 2 in B
 <ol>
-<li>Item 1 in C</li>
-<li>Item 2 in C</li>
+<li style="list-style-type: none;">Item 1 in C</li>
+<li style="list-style-type: none;">Item 2 in C</li>
 </ol>
 </li>
-<li>Item 3 in B</li>
+<li style="list-style-type: none;">Item 3 in B</li>
 </ol>
 </li>
 <li style="list-style-type: '(iv) ';">Item 4 in A</li>
 </ol>
 <ul>
-<li>List item without parent list group</li>
+<li style="list-style-type: none;">List item without parent list group</li>
 </ul>
 <p>The end.</p>
 </div>

--- a/test/data/doc/constructed_orig_true.gt.html
+++ b/test/data/doc/constructed_orig_true.gt.html
@@ -187,12 +187,12 @@
 <li style="list-style-type: '■ ';">
 list item 3
 <ol>
-<li>list item 3.a</li>
-<li>list item 3.b</li>
-<li>
+<li style="list-style-type: none;">list item 3.a</li>
+<li style="list-style-type: none;">list item 3.b</li>
+<li style="list-style-type: none;">
 list item 3.c
 <ol>
-<li>list item 3.c.i</li>
+<li style="list-style-type: none;">list item 3.c.i</li>
 </ol>
 </li>
 </ol>
@@ -207,7 +207,7 @@ list item 3.c
 </ul>
 <ul>
 <li style="list-style-type: '* ';">item 1 of list after empty list</li>
-<li>item 2 of list after empty list</li>
+<li style="list-style-type: none;">item 2 of list after empty list</li>
 </ul>
 <ul>
 <li style="list-style-type: '■ ';">item 1 of neighboring list</li>
@@ -247,21 +247,21 @@ item 2 of neighboring list
 <li style="list-style-type: '(iii) ';">
 Item 3 in A
 <ol>
-<li>Item 1 in B</li>
+<li style="list-style-type: none;">Item 1 in B</li>
 <li style="list-style-type: '42. ';">
 Item 2 in B
 <ol>
-<li>Item 1 in C</li>
-<li>Item 2 in C</li>
+<li style="list-style-type: none;">Item 1 in C</li>
+<li style="list-style-type: none;">Item 2 in C</li>
 </ol>
 </li>
-<li>Item 3 in B</li>
+<li style="list-style-type: none;">Item 3 in B</li>
 </ol>
 </li>
 <li style="list-style-type: '(iv) ';">Item 4 in A</li>
 </ol>
 <ul>
-<li>List item without parent list group</li>
+<li style="list-style-type: none;">List item without parent list group</li>
 </ul>
 <p>The end.</p>
 </div>

--- a/test/data/doc/polymers.gt.html
+++ b/test/data/doc/polymers.gt.html
@@ -180,48 +180,48 @@
 <h3>Elastomers</h3>
 <h2>Physical and Chemical Properties Relevant to Food Packaging</h2>
 <ul>
-<li>
+<li style="list-style-type: none;">
 <span class='inline-group'><strong>Barrier to gases and moisture</strong></span>
 <ul>
-<li>Oxygen transmission rate (OTR) – how much O₂ passes per square meter per hour.</li>
-<li>Carbon‑dioxide transmission rate (CO₂TR) – how much CO₂ permeates.</li>
-<li>Water‑vapor transmission rate (WVTR) – amount of moisture that diffuses.</li>
-<li>Influence of polymer crystallinity, copolymer composition, and barrier additives on all three rates.</li>
+<li style="list-style-type: none;">Oxygen transmission rate (OTR) – how much O₂ passes per square meter per hour.</li>
+<li style="list-style-type: none;">Carbon‑dioxide transmission rate (CO₂TR) – how much CO₂ permeates.</li>
+<li style="list-style-type: none;">Water‑vapor transmission rate (WVTR) – amount of moisture that diffuses.</li>
+<li style="list-style-type: none;">Influence of polymer crystallinity, copolymer composition, and barrier additives on all three rates.</li>
 </ul>
 </li>
-<li>
+<li style="list-style-type: none;">
 <span class='inline-group'><strong>Tensile strength</strong></span>
 <ul>
-<li>Tensile modulus (MPa) – stiffness of the material.</li>
-<li>Elongation at break (%) – flexibility before failure.</li>
-<li>Standard test conditions (temperature, strain rate) that determine the reported values.</li>
+<li style="list-style-type: none;">Tensile modulus (MPa) – stiffness of the material.</li>
+<li style="list-style-type: none;">Elongation at break (%) – flexibility before failure.</li>
+<li style="list-style-type: none;">Standard test conditions (temperature, strain rate) that determine the reported values.</li>
 </ul>
 </li>
-<li>
+<li style="list-style-type: none;">
 <span class='inline-group'><strong>Heat resistance</strong></span>
 <ul>
-<li>Glass transition temperature (Tg) – the temperature at which the polymer softens.</li>
-<li>Heat deflection temperature (HDT) – the temperature at which it bends under load.</li>
-<li>Thermal degradation onset temperature – the point where chemical breakdown starts.</li>
-<li>Suitability for microwave, oven, or sterilization processes.</li>
+<li style="list-style-type: none;">Glass transition temperature (Tg) – the temperature at which the polymer softens.</li>
+<li style="list-style-type: none;">Heat deflection temperature (HDT) – the temperature at which it bends under load.</li>
+<li style="list-style-type: none;">Thermal degradation onset temperature – the point where chemical breakdown starts.</li>
+<li style="list-style-type: none;">Suitability for microwave, oven, or sterilization processes.</li>
 </ul>
 </li>
-<li>
+<li style="list-style-type: none;">
 <span class='inline-group'><strong>Chemical stability</strong></span>
 <ul>
-<li>Resistance to acids, bases, and organic solvents used in food processing.</li>
-<li>Oxidative stability – how well the polymer resists free‑radical degradation.</li>
-<li>Interaction with food constituents such as fatty acids, alcohols, and acids.</li>
-<li>Impact on polymer aging and shelf‑life of packaged products.</li>
+<li style="list-style-type: none;">Resistance to acids, bases, and organic solvents used in food processing.</li>
+<li style="list-style-type: none;">Oxidative stability – how well the polymer resists free‑radical degradation.</li>
+<li style="list-style-type: none;">Interaction with food constituents such as fatty acids, alcohols, and acids.</li>
+<li style="list-style-type: none;">Impact on polymer aging and shelf‑life of packaged products.</li>
 </ul>
 </li>
-<li>
+<li style="list-style-type: none;">
 <span class='inline-group'><strong>Migration potential</strong></span>
 <ul>
-<li>Results of migration tests (e.g., extraction of additives or additives’ leaching).</li>
-<li>Compliance with regulatory limits (e.g., EU Directive 10/2011, FDA food‑contact legislation).</li>
-<li>Effect of temperature, time, and food type on the amount of material that migrates.</li>
-<li>Barrier performance against the migration of contaminants or degradation products.</li>
+<li style="list-style-type: none;">Results of migration tests (e.g., extraction of additives or additives’ leaching).</li>
+<li style="list-style-type: none;">Compliance with regulatory limits (e.g., EU Directive 10/2011, FDA food‑contact legislation).</li>
+<li style="list-style-type: none;">Effect of temperature, time, and food type on the amount of material that migrates.</li>
+<li style="list-style-type: none;">Barrier performance against the migration of contaminants or degradation products.</li>
 </ul>
 </li>
 </ul>
@@ -233,85 +233,85 @@
 <h2>Safety and Regulatory Considerations</h2>
 <strong><p>Common migration testing methods</p></strong>
 <ul>
-<li>
+<li style="list-style-type: none;">
 <span class='inline-group'><strong>Extraction in food simulants</strong></span>
 <ul>
-<li>
+<li style="list-style-type: none;">
 <span class='inline-group'><em>What it is</em> : Samples of the packaging material are immersed in a liquid that mimics the chemical properties of a specific food type (e.g., aqueous, acidic, fatty).</span>
 </li>
-<li>
+<li style="list-style-type: none;">
 <span class='inline-group'><em>Typical simulants</em> :</span>
 <ul>
-<li>3% acetic acid (for acidic foods)</li>
-<li>50% ethanol (for alcohol‑based foods)</li>
-<li>95% ethanol (for high‑fat foods)</li>
-<li>Distilled water (for aqueous foods)</li>
+<li style="list-style-type: none;">3% acetic acid (for acidic foods)</li>
+<li style="list-style-type: none;">50% ethanol (for alcohol‑based foods)</li>
+<li style="list-style-type: none;">95% ethanol (for high‑fat foods)</li>
+<li style="list-style-type: none;">Distilled water (for aqueous foods)</li>
 </ul>
 </li>
-<li>
+<li style="list-style-type: none;">
 <span class='inline-group'><em>Procedure</em> :</span>
 <ul>
-<li>Prepare a defined volume of simulant in a sealed vessel.</li>
-<li>Immerse the material for a set time at a controlled temperature (often 50 °C–70 °C).</li>
-<li>Remove, filter, and concentrate the extract for analysis.</li>
+<li style="list-style-type: none;">Prepare a defined volume of simulant in a sealed vessel.</li>
+<li style="list-style-type: none;">Immerse the material for a set time at a controlled temperature (often 50 °C–70 °C).</li>
+<li style="list-style-type: none;">Remove, filter, and concentrate the extract for analysis.</li>
 </ul>
 </li>
-<li>
+<li style="list-style-type: none;">
 <span class='inline-group'><em>Analysis</em> : GC‑MS, LC‑MS, or HPLC depending on the analyte class.</span>
 </li>
-<li>
+<li style="list-style-type: none;">
 <span class='inline-group'><em>Advantages</em> : Direct assessment of potential migration into a realistic medium; scalable for routine testing.</span>
 </li>
-<li>
+<li style="list-style-type: none;">
 <span class='inline-group'><em>Limitations</em> : Does not account for headspace gas migration; may underestimate migration of highly volatile substances.</span>
 </li>
 </ul>
 </li>
-<li>
+<li style="list-style-type: none;">
 <span class='inline-group'><strong>Headspace analysis</strong></span>
 <ul>
-<li>
+<li style="list-style-type: none;">
 <span class='inline-group'><em>What it is</em> : Measurement of volatile substances that migrate from the material into the surrounding gas phase.</span>
 </li>
-<li>
+<li style="list-style-type: none;">
 <span class='inline-group'><em>Procedure</em> :</span>
 <ul>
-<li>Seal the material in a headspace vial or chamber.</li>
-<li>Equilibrate at a defined temperature (commonly 25 °C–60 °C).</li>
-<li>Sample the gas phase with a gas sampling needle or syringe.</li>
-<li>Analyze via GC‑FID, GC‑MS, or PTR‑MS.</li>
+<li style="list-style-type: none;">Seal the material in a headspace vial or chamber.</li>
+<li style="list-style-type: none;">Equilibrate at a defined temperature (commonly 25 °C–60 °C).</li>
+<li style="list-style-type: none;">Sample the gas phase with a gas sampling needle or syringe.</li>
+<li style="list-style-type: none;">Analyze via GC‑FID, GC‑MS, or PTR‑MS.</li>
 </ul>
 </li>
-<li>
+<li style="list-style-type: none;">
 <span class='inline-group'><em>Applications</em> : Assessment of aromas, flavor compounds, or volatile contaminants.</span>
 </li>
-<li>
+<li style="list-style-type: none;">
 <span class='inline-group'><em>Advantages</em> : Sensitive to low‑concentration volatiles; minimal sample preparation.</span>
 </li>
-<li>
+<li style="list-style-type: none;">
 <span class='inline-group'><em>Limitations</em> : Does not capture non‑volatile migration; results depend on equilibrium time and temperature.</span>
 </li>
 </ul>
 </li>
-<li>
+<li style="list-style-type: none;">
 <span class='inline-group'><strong>Direct contact tests</strong></span>
 <ul>
-<li>
+<li style="list-style-type: none;">
 <span class='inline-group'><em>What it is</em> : The packaging material is placed in direct contact with the food or food simulant, often using a defined food‑packaging configuration.</span>
 </li>
-<li>
+<li style="list-style-type: none;">
 <span class='inline-group'><em>Procedure</em> :</span>
 <ul>
-<li>Assemble the material and food (or simulant) in a mold or container that simulates real usage (e.g., sealed pouch, jar).</li>
-<li>Incubate for the intended storage time at the relevant temperature.</li>
-<li>Extract or sample the food directly (e.g., through the material or by taking a portion of the food).</li>
-<li>Analyze for migrated substances.</li>
+<li style="list-style-type: none;">Assemble the material and food (or simulant) in a mold or container that simulates real usage (e.g., sealed pouch, jar).</li>
+<li style="list-style-type: none;">Incubate for the intended storage time at the relevant temperature.</li>
+<li style="list-style-type: none;">Extract or sample the food directly (e.g., through the material or by taking a portion of the food).</li>
+<li style="list-style-type: none;">Analyze for migrated substances.</li>
 </ul>
 </li>
-<li>
+<li style="list-style-type: none;">
 <span class='inline-group'><em>Advantages</em> : Mimics real consumer exposure; captures both liquid and vapor migration pathways.</span>
 </li>
-<li>
+<li style="list-style-type: none;">
 <span class='inline-group'><em>Limitations</em> : More labor‑intensive; requires careful control of contact area, thickness, and sealing integrity.</span>
 </li>
 </ul>
@@ -320,31 +320,31 @@
 <p>These three approaches—extraction in food simulants, headspace analysis, and direct contact tests—complement each other to provide a comprehensive assessment of potential migration from packaging into food.</p>
 <h2>Environmental Impact and Sustainability</h2>
 <ul>
-<li>
+<li style="list-style-type: none;">
 <strong>Resource consumption</strong>
 <ul>
-<li>Energy usage for manufacturing, transportation, and daily activities</li>
-<li>Water consumption in agriculture, industry, and household use</li>
-<li>Extraction of raw materials (mining, drilling, logging)</li>
-<li>Associated carbon emissions and climate impact</li>
+<li style="list-style-type: none;">Energy usage for manufacturing, transportation, and daily activities</li>
+<li style="list-style-type: none;">Water consumption in agriculture, industry, and household use</li>
+<li style="list-style-type: none;">Extraction of raw materials (mining, drilling, logging)</li>
+<li style="list-style-type: none;">Associated carbon emissions and climate impact</li>
 </ul>
 </li>
-<li>
+<li style="list-style-type: none;">
 <strong>Landfill waste</strong>
 <ul>
-<li>Rapid growth in waste volume due to population and consumption increases</li>
-<li>Methane production from decomposing organic matter</li>
-<li>Leachate generation that can contaminate soil and groundwater</li>
-<li>Limited landfill space leading to overburdened disposal sites</li>
+<li style="list-style-type: none;">Rapid growth in waste volume due to population and consumption increases</li>
+<li style="list-style-type: none;">Methane production from decomposing organic matter</li>
+<li style="list-style-type: none;">Leachate generation that can contaminate soil and groundwater</li>
+<li style="list-style-type: none;">Limited landfill space leading to overburdened disposal sites</li>
 </ul>
 </li>
-<li>
+<li style="list-style-type: none;">
 <strong>Plastic pollution</strong>
 <ul>
-<li>Accumulation of large‑scale debris in oceans and rivers</li>
-<li>Formation of microplastics that enter the food chain</li>
-<li>Low recycling rates and inefficient waste separation</li>
-<li>Prevalence of single‑use plastics contributing to ongoing litter</li>
+<li style="list-style-type: none;">Accumulation of large‑scale debris in oceans and rivers</li>
+<li style="list-style-type: none;">Formation of microplastics that enter the food chain</li>
+<li style="list-style-type: none;">Low recycling rates and inefficient waste separation</li>
+<li style="list-style-type: none;">Prevalence of single‑use plastics contributing to ongoing litter</li>
 </ul>
 </li>
 </ul>
@@ -353,40 +353,40 @@
 <h2>Emerging Trends and Future Outlook</h2>
 <h2>Conclusion</h2>
 <ul>
-<li>
+<li style="list-style-type: none;">
 <strong>Polymer Versatility</strong>
 <ul>
-<li>Multiple functional groups enable tailoring of mechanical, thermal, and chemical properties for specific applications</li>
-<li>Used across diverse fields: electronics (semiconductors, flexible displays), biomedicine (drug delivery, tissue scaffolds), packaging, automotive, and aerospace</li>
-<li>Compatible with additive manufacturing techniques (3D printing, fused deposition modeling) for rapid prototyping and custom parts</li>
-<li>Recyclability and upcycling potential, allowing polymers to be re‑processed into higher‑value materials</li>
+<li style="list-style-type: none;">Multiple functional groups enable tailoring of mechanical, thermal, and chemical properties for specific applications</li>
+<li style="list-style-type: none;">Used across diverse fields: electronics (semiconductors, flexible displays), biomedicine (drug delivery, tissue scaffolds), packaging, automotive, and aerospace</li>
+<li style="list-style-type: none;">Compatible with additive manufacturing techniques (3D printing, fused deposition modeling) for rapid prototyping and custom parts</li>
+<li style="list-style-type: none;">Recyclability and upcycling potential, allowing polymers to be re‑processed into higher‑value materials</li>
 </ul>
 </li>
-<li>
+<li style="list-style-type: none;">
 <strong>Regulatory Compliance</strong>
 <ul>
-<li>Adherence to FDA, CE, and ISO standards for medical and consumer products</li>
-<li>Compliance with chemical restriction directives such as RoHS, REACH, and TSCA to limit hazardous substances</li>
-<li>Robust traceability systems (batch records, chain‑of‑custody documentation) required for quality assurance</li>
-<li>Market‑specific adaptations: meeting US FDA 510(k) or PMA requirements, EU MDR for medical devices, and emerging guidelines in Asia</li>
+<li style="list-style-type: none;">Adherence to FDA, CE, and ISO standards for medical and consumer products</li>
+<li style="list-style-type: none;">Compliance with chemical restriction directives such as RoHS, REACH, and TSCA to limit hazardous substances</li>
+<li style="list-style-type: none;">Robust traceability systems (batch records, chain‑of‑custody documentation) required for quality assurance</li>
+<li style="list-style-type: none;">Market‑specific adaptations: meeting US FDA 510(k) or PMA requirements, EU MDR for medical devices, and emerging guidelines in Asia</li>
 </ul>
 </li>
-<li>
+<li style="list-style-type: none;">
 <strong>Environmental Sustainability</strong>
 <ul>
-<li>Life‑cycle assessments (LCAs) demonstrate reductions in greenhouse gas emissions and energy consumption compared to traditional materials</li>
-<li>Development of renewable monomers (PLA from corn starch, PHA from microbial fermentation) to reduce fossil‑fuel dependence</li>
-<li>Biodegradable and compostable polymers that safely break down under industrial or home composting conditions</li>
-<li>Closed‑loop recycling strategies and chemical depolymerization processes to recover monomers and reduce waste</li>
+<li style="list-style-type: none;">Life‑cycle assessments (LCAs) demonstrate reductions in greenhouse gas emissions and energy consumption compared to traditional materials</li>
+<li style="list-style-type: none;">Development of renewable monomers (PLA from corn starch, PHA from microbial fermentation) to reduce fossil‑fuel dependence</li>
+<li style="list-style-type: none;">Biodegradable and compostable polymers that safely break down under industrial or home composting conditions</li>
+<li style="list-style-type: none;">Closed‑loop recycling strategies and chemical depolymerization processes to recover monomers and reduce waste</li>
 </ul>
 </li>
-<li>
+<li style="list-style-type: none;">
 <strong>Ongoing Research</strong>
 <ul>
-<li>Creation of smart polymers (shape‑memory, self‑healing, stimuli‑responsive) for adaptive applications in robotics and wearables</li>
-<li>Exploration of polymer nanocomposites to enhance strength, thermal conductivity, and electrical properties</li>
-<li>Application of machine‑learning algorithms for high‑throughput polymer design and property prediction</li>
-<li>Long‑term durability studies in extreme environments (high‑temperature, corrosive, UV exposure) to validate performance for aerospace and infrastructure use</li>
+<li style="list-style-type: none;">Creation of smart polymers (shape‑memory, self‑healing, stimuli‑responsive) for adaptive applications in robotics and wearables</li>
+<li style="list-style-type: none;">Exploration of polymer nanocomposites to enhance strength, thermal conductivity, and electrical properties</li>
+<li style="list-style-type: none;">Application of machine‑learning algorithms for high‑throughput polymer design and property prediction</li>
+<li style="list-style-type: none;">Long‑term durability studies in extreme environments (high‑temperature, corrosive, UV exposure) to validate performance for aerospace and infrastructure use</li>
 </ul>
 </li>
 </ul>

--- a/test/data/doc/rich_table.gt.html
+++ b/test/data/doc/rich_table.gt.html
@@ -175,8 +175,8 @@
 <div class='page'>
 <h1>Rich tables</h1>
 <table><tbody><tr><td>cell 0,0</td><td>cell 0,1</td></tr><tr><td>cell 1,0</td><td><em><p>text in italic</p></em></td></tr><tr><td><ul>
-<li>list item 1</li>
-<li>list item 2</li>
+<li style="list-style-type: none;">list item 1</li>
+<li style="list-style-type: none;">list item 2</li>
 </ul></td><td>cell 2,1</td></tr><tr><td>cell 3,0</td><td><table><tbody><tr><td>inner cell 0,0</td><td>inner cell 0,1</td><td>inner cell 0,2</td></tr><tr><td>inner cell 1,0</td><td>inner cell 1,1</td><td>inner cell 1,2</td></tr></tbody></table></td></tr><tr><td><p>Some text in a generic group.</p>
 <p>More text in the group.</p></td><td>cell 4,1</td></tr></tbody></table>
 </div>

--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -900,6 +900,50 @@ def test_html_list_item_markers(sample_doc):
         )
 
 
+def test_html_mixed_list_items_do_not_invent_markers():
+    doc = DoclingDocument(name="mixed-list")
+    list_group = doc.add_list_group(name="table-of-contents")
+
+    doc.add_list_item(
+        text="Purpose",
+        orig="1. Purpose",
+        enumerated=True,
+        marker="1.",
+        parent=list_group,
+    )
+    doc.add_list_item(
+        text="1.1 Scope",
+        orig="1.1 Scope",
+        enumerated=False,
+        marker="",
+        parent=list_group,
+    )
+    doc.add_list_item(
+        text="Operation",
+        orig="2. Operation",
+        enumerated=True,
+        marker="2.",
+        parent=list_group,
+    )
+
+    html = (
+        HTMLDocSerializer(
+            doc=doc,
+            params=HTMLParams(
+                prettify=False,
+                show_original_list_item_marker=True,
+            ),
+        )
+        .serialize()
+        .text
+    )
+
+    assert "<ol>" in html
+    assert "<li style=\"list-style-type: '1. ';\">Purpose</li>" in html
+    assert '<li style="list-style-type: none;">1.1 Scope</li>' in html
+    assert "<li style=\"list-style-type: '2. ';\">Operation</li>" in html
+
+
 def test_html_nested_lists():
     src = Path("./test/data/doc/polymers.json")
     doc = DoclingDocument.load_from_json(src)


### PR DESCRIPTION
This PR implements option 1 of issue #699 

HTML list items with an empty `marker` now render with `list-style-type: none;` when original markers are being shown, so the browser no longer invents numbering that is not present in the `DoclingDocument`.

### Changes

- Updated `HTMLTextSerializer` to suppress default list markers for unmarked list items while preserving explicit markers.
- Added a regression test for a mixed enumerated/non-enumerated list group.
- Refreshed the affected HTML and chunker goldens to match the new serializer output.