### PR TITLE
feat: add EPUB book Markdown serializer

### DIFF
--- a/docling_core/transforms/serializer/epub.py
+++ b/docling_core/transforms/serializer/epub.py
@@ -1,0 +1,155 @@
+"""Define classes for EPUB book Markdown serialization."""
+
+import json
+from typing import Any, Optional
+
+from pydantic import BaseModel, Field
+from typing_extensions import override
+
+from docling_core.transforms.serializer.base import SerializationResult
+from docling_core.transforms.serializer.common import create_ser_result
+from docling_core.transforms.serializer.markdown import (
+    MarkdownDocSerializer,
+    MarkdownParams,
+)
+from docling_core.types.doc.items.text import SectionHeaderItem, TitleItem
+
+_OFFSET_WIDTH = 10
+"""Width the chapter offsets are padded to.
+
+The frontmatter is rendered twice: once to measure how far it shifts the body,
+and once with the shifted offsets. Padding every offset to a fixed width keeps
+the second rendering the same size as the first, so the offsets it advertises
+remain correct.
+"""
+
+
+class EpubMetadata(BaseModel):
+    """Book metadata, typically read from an EPUB package document."""
+
+    title: Optional[str] = Field(default=None, description="The title of the book.")
+    authors: list[str] = Field(default_factory=list, description="The creators of the book.")
+    published: Optional[str] = Field(default=None, description="The publication date, as spelled in the source.")
+    language: Optional[str] = Field(default=None, description="The language of the book.")
+    source_file: Optional[str] = Field(default=None, description="The file name the book was converted from.")
+
+
+class EpubParams(MarkdownParams):
+    """EPUB-specific serialization parameters."""
+
+    metadata: Optional[EpubMetadata] = Field(
+        default=None,
+        description="Book metadata to render as frontmatter. Unset fields are left out.",
+        exclude=True,
+    )
+
+
+class ChapterPosition(BaseModel):
+    """Where a chapter heading starts within the serialized book."""
+
+    title: str = Field(description="The heading text of the chapter.")
+    line: int = Field(description="The 1-based line the heading is on.")
+    byte: int = Field(description="The absolute UTF-8 byte offset of the heading.")
+
+
+class EpubDocSerializer(MarkdownDocSerializer):
+    """EPUB-specific document serializer."""
+
+    params: EpubParams = EpubParams()
+
+    @override
+    def serialize_doc(
+        self,
+        *,
+        parts: list[SerializationResult],
+        **kwargs: Any,
+    ) -> SerializationResult:
+        """Serialize a document out of its parts, prefixed by the book frontmatter."""
+        body_result = super().serialize_doc(parts=parts, **kwargs)
+
+        chapters = self._collect_chapters(parts)
+        preliminary = self._render_frontmatter(chapters)
+        byte_shift = len(preliminary.encode("utf-8"))
+        line_shift = preliminary.count("\n")
+        shifted = [
+            chapter.model_copy(update={"byte": chapter.byte + byte_shift, "line": chapter.line + line_shift})
+            for chapter in chapters
+        ]
+        frontmatter = self._render_frontmatter(shifted)
+        if len(frontmatter.encode("utf-8")) != byte_shift:
+            raise ValueError("EPUB frontmatter changed size after applying the chapter offsets")
+
+        return create_ser_result(text=f"{frontmatter}{body_result.text}", span_source=parts)
+
+    def _collect_chapters(self, parts: list[SerializationResult]) -> list[ChapterPosition]:
+        """Locate the chapter headings among the top-level parts of the body.
+
+        A chapter is a part that opens on a top-level heading, i.e. a
+        ``TitleItem`` (rendered as ``#``) or a level-1 ``SectionHeaderItem``
+        (rendered as ``##``). Both are matched because an EPUB spine document
+        may title its chapters with either ``<h1>`` or ``<h2>``.
+        """
+        chapters: list[ChapterPosition] = []
+        byte_offset = 0
+        line_number = 1
+        has_content = False
+
+        for part in parts:
+            if not part.text:
+                continue
+            part_text = self._finalize_part_text(part.text)
+            if has_content:
+                # The parts are joined by a blank line.
+                byte_offset += len(b"\n\n")
+                line_number += 2
+
+            first_item = part.spans[0].item if part.spans else None
+            if isinstance(first_item, TitleItem) or (
+                isinstance(first_item, SectionHeaderItem) and first_item.level == 1
+            ):
+                chapters.append(ChapterPosition(title=first_item.text, line=line_number, byte=byte_offset))
+
+            byte_offset += len(part_text.encode("utf-8"))
+            line_number += part_text.count("\n")
+            has_content = True
+
+        return chapters
+
+    def _finalize_part_text(self, text: str) -> str:
+        """Apply the body-level substitutions before measuring a serialized part."""
+        if not self.requires_page_break():
+            return text
+
+        page_separator = self.params.page_break_placeholder or ""
+        for full_match, _, _ in self._get_page_breaks(text=text):
+            text = text.replace(full_match, page_separator)
+        return text
+
+    def _render_frontmatter(self, chapters: list[ChapterPosition]) -> str:
+        """Render the YAML frontmatter block, trailing blank line included."""
+        metadata = self.params.metadata
+        lines = ["---"]
+        if metadata is not None:
+            fields: tuple[tuple[str, Optional[str] | list[str]], ...] = (
+                ("title", metadata.title),
+                ("authors", metadata.authors or None),
+                ("published", metadata.published),
+                ("language", metadata.language),
+                ("source_file", metadata.source_file),
+            )
+            for key, value in fields:
+                if value is not None:
+                    lines.append(f"{key}: {json.dumps(value, ensure_ascii=False)}")
+
+        lines.append("chapters:" if chapters else "chapters: []")
+        for chapter in chapters:
+            lines.extend(
+                [
+                    f"  - title: {json.dumps(chapter.title, ensure_ascii=False)}",
+                    f"    line: {chapter.line:>{_OFFSET_WIDTH}}",
+                    f"    byte: {chapter.byte:>{_OFFSET_WIDTH}}",
+                ]
+            )
+
+        lines.append("---")
+        return "\n".join(lines) + "\n\n"

