### PR TITLE
feat: update the add_<...> items with source uniformly

### DIFF
--- a/docling_core/types/doc/document.py
+++ b/docling_core/types/doc/document.py
@@ -1446,6 +1446,8 @@ class DoclingDocument(BaseModel):
         content_layer: Optional[ContentLayer] = None,
         formatting: Optional[Formatting] = None,
         hyperlink: Optional[Union[AnyUrl, Path]] = None,
+        *,
+        source: Optional[SourceType] = None,
     ):
         """add_list_item.
 
@@ -1480,6 +1482,8 @@ class DoclingDocument(BaseModel):
         )
         if prov:
             list_item.prov.append(prov)
+        if source is not None:
+            list_item.source.append(source)
         if content_layer:
             list_item.content_layer = content_layer
 
@@ -1522,6 +1526,7 @@ class DoclingDocument(BaseModel):
                 content_layer=content_layer,
                 formatting=formatting,
                 hyperlink=hyperlink,
+                source=source,
             )
 
         elif label in [DocItemLabel.LIST_ITEM]:
@@ -1533,6 +1538,7 @@ class DoclingDocument(BaseModel):
                 content_layer=content_layer,
                 formatting=formatting,
                 hyperlink=hyperlink,
+                source=source,
             )
 
         elif label in [DocItemLabel.SECTION_HEADER]:
@@ -1544,6 +1550,7 @@ class DoclingDocument(BaseModel):
                 content_layer=content_layer,
                 formatting=formatting,
                 hyperlink=hyperlink,
+                source=source,
                 **kwargs,
             )
 
@@ -1556,6 +1563,7 @@ class DoclingDocument(BaseModel):
                 content_layer=content_layer,
                 formatting=formatting,
                 hyperlink=hyperlink,
+                source=source,
             )
         elif label in [DocItemLabel.FORMULA]:
             return self.add_formula(
@@ -1566,6 +1574,7 @@ class DoclingDocument(BaseModel):
                 content_layer=content_layer,
                 formatting=formatting,
                 hyperlink=hyperlink,
+                source=source,
             )
         elif label in [DocItemLabel.FIELD_HEADING]:
             return self.add_field_heading(
@@ -1576,6 +1585,7 @@ class DoclingDocument(BaseModel):
                 content_layer=content_layer,
                 formatting=formatting,
                 hyperlink=hyperlink,
+                source=source,
                 **kwargs,
             )
         elif label in [DocItemLabel.FIELD_VALUE]:
@@ -1587,6 +1597,7 @@ class DoclingDocument(BaseModel):
                 content_layer=content_layer,
                 formatting=formatting,
                 hyperlink=hyperlink,
+                source=source,
                 **kwargs,
             )
 
@@ -1610,7 +1621,7 @@ class DoclingDocument(BaseModel):
             )
             if prov:
                 text_item.prov.append(prov)
-            if source:
+            if source is not None:
                 text_item.source.append(source)
 
             if content_layer:
@@ -1628,6 +1639,7 @@ class DoclingDocument(BaseModel):
         prov: Optional[ProvenanceItem] = None,
         parent: Optional[NodeItem] = None,
         targets: Optional[list[Union[DocItem, tuple[DocItem, tuple[int, int]]]]] = None,
+        source: Optional[SourceType] = None,
     ):
         """Adds a comment to the document, assigning it to the given targets.
 
@@ -1643,6 +1655,7 @@ class DoclingDocument(BaseModel):
             prov=prov,
             parent=parent,
             content_layer=ContentLayer.NOTES,
+            source=source,
         )
         if targets:
             for target in targets:
@@ -1662,6 +1675,8 @@ class DoclingDocument(BaseModel):
         label: DocItemLabel = DocItemLabel.TABLE,
         content_layer: Optional[ContentLayer] = None,
         annotations: Optional[list[TableAnnotationType]] = None,
