### PR TITLE
fix(serializer): resolve page-break markers when serializing a single node

### DIFF
--- a/docling_core/transforms/serializer/common.py
+++ b/docling_core/transforms/serializer/common.py
@@ -495,7 +495,12 @@ class DocSerializer(BaseModel, BaseDocSerializer):
         if meta_part is not None and meta_position == "after":
             parts.append(meta_part)
 
-        return create_ser_result(text=delim.join([p.text for p in parts if p.text]), span_source=parts)
+        text_res = delim.join([p.text for p in parts if p.text])
+        if self.requires_page_break() and not isinstance(my_item, _PageBreakNode):
+            # A page break nested inside a group would otherwise only be resolved by
+            # serialize_doc(), i.e. never when a single node is serialized on its own.
+            text_res = self._replace_page_breaks(text=text_res)
+        return create_ser_result(text=text_res, span_source=parts)
 
     # making some assumptions about the kwargs it can pass
     @override
@@ -711,6 +716,14 @@ class DocSerializer(BaseModel, BaseDocSerializer):
 
     def _create_page_break(self, node: _PageBreakNode) -> str:
         return f"#_#_DOCLING_DOC_PAGE_BREAK_{node.prev_page}_{node.next_page}_#_#"
+
+    def _replace_page_breaks(self, text: str) -> str:
+        """Replace the internal page break markers by their serialized form.
+
+        The base implementation leaves the markers untouched, for serializers that
+        can only resolve them once the whole document is available.
+        """
+        return text
 
     def _get_page_breaks(self, text: str) -> Iterable[tuple[str, int, int]]:
         pattern = r"#_#_DOCLING_DOC_PAGE_BREAK_(\d+)_(\d+)_#_#"

--- a/docling_core/transforms/serializer/doctags.py
+++ b/docling_core/transforms/serializer/doctags.py
@@ -596,9 +596,7 @@ class DocTagsDocSerializer(DocSerializer):
         text_res = delim.join([p.text for p in parts if p.text])
 
         if self.params.add_page_break:
-            page_sep = f"<{DocumentToken.PAGE_BREAK.value}>"
-            for full_match, _, _ in self._get_page_breaks(text=text_res):
-                text_res = text_res.replace(full_match, page_sep)
+            text_res = self._replace_page_breaks(text=text_res)
 
         wrap_tag = DocumentToken.DOCUMENT.value
         text_res = f"<{wrap_tag}>{text_res}{delim}</{wrap_tag}>"
@@ -633,6 +631,13 @@ class DocTagsDocSerializer(DocSerializer):
         if text_res:
             text_res = _wrap(text=text_res, wrap_tag=DocumentToken.CAPTION.value)
         return create_ser_result(text=text_res, span_source=results)
+
+    @override
+    def _replace_page_breaks(self, text: str) -> str:
+        page_sep = f"<{DocumentToken.PAGE_BREAK.value}>"
+        for full_match, _, _ in self._get_page_breaks(text=text):
+            text = text.replace(full_match, page_sep)
+        return text
 
     @override
     def requires_page_break(self):

--- a/docling_core/transforms/serializer/latex.py
+++ b/docling_core/transforms/serializer/latex.py
@@ -671,6 +671,13 @@ class LaTeXDocSerializer(DocSerializer):
         return create_ser_result(text=full_text, span_source=parts)
 
     @override
+    def _replace_page_breaks(self, text: str) -> str:
+        page_sep = self.params.page_break_command or ""
+        for full_match, _, _ in self._get_page_breaks(text=text):
+            text = text.replace(full_match, page_sep)
+        return text
+
+    @override
     def requires_page_break(self) -> bool:
         """Return True if page break replacement is enabled."""
         return self.params.page_break_command is not None

--- a/docling_core/transforms/serializer/markdown.py
+++ b/docling_core/transforms/serializer/markdown.py
@@ -944,11 +944,16 @@ class MarkdownDocSerializer(DocSerializer):
         """Serialize a document out of its parts."""
         text_res = "\n\n".join([p.text for p in parts if p.text])
         if self.requires_page_break():
-            page_sep = self.params.page_break_placeholder or ""
-            for full_match, _, _ in self._get_page_breaks(text=text_res):
-                text_res = text_res.replace(full_match, page_sep)
+            text_res = self._replace_page_breaks(text=text_res)
 
         return create_ser_result(text=text_res, span_source=parts)
+
+    @override
+    def _replace_page_breaks(self, text: str) -> str:
+        page_sep = self.params.page_break_placeholder or ""
+        for full_match, _, _ in self._get_page_breaks(text=text):
+            text = text.replace(full_match, page_sep)
+        return text
 
     @override
     def requires_page_break(self) -> bool:

--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -8,12 +8,20 @@ from xml.etree import ElementTree as ET
 import pytest
 
 from docling_core.transforms.serializer.common import _DEFAULT_LABELS
