### PR TITLE
fix(page): clamp out-of-range alpha in render_as_image instead of raising

### DIFF
--- a/docling_core/types/doc/page.py
+++ b/docling_core/types/doc/page.py
@@ -991,20 +991,15 @@ class SegmentedPdfPage(SegmentedPage):
         Returns:
             PIL Image of the rendered page
         """
-        for _ in [
-            cell_alpha,
-            cell_bl_alpha,
-            cell_tr_alpha,
-            bitmap_resources_alpha,
-            shape_alpha,
-            annotations_alpha,
-            widgets_alpha,
-            hyperlinks_alpha,
-            cropbox_alpha,
-        ]:
-            if _ < 0 or 1.0 < _:
-                logging.error(f"alpha value {_} needs to be in [0, 1]")
-                _ = max(0, min(1.0, _))
+        cell_alpha = self._clamp_alpha(cell_alpha)
+        cell_bl_alpha = self._clamp_alpha(cell_bl_alpha)
+        cell_tr_alpha = self._clamp_alpha(cell_tr_alpha)
+        bitmap_resources_alpha = self._clamp_alpha(bitmap_resources_alpha)
+        shape_alpha = self._clamp_alpha(shape_alpha)
+        annotations_alpha = self._clamp_alpha(annotations_alpha)
+        widgets_alpha = self._clamp_alpha(widgets_alpha)
+        hyperlinks_alpha = self._clamp_alpha(hyperlinks_alpha)
+        cropbox_alpha = self._clamp_alpha(cropbox_alpha)
 
         page_bbox = self.dimension.crop_bbox
 
@@ -1089,6 +1084,20 @@ class SegmentedPdfPage(SegmentedPage):
             )
 
         return result
+
+    def _clamp_alpha(self, alpha: float) -> float:
+        """Clamp an alpha value into [0, 1].
+
+        Args:
+            alpha: Alpha value to check
+
+        Returns:
+            The alpha value, clamped into [0, 1]
+        """
+        if alpha < 0.0 or 1.0 < alpha:
+            logging.error(f"alpha value {alpha} needs to be in [0, 1]")
+            return max(0.0, min(1.0, alpha))
+        return alpha
 
     def _get_rgba(self, name: str, alpha: float):
         """Get RGBA tuple from color name and alpha value.

--- a/test/test_page.py
+++ b/test/test_page.py
@@ -5,7 +5,16 @@ import pytest
 from pydantic import AnyUrl
 
 from docling_core.types.doc import CoordOrigin
-from docling_core.types.doc.page import BoundingRectangle, PdfHyperlink
+from docling_core.types.doc.base import BoundingBox
+from docling_core.types.doc.page import (
+    BoundingRectangle,
+    PdfHyperlink,
+    PdfPageBoundaryType,
+    PdfPageGeometry,
+    SegmentedPdfPage,
+    TextCell,
+    TextCellUnit,
+)
 
 SQRT_2 = math.sqrt(2)
 
@@ -267,3 +276,72 @@ class TestPdfHyperlinkUri:
     def test_omitted_uri(self):
         h = PdfHyperlink(rect=RECT)
         assert h.uri is None
