### PR TITLE
feat: accept EBCDIC MIME types in DocumentOrigin

### DIFF
--- a/docling_core/types/doc/common/origin.py
+++ b/docling_core/types/doc/common/origin.py
@@ -27,6 +27,7 @@ class DocumentOrigin(BaseModel):
     _extra_mimetypes: typing.ClassVar[list[str]] = [
         "application/epub+zip",
         "application/vnd.box.boxnote",
+        "application/vnd.docling.ebcdic",  # accepted alias, see application/x-ebcdic
         "application/vnd.oasis.opendocument.presentation",
         "application/vnd.oasis.opendocument.spreadsheet",
         "application/vnd.oasis.opendocument.text",
@@ -36,6 +37,10 @@ class DocumentOrigin(BaseModel):
         "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
         "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
         "application/vnd.openxmlformats-officedocument.wordprocessingml.template",
+        # EBCDIC data files have no IANA-registered media type, so they will never
+        # appear in mimetypes.types_map. "application/x-ebcdic" is the standard
+        # spelling docling emits; the vendor-tree alias above is accepted as well.
+        "application/x-ebcdic",
         "audio/mp3",
         "audio/wav",
         "audio/x-wav",

--- a/test/test_doc_base.py
+++ b/test/test_doc_base.py
@@ -1,7 +1,29 @@
 import pytest
 from pydantic import ValidationError
 
-from docling_core.types.doc import DocItemLabel, DoclingDocument, TrackSource
+from docling_core.types.doc import DocItemLabel, DoclingDocument, DocumentOrigin, TrackSource
+
+
+@pytest.mark.parametrize(
+    "mimetype",
+    [
+        "application/pdf",
+        "application/vnd.box.boxnote",
+        "application/vnd.docling.ebcdic",
+        "application/x-ebcdic",
+        "text/markdown",
+    ],
+)
+def test_document_origin_mimetype(mimetype: str):
+    """Test that DocumentOrigin accepts the supported MIME types."""
+    origin = DocumentOrigin(mimetype=mimetype, binary_hash=42, filename="test")
+    assert origin.mimetype == mimetype
+
+
+def test_document_origin_invalid_mimetype():
+    """Test that DocumentOrigin rejects unknown MIME types."""
+    with pytest.raises(ValidationError, match="is not a valid MIME type"):
+        DocumentOrigin(mimetype="application/x-not-a-mimetype", binary_hash=42, filename="test")
 
 
 def test_track_source():


### PR DESCRIPTION
  Registers the EBCDIC media type with `DocumentOrigin.validate_mimetype`, so
  the EBCDIC backend can build a `DoclingDocument` with an honest origin.

  EBCDIC data files have no IANA-registered media type, so `mimetypes.types_map`
  will never contain one, and `_extra_mimetypes` is a closed `ClassVar` that
  downstream packages cannot extend. Until now docling worked around this by
  calling `mimetypes.add_type` at import time in
  `docling/datamodel/base_models.py` — a global side effect on an unrelated
  stdlib registry that only happened to work because that module is imported
  before any `DocumentOrigin` is constructed.

  ### Changes

  - Add `application/x-ebcdic` to `DocumentOrigin._extra_mimetypes`. This is the
    standard spelling and the one docling emits from
    `FormatToMimeType[InputFormat.EBCDIC]` and `_MIME_TYPE` in
    `docling/backend/ebcdic_backend.py`. `application/octet-stream` was rejected
    because it would collide with every other unrecognized binary input during
    format detection.
  - Also accept `application/vnd.docling.ebcdic` as an alias, so origins written
    with the vendor-tree spelling still validate.
  - Add tests for both, plus a stdlib type, two existing extras, and a negative
    case asserting unknown types still raise.

  `ImageRef.validate_mimetype` is a separate validator for image payloads and is
  untouched.