### PR TITLE
fix(chunker): keep concrete DocItem subclasses in HybridChunker chunks (#728)

### DIFF
--- a/docling_core/transforms/chunker/hybrid_chunker.py
+++ b/docling_core/transforms/chunker/hybrid_chunker.py
@@ -237,7 +237,11 @@ class HybridChunker(BaseChunker):
     ) -> list[DocChunk]:
         lengths = self._doc_chunk_length(doc_chunk)
         if lengths.total_len <= self.max_tokens:
-            return [DocChunk(**doc_chunk.export_json_dict())]
+            # NOTE: copy through the model, not through a JSON round-trip: the
+            # latter revalidates `meta.doc_items` against its declared `DocItem`
+            # type, downcasting every concrete subclass (e.g. `TableItem`) and
+            # dropping the payload that only the subclass carries.
+            return [doc_chunk.model_copy()]
         else:
             # How much room is there for text after subtracting out the headers and
             # captions:

--- a/test/test_hybrid_chunker.py
+++ b/test/test_hybrid_chunker.py
@@ -21,6 +21,8 @@ from docling_core.transforms.serializer.html import HTMLTableSerializer
 from docling_core.transforms.serializer.markdown import MarkdownParams, MarkdownTableSerializer
 from docling_core.types.doc import DocItemLabel, DoclingDocument
 from docling_core.types.doc.common.content_layer import ContentLayer
+from docling_core.types.doc.common.meta import DescriptionMetaField, FloatingMeta
+from docling_core.types.doc.document import TableItem, TextItem
 from docling_core.types.doc.items.table.table_data import TableCell, TableData
 
 from .test_utils import assert_or_generate_json_ground_truth, build_single_cell_rich_table_doc
@@ -432,6 +434,68 @@ def test_chunk_single_cell_rich_table():
     assert len(chunks) == 1
     assert chunks[0].text == "Important body text inside layout table"
     assert [item.self_ref for item in chunks[0].meta.doc_items] == [doc.tables[0].self_ref]
+
+
+def test_chunk_keeps_concrete_doc_item_types():
+    """HybridChunker must not downcast meta.doc_items to bare DocItem.
+
+    The chunks are copied on the way out; copying them through a JSON
+    round-trip revalidates `doc_items` against its declared `DocItem` type,
+    which replaces each concrete subclass with a bare `DocItem` and drops the
+    payload only the subclass carries. HierarchicalChunker hands back the
+    document's own items, so it is the reference for what the types should be.
+    """
+    doc = DoclingDocument(name="concrete_item_types")
+    doc.add_text(label=DocItemLabel.TEXT, text="Some paragraph.")
+    table = doc.add_table(
+        data=TableData(
+            num_rows=2,
+            num_cols=1,
+            table_cells=[
+                TableCell(
+                    text="Year",
+                    start_row_offset_idx=0,
+                    end_row_offset_idx=1,
+                    start_col_offset_idx=0,
+                    end_col_offset_idx=1,
+                    column_header=True,
+                ),
+                TableCell(
+                    text="2024",
+                    start_row_offset_idx=1,
+                    end_row_offset_idx=2,
+                    start_col_offset_idx=0,
+                    end_col_offset_idx=1,
+                ),
+            ],
+        )
+    )
+    table.meta = FloatingMeta(description=DescriptionMetaField(text="Revenue by year."))
+
+    # Large enough that every chunk fits and no splitting is needed.
+    chunker = HybridChunker(
+        tokenizer=OpenAITokenizer(
+            tokenizer=tiktoken.encoding_for_model("gpt-4o"),
+            max_tokens=128 * 1024,
+        )
+    )
+    ref_chunker = HierarchicalChunker()
+
+    def items_of(chunker_):
+        return [item for chunk in chunker_.chunk(dl_doc=doc) for item in chunk.meta.doc_items]
+
+    exp_items = items_of(ref_chunker)
+    act_items = items_of(chunker)
+
+    assert [type(item) for item in exp_items] == [TextItem, TableItem]
+    assert [type(item) for item in act_items] == [type(item) for item in exp_items]
+    assert [item.self_ref for item in act_items] == [item.self_ref for item in exp_items]
+
+    # The subclass payload has to survive too, not just the class name.
+    act_table = act_items[1]
+    assert act_table.meta is not None
+    assert act_table.meta.description.text == "Revenue by year."
+    assert [cell.text for cell in act_table.data.table_cells] == ["Year", "2024"]
 
 
 def test_chunk_explicit():


