### PR TITLE
feat: optionally preserve page numbers when concatenating

### DIFF
--- a/docling_core/types/doc/document.py
+++ b/docling_core/types/doc/document.py
@@ -5255,12 +5255,23 @@ class DoclingDocument(BaseModel):
         def get_item_list(self, key: str) -> list[NodeItem]:
             return getattr(self, key)
 
-        def index(self, doc: "DoclingDocument", page_nrs: Optional[set[int]] = None) -> None:
+        def index(
+            self,
+            doc: "DoclingDocument",
+            page_nrs: Optional[set[int]] = None,
+            preserve_page_numbers: bool = False,
+        ) -> None:
             if page_nrs is not None and (unavailable_page_nrs := page_nrs - set(doc.pages.keys())):
                 raise ValueError(f"The following page numbers are not present in the document: {unavailable_page_nrs}")
 
             orig_ref_to_new_ref: dict[str, str] = {}
-            page_delta = self._max_page - min(doc.pages.keys()) + 1 if doc.pages else 0
+            indexed_page_nrs = set(doc.pages) if page_nrs is None else page_nrs
+            if preserve_page_numbers:
+                if overlapping_page_nrs := indexed_page_nrs & set(self.pages):
+                    raise ValueError(f"Cannot preserve overlapping page numbers: {sorted(overlapping_page_nrs)}")
+                page_delta = 0
+            else:
+                page_delta = self._max_page - min(doc.pages.keys()) + 1 if doc.pages else 0
 
             if self._body is None:
                 self._body = GroupItem(**doc.body.model_dump(exclude={"children"}))
@@ -5423,11 +5434,27 @@ class DoclingDocument(BaseModel):
         return res_doc
 
     @classmethod
-    def concatenate(cls, docs: Sequence["DoclingDocument"]) -> "DoclingDocument":
-        """Concatenate multiple documents into a single document."""
+    def concatenate(
+        cls,
+        docs: Sequence["DoclingDocument"],
+        *,
+        preserve_page_numbers: bool = False,
+    ) -> "DoclingDocument":
+        """Concatenate multiple documents into a single document.
+
+        Args:
+            docs: Documents to concatenate in order.
+            preserve_page_numbers: Preserve each input document's original page
+                numbers instead of shifting them into a continuous sequence. The
+                input documents must not contain overlapping page numbers.
+
+        Raises:
+            ValueError: If page numbers overlap while ``preserve_page_numbers``
+                is enabled.
+        """
         doc_index = DoclingDocument._DocIndex()
         for doc in docs:
-            doc_index.index(doc=doc)
+            doc_index.index(doc=doc, preserve_page_numbers=preserve_page_numbers)
 
         res_doc = DoclingDocument(name=doc_index.get_name())
         res_doc._update_from_index(doc_index)

--- a/test/test_docling_doc.py
+++ b/test/test_docling_doc.py
@@ -1847,6 +1847,67 @@ def test_concatenate_shifts_graph_cell_pages_for_keyvalue_and_form():
     assert form_item_pages == [[1], [2]]
 
 
+def test_concatenate_can_preserve_original_page_numbers():
+    def _make_provenance(page_no: int) -> ProvenanceItem:
+        return ProvenanceItem(
+            page_no=page_no,
+            charspan=(0, 1),
+            bbox=BoundingBox(
+                l=10,
+                t=40,
+                r=30,
+                b=10,
+                coord_origin=CoordOrigin.BOTTOMLEFT,
+            ),
+        )
+
+    def _make_doc(page_no: int) -> DoclingDocument:
+        doc = DoclingDocument(name="source")
+        doc.add_page(page_no=page_no, size=Size(width=100, height=100))
+        doc.add_text(label=DocItemLabel.TEXT, text=str(page_no), prov=_make_provenance(page_no))
+        doc.add_key_values(
+            graph=GraphData(
+                cells=[
+                    GraphCell(
+                        label=GraphCellLabel.KEY,
+                        cell_id=1,
+                        text="k",
+                        orig="k",
+                        prov=_make_provenance(page_no),
+                    )
+                ],
+                links=[],
+            )
+        )
+        return doc
+
+    merged = DoclingDocument.concatenate(
+        docs=[_make_doc(page_no=5), _make_doc(page_no=11)],
+        preserve_page_numbers=True,
+    )
+
+    assert sorted(merged.pages) == [5, 11]
+    assert [merged.pages[page_no].page_no for page_no in sorted(merged.pages)] == [5, 11]
+    assert [item.prov[0].page_no for item in merged.texts] == [5, 11]
+    assert [item.graph.cells[0].prov.page_no for item in merged.key_value_items if item.graph.cells[0].prov] == [
+        5,
+        11,
+    ]
+
+
+def test_concatenate_rejects_overlapping_preserved_page_numbers():
+    def _make_doc(name: str) -> DoclingDocument:
+        doc = DoclingDocument(name=name)
+        doc.add_page(page_no=5, size=Size(width=100, height=100))
+        return doc
+
+    with pytest.raises(ValueError, match=r"Cannot preserve overlapping page numbers: \[5\]"):
+        DoclingDocument.concatenate(
+            docs=[_make_doc("first"), _make_doc("second")],
+            preserve_page_numbers=True,
+        )
+
+
 def test_concatenate_squeezes_successive_duplicate_names():
     def _make_doc(name: str) -> DoclingDocument:
         doc = DoclingDocument(name=name)


### PR DESCRIPTION
## Summary

- add an opt-in `preserve_page_numbers` argument to `DoclingDocument.concatenate()`
- preserve page keys, `PageItem.page_no`, item provenance, and key-value/form graph-cell provenance when enabled
- reject overlapping input page numbers instead of silently replacing pages
- keep the existing continuous renumbering behavior as the default

## Motivation

`_DocIndex.index()` always calculates a page offset that shifts every input document into a continuous sequence. This also shifts the first chunk when its original page range does not start at page 1, so callers processing PDF page ranges in parallel lose the source page numbers after concatenation.

The new opt-in mode uses a zero page offset after checking that the input ranges do not overlap. Existing callers are unaffected.

Closes docling-project/docling#3890.

## Validation

- targeted concatenate and filter tests: 6 passed
- Ruff lint and format checks
- MyPy on the changed implementation and tests
- issue fixtures: pages 5–10 and page 11 concatenate to pages 5–11; the 3,723-item result passes JSON serialization and model validation
