### PR TITLE
fix(doctags): accept the paragraph tag when loading DocTags

### DIFF
--- a/docling_core/types/doc/document.py
+++ b/docling_core/types/doc/document.py
@@ -4169,6 +4169,9 @@ class DoclingDocument(BaseModel):
             "checkbox_selected": DocItemLabel.CHECKBOX_SELECTED,
             "checkbox_unselected": DocItemLabel.CHECKBOX_UNSELECTED,
             "text": DocItemLabel.TEXT,
+            "paragraph": DocItemLabel.PARAGRAPH,
+            "handwritten_text": DocItemLabel.HANDWRITTEN_TEXT,
+            "reference": DocItemLabel.REFERENCE,
             "page_header": DocItemLabel.PAGE_HEADER,
             "page_footer": DocItemLabel.PAGE_FOOTER,
             "formula": DocItemLabel.FORMULA,
@@ -4483,7 +4486,9 @@ class DoclingDocument(BaseModel):
             tag_pattern = (
                 rf"<(?P<tag>{DocItemLabel.TITLE}|{DocItemLabel.DOCUMENT_INDEX}|"
                 rf"{DocItemLabel.CHECKBOX_UNSELECTED}|{DocItemLabel.CHECKBOX_SELECTED}|"
-                rf"{DocItemLabel.TEXT}|{DocItemLabel.PAGE_HEADER}|{GroupLabel.INLINE}|"
+                rf"{DocItemLabel.TEXT}|{DocItemLabel.PARAGRAPH}|"
+                rf"{DocItemLabel.HANDWRITTEN_TEXT}|{DocItemLabel.REFERENCE}|"
+                rf"{DocItemLabel.PAGE_HEADER}|{GroupLabel.INLINE}|"
                 rf"{DocItemLabel.PAGE_FOOTER}|{DocItemLabel.FORMULA}|"
                 rf"{DocItemLabel.CAPTION}|{DocItemLabel.PICTURE}|"
                 rf"{DocItemLabel.FOOTNOTE}|{DocItemLabel.CODE}|"

--- a/test/test_doctags_load.py
+++ b/test/test_doctags_load.py
@@ -1,9 +1,10 @@
 import json
 from pathlib import Path
 
+import pytest
 from PIL import Image as PILImage
 
-from docling_core.types.doc import DoclingDocument
+from docling_core.types.doc import DocItemLabel, DoclingDocument
 from docling_core.types.doc.document import DocTagsDocument
 
 from .test_data_gen_flag import GEN_TEST_DATA
@@ -168,3 +169,40 @@ def test_doctags_inline():
         exp_file=exp,
         actual=deser_doc.export_to_dict(),
     )
+
+
+@pytest.mark.parametrize(
+    "label",
+    [DocItemLabel.PARAGRAPH, DocItemLabel.HANDWRITTEN_TEXT, DocItemLabel.REFERENCE],
+)
+def test_doctags_text_label_roundtrip(label: DocItemLabel):
+    """Text items must survive a DocTags round-trip for every label exported.
+
+    `export_to_doctags` emits `<{label}>` for these labels — PARAGRAPH is produced
+    by the PPTX, JATS, USPTO, AsciiDoc and LaTeX backends, REFERENCE by the LaTeX
+    backend. The tags have to be accepted on load as well, otherwise the content
+    is silently dropped.
+    """
+    doc = DoclingDocument(name="doc")
+    doc.add_text(label=label, text="Labelled content")
+    doc.add_text(label=DocItemLabel.TEXT, text="Text content")
+
+    doctags = doc.export_to_doctags()
+    assert f"<{label.value}>" in doctags
+
+    doctags_doc = DocTagsDocument.from_doctags_and_image_pairs([doctags], None)
+    deser_doc = DoclingDocument.load_from_doctags(doctags_doc, document_name="doc")
+
+    text = deser_doc.export_to_text()
+    assert "Labelled content" in text
+    assert "Text content" in text
+    assert [item.label for item in deser_doc.texts] == [label, DocItemLabel.TEXT]
+
+
+def test_doctags_paragraph_with_location_roundtrip():
+    """The same holds when the paragraph carries `<loc_...>` coordinates."""
+    doctags = "<doctag><paragraph><loc_10><loc_20><loc_30><loc_40>Located paragraph</paragraph></doctag>"
+    doctags_doc = DocTagsDocument.from_doctags_and_image_pairs([doctags], None)
+    deser_doc = DoclingDocument.load_from_doctags(doctags_doc, document_name="para")
+
+    assert "Located paragraph" in deser_doc.export_to_text()


### PR DESCRIPTION
### Problem

`export_to_doctags()` emits `<paragraph>` for items labelled `PARAGRAPH`, but the
tag is missing from the pattern `load_from_doctags()` matches against, so those
elements are skipped and their text is silently dropped. Export and import
disagree about the format.

`PARAGRAPH` is produced by the PPTX, JATS, USPTO, AsciiDoc and LaTeX backends, so
this affects ordinary documents. For a PowerPoint deck, every slide body is lost
and only the titles survive:

```python
from docling.document_converter import DocumentConverter
from docling_core.types.doc import DoclingDocument
from docling_core.types.doc.document import DocTagsDocument

doc = DocumentConverter().convert("deck.pptx").document
print(doc.export_to_text())
# Quarterly Report
# Revenue grew by twelve percent this quarter.
# Costs remained flat across all regions.

dt = doc.export_to_doctags()          # contains <paragraph>Revenue grew ...</paragraph>
back = DoclingDocument.load_from_doctags(
    DocTagsDocument.from_doctags_and_image_pairs([dt], [None]), document_name="d")
print(back.export_to_text())
# Quarterly Report          <- slide text is gone
```

Minimal version, no files needed:

```python
doc = DoclingDocument(name="x")
doc.add_text(label=DocItemLabel.PARAGRAPH, text="PARA")
doc.add_text(label=DocItemLabel.TEXT, text="TEXT")
# round-trip through DocTags -> "TEXT"   ("PARA" dropped)
```

### Fix

Add the tag to the parser's pattern and map it to `DocItemLabel.PARAGRAPH`, so
both the content and the label survive.

### Impact

Measured over the 192 groundtruth `DoclingDocument`s in the docling repo,
comparing text length before and after a DocTags round-trip:

| | documents losing >10% of text |
|---|---|
| before | 29 |
| after | 17 |

The six worst cases (patents `ipa20200022300`, `pftaps057006474`, `pg06442728`,
`pa20010031492`, `ipa20180000016`, and `powerpoint_malformed_pictures`) returned
0–3% of their text and now round-trip correctly. The remaining 17 lose text for
unrelated reasons (drawingml, some tables, checkboxes) and are untouched here.

### Tests

Two tests in `test/test_doctags_load.py`, covering the plain and `<loc_...>`
forms. Both fail without the change and pass with it; the existing doctags tests
are unaffected (12 passed).

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.