+
+
+def _one_cell_pdf_page() -> SegmentedPdfPage:
+    """Build a minimal one-word page that render_as_image() can draw."""
+    page_bbox = BoundingBox(l=0, t=100, r=200, b=0, coord_origin=CoordOrigin.BOTTOMLEFT)
+    page_rect = BoundingRectangle(
+        r_x0=0,
+        r_y0=0,
+        r_x1=200,
+        r_y1=0,
+        r_x2=200,
+        r_y2=100,
+        r_x3=0,
+        r_y3=100,
+        coord_origin=CoordOrigin.BOTTOMLEFT,
+    )
+    cell_rect = BoundingRectangle(
+        r_x0=10,
+        r_y0=10,
+        r_x1=90,
+        r_y1=10,
+        r_x2=90,
+        r_y2=40,
+        r_x3=10,
+        r_y3=40,
+        coord_origin=CoordOrigin.BOTTOMLEFT,
+    )
+    return SegmentedPdfPage(
+        dimension=PdfPageGeometry(
+            angle=0.0,
+            rect=page_rect,
+            boundary_type=PdfPageBoundaryType.CROP_BOX,
+            art_bbox=page_bbox,
+            bleed_bbox=page_bbox,
+            crop_bbox=page_bbox,
+            media_bbox=page_bbox,
+            trim_bbox=page_bbox,
+        ),
+        char_cells=[],
+        word_cells=[TextCell(index=0, rect=cell_rect, text="word", orig="word", from_ocr=False)],
+        textline_cells=[],
+        has_words=True,
+    )
+
+
+def _render_with_cell_alpha(page: SegmentedPdfPage, alpha: float):
+    return page.render_as_image(
+        cell_unit=TextCellUnit.WORD,
+        draw_cells_bbox=True,
+        draw_cells_text=False,
+        draw_bitmap_resources=False,
+        draw_shapes=False,
+        draw_widgets=False,
+        draw_hyperlinks=False,
+        cell_alpha=alpha,
+    )
+
+
+class TestRenderAsImageAlpha:
+    """Out-of-range alpha values are clamped into [0, 1] instead of raising."""
+
+    @pytest.mark.parametrize("alpha, clamped", [(1.5, 1.0), (-0.2, 0.0)])
+    def test_out_of_range_alpha_is_clamped(self, alpha: float, clamped: float):
+        page = _one_cell_pdf_page()
+        assert _render_with_cell_alpha(page, alpha).tobytes() == _render_with_cell_alpha(page, clamped).tobytes()
+
+    def test_in_range_alpha_is_untouched(self):
+        page = _one_cell_pdf_page()
+        assert _render_with_cell_alpha(page, 0.5).tobytes() != _render_with_cell_alpha(page, 1.0).tobytes()


### PR DESCRIPTION
### What

`SegmentedPdfPage.render_as_image()` opens with a loop that is meant to clamp every
out-of-range `*_alpha` argument into `[0, 1]`:

```python
for _ in [cell_alpha, cell_bl_alpha, ..., cropbox_alpha]:
    if _ < 0 or 1.0 < _:
        logging.error(f"alpha value {_} needs to be in [0, 1]")
        _ = max(0, min(1.0, _))
```

`_` is the loop variable, so the clamped value is discarded on the next iteration and the
argument the caller passed is what actually reaches `_get_rgba()` — which asserts
`0.0 <= alpha and alpha <= 1.0`.

The user-visible result is that the error is logged as if the value had been corrected, and
then rendering dies anyway with a bare `AssertionError` raised from a private helper:

```
ERROR:root:alpha value 1.5 needs to be in [0, 1]
AssertionError: 0.0 <= alpha and alpha <= 1.0
```

Under `python -O` the assert is stripped instead, and the out-of-range alpha reaches
`ImageColor.getrgb(name) + (int(alpha * 255),)`.

### Fix

Move the range check into a small `_clamp_alpha()` helper next to `_get_rgba()` and assign
its return value back to each of the nine alpha arguments, so the clamp the loop was already
trying to apply takes effect. Logging severity and message are unchanged, and in-range alphas
are returned untouched (no float round-tripping).

### Verification

Repro on a minimal one-word `SegmentedPdfPage`, rendering cell bounding boxes:

| `cell_alpha` | before | after |
|---|---|---|
| `1.0` | renders | renders |
| `1.5` | `AssertionError: 0.0 <= alpha and alpha <= 1.0` | renders, identical to `1.0` |
| `-0.2` | `AssertionError: 0.0 <= alpha and alpha <= 1.0` | renders, identical to `0.0` |

`test/test_page.py` gains `TestRenderAsImageAlpha`, which asserts the clamping as an
invariant (`render(1.5) == render(1.0)`, `render(-0.2) == render(0.0)`) rather than against a
hard-coded image, plus a guard that an in-range alpha still changes the output.

```
# on main
2 failed, 24 passed
# with this change
26 passed
```

`ruff check` / `ruff format --check` clean at the pinned `v0.15.17` with `--config=pyproject.toml`.

### Scope

Only the no-op clamp is addressed. `render_as_image()` also accepts `boundary_type`,
`draw_annotations` / `annotations_*` and `draw_crop_box` / `cropbox_*` that the body never
acts on; those are separate questions (the first looks deliberate — `PdfPageGeometry.boundary_type`
documents that geometry is computed from `crop_bbox` regardless) and are left alone here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