+        *,
+        source: Optional[SourceType] = None,
     ):
         """add_table.
 
@@ -1687,6 +1702,8 @@ class DoclingDocument(BaseModel):
         )
         if prov:
             tbl_item.prov.append(prov)
+        if source is not None:
+            tbl_item.source.append(source)
         if content_layer:
             tbl_item.content_layer = content_layer
 
@@ -1706,6 +1723,8 @@ class DoclingDocument(BaseModel):
         prov: Optional[ProvenanceItem] = None,
         parent: Optional[NodeItem] = None,
         content_layer: Optional[ContentLayer] = None,
+        *,
+        source: Optional[SourceType] = None,
     ):
         """add_picture.
 
@@ -1730,6 +1749,8 @@ class DoclingDocument(BaseModel):
         )
         if prov:
             fig_item.prov.append(prov)
+        if source is not None:
+            fig_item.source.append(source)
         if content_layer:
             fig_item.content_layer = content_layer
         if caption:
@@ -1749,6 +1770,8 @@ class DoclingDocument(BaseModel):
         content_layer: Optional[ContentLayer] = None,
         formatting: Optional[Formatting] = None,
         hyperlink: Optional[Union[AnyUrl, Path]] = None,
+        *,
+        source: Optional[SourceType] = None,
     ):
         """add_title.
 
@@ -1776,6 +1799,8 @@ class DoclingDocument(BaseModel):
         )
         if prov:
             item.prov.append(prov)
+        if source is not None:
+            item.source.append(source)
         if content_layer:
             item.content_layer = content_layer
 
@@ -1795,6 +1820,8 @@ class DoclingDocument(BaseModel):
         content_layer: Optional[ContentLayer] = None,
         formatting: Optional[Formatting] = None,
         hyperlink: Optional[Union[AnyUrl, Path]] = None,
+        *,
+        source: Optional[SourceType] = None,
     ):
         """add_code.
 
@@ -1829,6 +1856,8 @@ class DoclingDocument(BaseModel):
             code_item.content_layer = content_layer
         if prov:
             code_item.prov.append(prov)
+        if source is not None:
+            code_item.source.append(source)
         if caption:
             code_item.captions.append(caption.get_ref())
 
@@ -1846,6 +1875,8 @@ class DoclingDocument(BaseModel):
         content_layer: Optional[ContentLayer] = None,
         formatting: Optional[Formatting] = None,
         hyperlink: Optional[Union[AnyUrl, Path]] = None,
+        *,
+        source: Optional[SourceType] = None,
     ):
         """add_formula.
 
@@ -1873,6 +1904,8 @@ class DoclingDocument(BaseModel):
         )
         if prov:
             section_header_item.prov.append(prov)
+        if source is not None:
+            section_header_item.source.append(source)
         if content_layer:
             section_header_item.content_layer = content_layer
 
@@ -1891,6 +1924,8 @@ class DoclingDocument(BaseModel):
         content_layer: Optional[ContentLayer] = None,
         formatting: Optional[Formatting] = None,
         hyperlink: Optional[Union[AnyUrl, Path]] = None,
+        *,
+        source: Optional[SourceType] = None,
     ):
         """add_heading.
 
@@ -1920,6 +1955,8 @@ class DoclingDocument(BaseModel):
         )
         if prov:
             section_header_item.prov.append(prov)
+        if source is not None:
+            section_header_item.source.append(source)
         if content_layer:
             section_header_item.content_layer = content_layer
 
@@ -1933,6 +1970,8 @@ class DoclingDocument(BaseModel):
         graph: GraphData,
         prov: Optional[ProvenanceItem] = None,
         parent: Optional[NodeItem] = None,
+        *,
+        source: Optional[SourceType] = None,
     ):
         """add_key_values.
 
@@ -1953,6 +1992,8 @@ class DoclingDocument(BaseModel):
         )
         if prov:
             kv_item.prov.append(prov)
+        if source is not None:
+            kv_item.source.append(source)
 
         self.key_value_items.append(kv_item)
         parent.children.append(RefItem(cref=cref))
@@ -1964,6 +2005,8 @@ class DoclingDocument(BaseModel):
         graph: GraphData,
         prov: Optional[ProvenanceItem] = None,
         parent: Optional[NodeItem] = None,
+        *,
+        source: Optional[SourceType] = None,
     ):
         """add_form.
 
@@ -1984,6 +2027,8 @@ class DoclingDocument(BaseModel):
         )
         if prov:
             form_item.prov.append(prov)