+from docling_core.transforms.serializer.doctags import (
+    DocTagsDocSerializer,
+    DocTagsParams,
+)
 from docling_core.transforms.serializer.html import (
     HTMLDocSerializer,
     HTMLMetaSerializer,
     HTMLOutputStyle,
     HTMLParams,
     HTMLTableSerializer,
+)
+from docling_core.transforms.serializer.latex import (
+    LaTeXDocSerializer,
+    LaTeXParams,
 )
 from docling_core.transforms.serializer.markdown import (
     MarkdownDocSerializer,
@@ -30,6 +38,7 @@ from docling_core.types.doc.document import (
     BaseMeta,
     CharSpan,
     DescriptionAnnotation,
+    DocumentToken,
     EntitiesMetaField,
     EntityMention,
     LanguageMetaField,
@@ -1103,3 +1112,47 @@ def test_html_meta_emits_xhtml_compatible_attributes():
     assert 'data-meta-name="entities"' in html_out
     # Output must be parseable by a strict XML parser.
     ET.fromstring(html_out)
+
+
+def test_md_page_break_resolved_when_serializing_a_single_group():
+    """A page break inside a group must not leak the internal marker (#/groups/2 spans pages 1-2)."""
+    src = Path("./test/data/doc/activities.json")
+    doc = DoclingDocument.load_from_json(src)
+    group = RefItem(cref="#/groups/2").resolve(doc=doc)
+
+    ser = MarkdownDocSerializer(
+        doc=doc,
+        params=MarkdownParams(page_break_placeholder="<!-- page break -->"),
+    )
+    actual = ser.serialize(item=group).text
+
+    assert "DOCLING_DOC_PAGE_BREAK" not in actual
+    assert actual.count("<!-- page break -->") == 1
+    # the whole-document output is unaffected
+    assert "DOCLING_DOC_PAGE_BREAK" not in ser.serialize().text
+
+
+def test_doctags_page_break_resolved_when_serializing_a_single_group():
+    """Same as above for DocTags, which resolves page breaks the same way."""
+    src = Path("./test/data/doc/activities.json")
+    doc = DoclingDocument.load_from_json(src)
+    group = RefItem(cref="#/groups/2").resolve(doc=doc)
+
+    ser = DocTagsDocSerializer(doc=doc, params=DocTagsParams(add_page_break=True))
+    actual = ser.serialize(item=group).text
+
+    assert "DOCLING_DOC_PAGE_BREAK" not in actual
+    assert actual.count(f"<{DocumentToken.PAGE_BREAK.value}>") == 1
+
+
+def test_latex_page_break_resolved_when_serializing_a_single_group():
+    """Same as above for LaTeX, which resolves page breaks the same way."""
+    src = Path("./test/data/doc/activities.json")
+    doc = DoclingDocument.load_from_json(src)
+    group = RefItem(cref="#/groups/2").resolve(doc=doc)
+
+    ser = LaTeXDocSerializer(doc=doc, params=LaTeXParams(page_break_command="\newpage"))
+    actual = ser.serialize(item=group).text
+
+    assert "DOCLING_DOC_PAGE_BREAK" not in actual
+    assert actual.count("\newpage") == 1


### PR DESCRIPTION
Fixes #714.

### The bug

`DocSerializer.serialize()` emits an internal sentinel for each page break
(`#_#_DOCLING_DOC_PAGE_BREAK_<prev>_<next>_#_#`, `common.py:481`), and every serializer replaces it in
`serialize_doc()`. But `serialize_doc()` is only reached from the whole-document path, so a page break
nested inside a group leaked the raw sentinel out of the single-node entry point — and into
`HierarchicalChunker`, which builds `chunk.text` from `serialize(item=...)`:

```text
whole document: '- item one\n<!-- page break -->\n- item two'
single group  : '- item one\n#_#_DOCLING_DOC_PAGE_BREAK_1_2_#_#\n- item two'   # before
chunk         : '- item one\n#_#_DOCLING_DOC_PAGE_BREAK_1_2_#_#\n- item two'   # before
```

### The fix

A new `DocSerializer._replace_page_breaks()` hook, called from `serialize()` as well. The base
implementation returns the text unchanged; Markdown, DocTags and LaTeX override it with the
context-free replacement they already performed in `serialize_doc()`, which now just calls the hook.

Two details keep the existing behaviour intact:

- **HTML is deliberately left on the base no-op.** `HTMLOutputStyle.SPLIT_PAGE` needs `prev_page` /
  `next_page` *and* each marker's offset to slice the body into pages, so it can only resolve them once
  the whole document is available. Its sentinel survives to `serialize_doc()` exactly as before.
- **`serialize()` skips the substitution when the node being serialized is itself the page break.**
  Markers between two top-level items therefore still reach `serialize_doc()` as their own part. That
  matters for `page_break_placeholder=""`: resolving those markers early would make them empty parts,
  which the `if p.text` join filters drop, silently removing the blank separators that
  `test_md_cross_page_list_page_break_empty` pins down.

LaTeX's `serialize_doc()` resolves markers from `self.params.merge_with_patch(patch=kwargs)` while
`requires_page_break()` reads `self.params`; the override follows `requires_page_break()` and uses
`self.params`. A per-call `page_break_command` override is already only half-honoured today (whether
breaks are emitted at all is decided from `self.params`), so I left that as-is rather than change it here.

### Verification

- Three regression tests in `test/test_serialization.py` (Markdown, DocTags, LaTeX) serialize
  `#/groups/2` of `activities.json` — a list spanning pages 1–2 — on its own. All three fail on `main`
  with the raw sentinel and pass here.
- **No whole-document output changes**: I exported all 38 documents under `test/data/doc/` as Markdown
  (with `page_break_placeholder` set *and* empty), DocTags, LaTeX and HTML `SPLIT_PAGE`, before and
  after. All 190 outputs are byte-identical.
- `pytest test/` — same 9 pre-existing failures as `main` in my environment (`test_doctags_load`,
  `test_docling_doc`; unrelated to serialization), 372 → 375 passed, the 3 being the new tests.
- `ruff check` and `ruff format --check` clean with the repo config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