### PR DESCRIPTION
Fixes #728.

## Problem

`HybridChunker` returns chunks whose `meta.doc_items` have been downcast to bare
`DocItem`. The concrete subclass is lost, and with it every attribute only that
subclass carries — a `TableItem`'s `data` and `meta.description`, a `TextItem`'s
`text`. `HierarchicalChunker`, by contrast, hands back the document's own items.

The cause is in `_split_using_plain_text`:

```python
return [DocChunk(**doc_chunk.export_json_dict())]
```

Rebuilding the model from its JSON dump revalidates `meta.doc_items` against its
declared type, `list[DocItem]`, so pydantic replaces each subclass instance with
a bare `DocItem` and drops the fields that only exist on the subclass. Every
chunk passes through this method, so this affects all `HybridChunker` output.

Reproducing on `main` (the reporter's script, trimmed):

```
HierarchicalChunker    ['TextItem', 'TableItem']
                         text='Some paragraph.' meta=None
                         text='<missing>' meta=... description=DescriptionMetaField(text='Revenue by year.')
HybridChunker          ['DocItem', 'DocItem']
                         text='<missing>' meta=None
                         text='<missing>' meta=... (description gone)
```

## Fix

Copy through `model_copy()` instead of a JSON round-trip. It still returns a
distinct `DocChunk` object, exactly as before, but it does not revalidate, so
the items keep their concrete type and payload. After the change `HybridChunker`
matches `HierarchicalChunker` item-for-item.

Every other chunk-construction site in this file already passes model objects
straight through (`_make_chunk_from_doc_items`, `_merge_chunks_with_matching_metadata`,
and the `DocChunk(text=s, meta=doc_chunk.meta)` branch a few lines below); this
was the odd one out.

## Verification

- Added `test_chunk_keeps_concrete_doc_item_types`, which asserts the **full**
  type list and self-ref list against what `HierarchicalChunker` produces for the
  same document, plus the `TableItem` payload (`meta.description.text` and every
  cell's text). It fails on `main` (`DocItem != TextItem`) and passes with this
  change.
- `pytest test/` — the failure set is byte-identical before and after this patch
  (I diffed the two `FAILED` lists; the pre-existing failures in my sandbox are
  network/model-download and image-comparison ones, unrelated to chunking).
  Within `test/test_hybrid_chunker.py`: 24 passed, and the single failure
  (`test_chunk_custom_serializer`) also fails on unmodified `main`.
- No ground-truth file changes: I regenerated `test/data/chunker/` with
  `DOCLING_GEN_TEST_DATA=1` both with and without this patch and diffed the
  parsed JSON — zero semantic differences.
- `ruff check` / `ruff format` clean at the pinned `v0.15.17` with the repo's
  `pyproject.toml`.

## Deliberately not in scope

The issue also points at the second `DocChunk(**doc_chunk.export_json_dict())`,
in the `available_length <= 0` warning branch. It is the same defect, but fixing
it is **not** behaviour-neutral, so I left it out of this PR rather than bundle a
judgement call with a straightforward fix.

Restoring the real types there makes the recursive call see a genuine
`TableItem`, which re-enables the table-aware path in `segment()`
(`repeat_table_header` — currently dead for chunks that reach this branch, since
the `isinstance` check never matches a bare `DocItem`). That shifts table chunk
boundaries: I measured 5 ground-truth files changing semantically
(`2a_out_chunks`, `2a_out_ser_chunks`, `2b_out_chunks`, `2d_out_ser_chunks`,
`2e_out_chunks`), e.g. `2a` going from 27 to 28 chunks. Arguably that is the
intended behaviour finally kicking in, but it is a real output change and some of
the resulting table splits look worth eyeballing, so it seemed like your call
rather than mine.

Happy to follow up with that in a separate PR (with regenerated ground truth) if
you'd like it fixed too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