+        if source is not None:
+            form_item.source.append(source)
 
         self.form_items.append(form_item)
         parent.children.append(RefItem(cref=cref))
@@ -1994,6 +2039,8 @@ class DoclingDocument(BaseModel):
         self,
         prov: Optional[ProvenanceItem] = None,
         parent: Optional[NodeItem] = None,
+        *,
+        source: Optional[SourceType] = None,
     ) -> FieldRegionItem:
         """add_field_region.
 
@@ -2012,6 +2059,8 @@ class DoclingDocument(BaseModel):
         )
         if prov:
             kv_item.prov.append(prov)
+        if source is not None:
+            kv_item.source.append(source)
 
         self.field_regions.append(kv_item)
         parent.children.append(RefItem(cref=cref))
@@ -2028,6 +2077,8 @@ class DoclingDocument(BaseModel):
         content_layer: Optional[ContentLayer] = None,
         formatting: Optional[Formatting] = None,
         hyperlink: Optional[Union[AnyUrl, Path]] = None,
+        *,
+        source: Optional[SourceType] = None,
     ):
         """add_kv_heading.
 
@@ -2060,6 +2111,8 @@ class DoclingDocument(BaseModel):
         )
         if prov:
             item.prov.append(prov)
+        if source is not None:
+            item.source.append(source)
         if content_layer:
             item.content_layer = content_layer
 
@@ -2073,6 +2126,8 @@ class DoclingDocument(BaseModel):
         prov: Optional[ProvenanceItem] = None,
         parent: Optional[NodeItem] = None,
         content_layer: Optional[ContentLayer] = None,
+        *,
+        source: Optional[SourceType] = None,
     ) -> FieldItem:
         """add_kv_entry."""
         _parent = parent or self.body
@@ -2083,6 +2138,8 @@ class DoclingDocument(BaseModel):
         )
         if prov:
             item.prov.append(prov)
+        if source is not None:
+            item.source.append(source)
         if content_layer:
             item.content_layer = content_layer
 
@@ -2099,6 +2156,8 @@ class DoclingDocument(BaseModel):
         content_layer: Optional[ContentLayer] = None,
         formatting: Optional[Formatting] = None,
         hyperlink: Optional[Union[AnyUrl, Path]] = None,
+        *,
+        source: Optional[SourceType] = None,
     ):
         """add_field_key.
 
@@ -2120,6 +2179,7 @@ class DoclingDocument(BaseModel):
             content_layer=content_layer,
             formatting=formatting,
             hyperlink=hyperlink,
+            source=source,
         )
         return item
 
@@ -2133,6 +2193,8 @@ class DoclingDocument(BaseModel):
         formatting: Optional[Formatting] = None,
         hyperlink: Optional[Union[AnyUrl, Path]] = None,
         kind: Optional[typing.Literal["read_only", "fillable"]] = "read_only",
+        *,
+        source: Optional[SourceType] = None,
     ):
         """add_field_value.
 
@@ -2166,6 +2228,8 @@ class DoclingDocument(BaseModel):
         )
         if prov:
             item.prov.append(prov)
+        if source is not None:
+            item.source.append(source)
         if content_layer:
             item.content_layer = content_layer
 
@@ -2183,6 +2247,8 @@ class DoclingDocument(BaseModel):
         content_layer: Optional[ContentLayer] = None,
         formatting: Optional[Formatting] = None,
         hyperlink: Optional[Union[AnyUrl, Path]] = None,
+        *,
+        source: Optional[SourceType] = None,
     ):
         """add_field_hint.
 
@@ -2203,6 +2269,7 @@ class DoclingDocument(BaseModel):
             content_layer=content_layer,
             formatting=formatting,
             hyperlink=hyperlink,
+            source=source,
         )
         return item
 
@@ -2215,6 +2282,8 @@ class DoclingDocument(BaseModel):
         content_layer: Optional[ContentLayer] = None,
         formatting: Optional[Formatting] = None,
         hyperlink: Optional[Union[AnyUrl, Path]] = None,
+        *,
+        source: Optional[SourceType] = None,
     ):
         """add_marker.
 