--- a/docling_core/types/doc/document.py
+++ b/docling_core/types/doc/document.py
@@ -17,6 +17,7 @@ from enum import Enum
 from io import BytesIO, StringIO
 from pathlib import Path
 from typing import (
+    TYPE_CHECKING,
     Annotated,
     Any,
     Final,
@@ -166,6 +167,10 @@ from docling_core.types.doc.utils import (
 from docling_core.utils.settings import settings
 
 # --- end re-exports ---
+
+if TYPE_CHECKING:
+    # Imported lazily at call time to avoid a circular import through the serializers.
+    from docling_core.transforms.serializer.epub import EpubMetadata
 
 
 _logger = logging.getLogger(__name__)
@@ -4148,6 +4153,98 @@ class DoclingDocument(BaseModel):
         )
 
         filename.write_text(vtt_out, encoding="utf-8")
+
+    def export_to_epub(
+        self,
+        *,
+        metadata: Optional["EpubMetadata"] = None,
+        image_mode: ImageRefMode = ImageRefMode.PLACEHOLDER,
+        included_content_layers: Optional[set[ContentLayer]] = None,
+        page_break_placeholder: Optional[str] = None,
+        compact_tables: bool = False,
+    ) -> str:
+        """Serializes the Docling document as book Markdown.
+
+        The output is Markdown preceded by a YAML frontmatter block holding the book
+        metadata and a chapter index. Every chapter entry carries the absolute UTF-8
+        byte offset and the 1-based line number of its heading, so a reader can seek
+        straight to a chapter instead of scanning the whole book.
+
+        Args:
+            metadata: The book metadata to render as frontmatter. Unset fields are left out.
+            image_mode: How to reference images in the Markdown body.
+            included_content_layers: The content layers to serialize. If omitted, the `DEFAULT_CONTENT_LAYERS`
+                will be serialized.
+            page_break_placeholder: The placeholder to render in place of a page break. If omitted, no page
+                break is rendered.
+            compact_tables: If True, serialize tables without column padding.
+
+        Returns:
+            A string representation of the Docling document as book Markdown.
+        """
+        from docling_core.transforms.serializer.epub import EpubDocSerializer, EpubParams
+
+        my_layers = included_content_layers if included_content_layers is not None else DEFAULT_CONTENT_LAYERS
+
+        serializer = EpubDocSerializer(
+            doc=self,
+            params=EpubParams(
+                metadata=metadata,
+                layers=my_layers,
+                image_mode=image_mode,
+                page_break_placeholder=page_break_placeholder,
+                compact_tables=compact_tables,
+            ),
+        )
+
+        return serializer.serialize().text
+
+    def save_as_epub(
+        self,
+        filename: Union[str, Path],
+        artifacts_dir: Optional[Path] = None,
+        *,
+        metadata: Optional["EpubMetadata"] = None,
+        image_mode: ImageRefMode = ImageRefMode.PLACEHOLDER,
+        included_content_layers: Optional[set[ContentLayer]] = None,
+        page_break_placeholder: Optional[str] = None,
+        compact_tables: bool = False,
+    ) -> None:
+        """Saves the Docling document to a file as book Markdown.
+
+        The file is written as raw UTF-8 bytes: the chapter offsets in the frontmatter
+        index the saved file, so they would be invalidated by the newline translation
+        that text mode applies on Windows.
+
+        Args:
+            filename: The path to the book Markdown file.
+            artifacts_dir: The directory to write referenced images to.
+            metadata: The book metadata to render as frontmatter. Unset fields are left out.
+            image_mode: How to reference images in the Markdown body.
+            included_content_layers: The content layers to serialize. If omitted, the `DEFAULT_CONTENT_LAYERS`
+                will be serialized.
+            page_break_placeholder: The placeholder to render in place of a page break. If omitted, no page
+                break is rendered.
+            compact_tables: If True, serialize tables without column padding.
+        """
+        if isinstance(filename, str):
+            filename = Path(filename)
+        artifacts_dir, reference_path = self._get_output_paths(filename, artifacts_dir)
+
+        if image_mode == ImageRefMode.REFERENCED:
+            artifacts_dir.mkdir(parents=True, exist_ok=True)
+
+        new_doc = self._make_copy_with_refmode(artifacts_dir, image_mode, page_no=None, reference_path=reference_path)
+
+        epub_out = new_doc.export_to_epub(
+            metadata=metadata,
+            image_mode=image_mode,
+            included_content_layers=included_content_layers,
+            page_break_placeholder=page_break_placeholder,
+            compact_tables=compact_tables,
+        )
+
+        filename.write_bytes(epub_out.encode("utf-8"))
 
     @staticmethod
     def load_from_doctags(  # noqa: C901

--- a/test/test_epub_serialization.py
+++ b/test/test_epub_serialization.py
@@ -1,0 +1,173 @@
+"""Test EPUB book Markdown serialization."""
+
+import yaml
+
+from docling_core.transforms.serializer.epub import (
+    EpubDocSerializer,
+    EpubMetadata,
+    EpubParams,
+)
+from docling_core.types.doc.base import BoundingBox
+from docling_core.types.doc.document import DoclingDocument, ProvenanceItem
+from docling_core.types.doc.labels import DocItemLabel
+
+
+def _metadata() -> EpubMetadata:
+    return EpubMetadata(
+        title="Alice's Adventures in Wonderland",
+        authors=["Lewis Carroll"],
+        published="2008-06-27",
+        language="en",
+        source_file="alice.epub",
+    )
+
+
+def _frontmatter(markdown: str) -> dict:
+    return yaml.safe_load(markdown.split("---\n", maxsplit=2)[1])
+
+
+def _book_document() -> DoclingDocument:
+    doc = DoclingDocument(name="alice")
+    doc.add_title("Alice's Adventures in Wonderland")
+    doc.add_heading("CHAPTER I. Dîner à Oxford", level=1)
+    doc.add_text(DocItemLabel.TEXT, "Down the rabbit-hole.")
+    doc.add_heading("CHAPTER II. The Pool of Tears", level=1)
+    doc.add_text(DocItemLabel.TEXT, "Curiouser and curiouser!")
+    return doc
+
+
+def test_frontmatter_holds_the_book_metadata():
+    """Metadata supplied to the serializer is rendered as YAML frontmatter."""
+    doc = DoclingDocument(name="alice")
+    doc.add_text(DocItemLabel.TEXT, "Down the rabbit-hole.")
+
+    ser = EpubDocSerializer(doc=doc, params=EpubParams(metadata=_metadata()))
+    parsed = _frontmatter(ser.serialize().text)
+
+    assert parsed["title"] == "Alice's Adventures in Wonderland"
+    assert parsed["authors"] == ["Lewis Carroll"]
+    assert parsed["published"] == "2008-06-27"
+    assert parsed["language"] == "en"
+    assert parsed["source_file"] == "alice.epub"
+
+
+def test_chapter_byte_offsets_seek_to_the_heading():
+    """Each chapter byte offset lands on the first byte of its rendered heading."""
+    ser = EpubDocSerializer(doc=_book_document(), params=EpubParams(metadata=_metadata()))
+    markdown = ser.serialize().text
+    parsed = _frontmatter(markdown)
+
+    assert [chapter["title"] for chapter in parsed["chapters"]] == [
+        "Alice's Adventures in Wonderland",
+        "CHAPTER I. Dîner à Oxford",
+        "CHAPTER II. The Pool of Tears",
+    ]
+    encoded = markdown.encode("utf-8")
+    for chapter in parsed["chapters"]:
+        heading = encoded[chapter["byte"] :].split(b"\n", maxsplit=1)[0].decode("utf-8")
+        assert heading.lstrip("# ") == chapter["title"]
+        assert heading.startswith("#")
+
+
+def test_chapters_titled_with_h1_are_indexed():
+    """A spine document that titles its chapter with <h1> yields a TitleItem, not a
+    level-1 section header, and must still appear in the chapter index."""
+    doc = DoclingDocument(name="novel")
+    doc.add_title("Chapter One")
+    doc.add_text(DocItemLabel.TEXT, "It was a bright cold day in April.")
+    doc.add_title("Chapter Two")
+    doc.add_text(DocItemLabel.TEXT, "The Ministry of Truth.")
+
+    ser = EpubDocSerializer(doc=doc, params=EpubParams(metadata=_metadata()))
+    markdown = ser.serialize().text
+    parsed = _frontmatter(markdown)
+
+    assert [chapter["title"] for chapter in parsed["chapters"]] == ["Chapter One", "Chapter Two"]
+    encoded = markdown.encode("utf-8")
+    for chapter in parsed["chapters"]:
+        assert encoded[chapter["byte"] :].startswith(f"# {chapter['title']}".encode())
+
+
+def test_chapter_line_offsets_are_one_based():
+    """Each chapter line offset indexes the heading line, counting from one."""
+    ser = EpubDocSerializer(doc=_book_document(), params=EpubParams(metadata=_metadata()))
+    markdown = ser.serialize().text
+    parsed = _frontmatter(markdown)
+    lines = markdown.splitlines()
+
+    for chapter in parsed["chapters"]:
+        assert lines[chapter["line"] - 1].lstrip("# ") == chapter["title"]
+
+
+def test_chapter_offsets_account_for_page_break_replacement():
+    """Page-break markers are replaced in the body, so offsets measure the replacement."""
+    prov = [ProvenanceItem(page_no=page, bbox=BoundingBox(l=0, t=0, r=1, b=1), charspan=(0, 1)) for page in (1, 2)]
+    doc = DoclingDocument(name="pages")
+    doc.add_heading("One", level=1, prov=prov[0])
+    doc.add_text(DocItemLabel.TEXT, "body", prov=prov[0])
+    doc.add_heading("Two", level=1, prov=prov[1])
+
+    ser = EpubDocSerializer(
+        doc=doc,
+        params=EpubParams(metadata=_metadata(), page_break_placeholder="<PB>"),
+    )
+    markdown = ser.serialize().text
+    parsed = _frontmatter(markdown)
+
+    assert "<PB>" in markdown
+    encoded = markdown.encode("utf-8")
+    lines = markdown.splitlines()
+    for chapter in parsed["chapters"]:
+        assert encoded[chapter["byte"] :].startswith(f"## {chapter['title']}".encode())
+        assert lines[chapter["line"] - 1] == f"## {chapter['title']}"
+
+
+def test_offsets_stay_correct_as_their_digit_width_grows():
+    """Chapter offsets are advertised inside the block they measure, so rendering
+    them must not resize that block whatever their digit width."""
+    digit_widths = set()
+    for body_size in (1, 2_000, 1_000_000):
+        doc = DoclingDocument(name="offset-width")
+        doc.add_text(DocItemLabel.TEXT, "x" * body_size)
+        doc.add_heading("Chapter", level=1)
+
+        ser = EpubDocSerializer(doc=doc, params=EpubParams(metadata=_metadata()))
+        markdown = ser.serialize().text
+        chapter = _frontmatter(markdown)["chapters"][0]
+
+        assert markdown.encode("utf-8")[chapter["byte"] :].startswith(b"## Chapter")
+        digit_widths.add(len(str(chapter["byte"])))
+
+    assert len(digit_widths) > 1, "the body sizes must span several offset digit widths"
+
+
+def test_book_without_headings_has_an_empty_chapter_list():
+    """A book with no top-level headings still advertises a parseable empty list."""
+    doc = DoclingDocument(name="empty")
+    doc.add_text(DocItemLabel.TEXT, "No headings here.")
+
+    ser = EpubDocSerializer(doc=doc, params=EpubParams(metadata=_metadata()))
+    parsed = _frontmatter(ser.serialize().text)
+
+    assert parsed["chapters"] == []
+
+
+def test_export_to_epub_is_consistent_with_the_serializer():
+    """export_to_epub() is consistent with EpubDocSerializer."""
+    doc = _book_document()
+    ser = EpubDocSerializer(doc=doc, params=EpubParams(metadata=_metadata()))
+
+    assert doc.export_to_epub(metadata=_metadata()) == ser.serialize().text
+
+
+def test_saved_book_offsets_address_the_bytes_on_disk(tmp_path):
+    """The advertised offsets index the saved file, so the save must not rewrite
+    newlines the way text mode does on Windows."""
+    out = tmp_path / "book.md"
+    _book_document().save_as_epub(out, metadata=_metadata())
+
+    saved = out.read_bytes()
+    parsed = yaml.safe_load(saved.decode("utf-8").split("---\n", maxsplit=2)[1])
+    for chapter in parsed["chapters"]:
+        heading = saved[chapter["byte"] :].split(b"\n", maxsplit=1)[0].decode("utf-8")
+        assert heading.lstrip("# ") == chapter["title"]

--- a/test/test_epub_serialization.py
+++ b/test/test_epub_serialization.py
@@ -1,13 +1,15 @@
 """Test EPUB book Markdown serialization."""
 
+import pytest
 import yaml
 
+from docling_core.transforms.serializer.base import SerializationResult
 from docling_core.transforms.serializer.epub import (
     EpubDocSerializer,
     EpubMetadata,
     EpubParams,
 )
-from docling_core.types.doc.base import BoundingBox
+from docling_core.types.doc.base import BoundingBox, ImageRefMode
 from docling_core.types.doc.document import DoclingDocument, ProvenanceItem
 from docling_core.types.doc.labels import DocItemLabel
 
@@ -141,6 +143,33 @@ def test_offsets_stay_correct_as_their_digit_width_grows():
     assert len(digit_widths) > 1, "the body sizes must span several offset digit widths"
 
 
+def test_frontmatter_size_change_is_rejected(monkeypatch):
+    """A frontmatter size change would invalidate every advertised byte offset."""
+    original_render = EpubDocSerializer._render_frontmatter
+    render_count = 0
+
+    def unstable_render(self, chapters):
+        nonlocal render_count
+        render_count += 1
+        rendered = original_render(self, chapters)
+        return f"{rendered} " if render_count == 2 else rendered
+
+    monkeypatch.setattr(EpubDocSerializer, "_render_frontmatter", unstable_render)
+    serializer = EpubDocSerializer(doc=_book_document(), params=EpubParams(metadata=_metadata()))
+
+    with pytest.raises(ValueError, match="frontmatter changed size"):
+        serializer.serialize()
+
+
+def test_empty_serialization_parts_are_ignored():
+    """An empty part must not add body separators or phantom chapters."""
+    serializer = EpubDocSerializer(doc=DoclingDocument(name="empty"))
+
+    result = serializer.serialize_doc(parts=[SerializationResult()])
+
+    assert result.text == "---\nchapters: []\n---\n\n"
+
+
 def test_book_without_headings_has_an_empty_chapter_list():
     """A book with no top-level headings still advertises a parseable empty list."""
     doc = DoclingDocument(name="empty")
@@ -164,10 +193,24 @@ def test_saved_book_offsets_address_the_bytes_on_disk(tmp_path):
     """The advertised offsets index the saved file, so the save must not rewrite
     newlines the way text mode does on Windows."""
     out = tmp_path / "book.md"
-    _book_document().save_as_epub(out, metadata=_metadata())
+    _book_document().save_as_epub(str(out), metadata=_metadata())
 
     saved = out.read_bytes()
     parsed = yaml.safe_load(saved.decode("utf-8").split("---\n", maxsplit=2)[1])
     for chapter in parsed["chapters"]:
         heading = saved[chapter["byte"] :].split(b"\n", maxsplit=1)[0].decode("utf-8")
         assert heading.lstrip("# ") == chapter["title"]
+
+
+def test_save_as_epub_creates_the_referenced_image_directory(tmp_path):
+    """Referenced-image output creates its artifacts directory before serialization."""
+    artifacts_dir = tmp_path / "images"
+
+    _book_document().save_as_epub(
+        tmp_path / "book.md",
+        artifacts_dir=artifacts_dir,
+        metadata=_metadata(),
+        image_mode=ImageRefMode.REFERENCED,
+    )
+
+    assert artifacts_dir.is_dir()


### PR DESCRIPTION
## What changed

Adds `EpubDocSerializer`, a `MarkdownDocSerializer` variant that renders a book as Markdown preceded by a YAML frontmatter block holding the book metadata and a chapter index, plus `DoclingDocument.export_to_epub()` / `save_as_epub()`.

Every chapter entry carries the absolute UTF-8 byte offset and the 1-based line number of its heading, so a reader can seek straight to a chapter instead of unpacking the source or scanning the whole book.

```yaml
---
title: "Alice's Adventures in Wonderland"
authors: ["Lewis Carroll"]
language: "en"
chapters:
  - title: "CHAPTER I. Down the Rabbit-Hole"
    line:         12
    byte:        287
---
```

## Why

Requested by @dolfim-ibm in review of docling-project/docling#3993, which had the same serializer living in `docling/backend/epub_serializer.py`:

> The serializer should be in `docling-core`, and I would propose to add Epub as a standalone output format

The companion docling PR is being restructured to drop its local serializer and consume this one behind a new `epub` output format.

## Notes for reviewers

Two details are load-bearing and have dedicated tests:

- **The offsets are advertised inside the block they measure.** The frontmatter is rendered twice: once to measure how far it shifts the body, once with the shifted offsets. Padding every offset to a fixed width keeps the two renderings byte-identical; a guard raises if that ever stops holding.
- **A chapter is a `TitleItem` *or* a level-1 `SectionHeaderItem`.** An EPUB spine document may title its chapters with either `<h1>` or `<h2>`, and the HTML backend maps `<h1>` to a title item. Matching only section headers leaves the index empty for every book that uses `<h1>` per chapter.

`save_as_epub()` writes raw UTF-8 bytes rather than going through text mode, since the advertised offsets index the saved file and Windows newline translation would invalidate them.

## Checklist

- [x] Tests added (`test/test_epub_serialization.py`, 9 cases)
- [x] `pytest test` — 606 passed, 6 skipped
- [x] `ruff check` / `ruff format` / `mypy` clean
- [x] Generated docs regenerated: no schema drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)