@@ -2235,6 +2304,7 @@ class DoclingDocument(BaseModel):
             content_layer=content_layer,
             formatting=formatting,
             hyperlink=hyperlink,
+            source=source,
         )
         return item
 

--- a/test/test_doc_base.py
+++ b/test/test_doc_base.py
@@ -1,7 +1,7 @@
 import pytest
 from pydantic import ValidationError
 
-from docling_core.types.doc import DocItemLabel, DoclingDocument, DocumentOrigin, TrackSource
+from docling_core.types.doc import DocItemLabel, DoclingDocument, DocumentOrigin, GraphData, TableData, TrackSource
 
 
 @pytest.mark.parametrize(
@@ -62,3 +62,55 @@ def test_track_source():
     assert item.source
     assert len(item.source) == 1
     assert item.source[0] == valid_track
+
+
+def test_add_doc_items_with_source():
+    """Test that add_* helpers append sources to created DocItems."""
+    source = TrackSource(start_time=11.0, end_time=12.0)
+    doc = DoclingDocument(name="Unknown")
+
+    items = [
+        doc.add_list_item(text="List item", source=source),
+        doc.add_text(text="Text", label=DocItemLabel.TEXT, source=source),
+        doc.add_comment(text="Comment", source=source),
+        doc.add_table(data=TableData(), source=source),
+        doc.add_picture(source=source),
+        doc.add_title(text="Title", source=source),
+        doc.add_code(text="Code", source=source),
+        doc.add_formula(text="Formula", source=source),
+        doc.add_heading(text="Heading", source=source),
+        doc.add_key_values(graph=GraphData(), source=source),
+        doc.add_form(graph=GraphData(), source=source),
+        doc.add_field_region(source=source),
+        doc.add_field_heading(text="Field heading", source=source),
+        doc.add_field_item(source=source),
+        doc.add_field_key(text="Field key", source=source),
+        doc.add_field_value(text="Field value", source=source),
+        doc.add_field_hint(text="Field hint", source=source),
+        doc.add_marker(text="Marker", source=source),
+    ]
+
+    for item in items:
+        assert item.source == [source]
+
+
+@pytest.mark.parametrize(
+    "label",
+    [
+        DocItemLabel.TITLE,
+        DocItemLabel.LIST_ITEM,
+        DocItemLabel.SECTION_HEADER,
+        DocItemLabel.CODE,
+        DocItemLabel.FORMULA,
+        DocItemLabel.FIELD_HEADING,
+        DocItemLabel.FIELD_VALUE,
+    ],
+)
+def test_add_text_dispatch_preserves_source(label: DocItemLabel):
+    """Test that add_text preserves source when dispatching to specialized helpers."""
+    source = TrackSource(start_time=11.0, end_time=12.0)
+    doc = DoclingDocument(name="Unknown")
+
+    item = doc.add_text(label=label, text="Hello world", source=source)
+
+    assert item.source == [source]


### PR DESCRIPTION
motivated by the Note in https://github.com/docling-project/docling/pull/3925

## What

  Add optional `source` support to all `DoclingDocument.add_*` helpers that create `DocItem`s.

  This includes `add_picture`, so callers can now do:

  ```python
  doc.add_picture(..., source=track_source)
```

  instead of creating the picture first and mutating picture.source afterward.

  ## Why

  DocItem.source is a list of SourceType, but some callers had to attach sources manually after item creation. That
  made it easy to accidentally assign a single TrackSource directly to item.source, producing a schema-invalid
  document.

  This also fixes an existing inconsistency where add_text(..., source=...) preserved sources only for the generic
  TextItem path, but silently dropped them when dispatching to specialized helpers such as add_title, add_heading,
  add_code, or add_formula.

  ## Changes

  - Add optional source parameters to DoclingDocument.add_* helpers that create DocItems.
  - Append source to the created item’s source list when provided.
  - Preserve source through add_text dispatch to specialized item builders.
  - Add regression tests for direct add_* source handling and add_text dispatch.

  ## Verification

  - uv run pytest test/test_doc_base.py
  - uv run python -m compileall -q docling_core/types/doc/document.py test/test_doc_base.py
  - uv run ruff check docling_core/types/doc/document.py test/test_doc_base.py