### PR TITLE
feat: add page-level PDF attachment types (FileAttachmentAnnotation, PdfAttachment)

### DIFF
--- a/docling_core/types/doc/page.py
+++ b/docling_core/types/doc/page.py
@@ -415,6 +415,43 @@ class PdfHyperlink(OrderedElement):
             return str(v)
 
 
+class FileAttachmentAnnotation(BaseModel):
+    """Position of a FileAttachment annotation on a page (1-based, PDF convention).
+
+    Attributes:
+        page_no: 1-based page number (1 = first page), translated from 0-based C++ storage.
+        bbox: Bounding rectangle in PDF user space (bottom-left origin).
+    """
+
+    model_config = {"validate_assignment": True}  # type: ignore[dict-item]
+
+    page_no: PageNumber
+    bbox: BoundingRectangle
+
+
+class PdfAttachment(BaseModel):
+    """PDF attachment (embedded file) with optional page annotations.
+
+    Attributes:
+        name: Filename from /UF or /F.
+        mime_type: MIME subtype if present (e.g., 'text/plain').
+        size: Decoded size in bytes (from /Params /Size or /Length).
+        annotations: List of FileAttachment annotation positions (empty if unanchored).
+        data: Raw binary payload of the embedded file, if available.
+    """
+
+    model_config = {"validate_assignment": True}  # type: ignore[dict-item]
+
+    name: str
+    mime_type: Optional[str] = None
+    size: int = 0
+    annotations: list[FileAttachmentAnnotation] = []
+    data: Optional[bytes] = Field(
+        default=None,
+        description="Raw binary payload of the embedded file, if available.",
+    )
+
+
 class BitmapResource(OrderedElement):
     """Model representing a bitmap resource with positioning and URI information."""
 

--- a/docling_core/types/doc/page.py
+++ b/docling_core/types/doc/page.py
@@ -1572,6 +1572,11 @@ class ParsedPdfDocument(BaseModel):
 
     pages: dict[PageNumber, SegmentedPdfPage] = {}
 
+    attachments: list[PdfAttachment] = Field(
+        default_factory=list,
+        description="Embedded file attachments extracted from the PDF document.",
+    )
+
     meta_data: Optional[PdfMetaData] = None
     table_of_contents: Optional[PdfTableOfContents] = None
 

--- a/docling_core/types/doc/page.py
+++ b/docling_core/types/doc/page.py
@@ -791,6 +791,11 @@ class SegmentedPdfPage(SegmentedPage):
     )
     shapes: list[PdfShape] = []
 
+    attachments: list[PdfAttachment] = Field(
+        default_factory=list,
+        description="File attachments anchored to this page (via FileAttachment annotations).",
+    )
+
     # Redefine typing of elements to include PdfTextCell
     char_cells: list[Union[PdfTextCell, TextCell]]
     word_cells: list[Union[PdfTextCell, TextCell]]

--- a/test/test_page_attachments.py
+++ b/test/test_page_attachments.py
@@ -8,6 +8,7 @@ from docling_core.types.doc.page import (
     PdfAttachment,
     PdfPageBoundaryType,
     PdfPageGeometry,
+    SegmentedPdfPage,
 )
 
 
@@ -82,3 +83,24 @@ def test_pdf_attachment_defaults():
     assert att.size == 0
     assert att.annotations == []
     assert att.data is None
+
+
+def _page(attachments: list[PdfAttachment] | None = None) -> SegmentedPdfPage:
+    return SegmentedPdfPage(
+        dimension=_geometry(),
+        char_cells=[],
+        word_cells=[],
+        textline_cells=[],
+        attachments=attachments or [],
+    )
+
+
+def test_segmented_pdf_page_carries_attachments():
+    """A SegmentedPdfPage exposes the attachments anchored to it, defaulting to empty."""
+    page = _page(attachments=[_attachment()])
+    assert len(page.attachments) == 1
+    assert page.attachments[0].name == "notes.txt"
+    assert page.attachments[0].data == b"hello world"
+
+    empty = _page()
+    assert empty.attachments == []

--- a/test/test_page_attachments.py
+++ b/test/test_page_attachments.py
@@ -5,6 +5,7 @@ from docling_core.types.doc.base import BoundingBox
 from docling_core.types.doc.page import (
     BoundingRectangle,
     FileAttachmentAnnotation,
+    ParsedPdfDocument,
     PdfAttachment,
     PdfPageBoundaryType,
     PdfPageGeometry,
@@ -104,3 +105,16 @@ def test_segmented_pdf_page_carries_attachments():
 
     empty = _page()
     assert empty.attachments == []
+
+
+def test_parsed_pdf_document_round_trip_with_attachments():
+    """Document-level attachments survive a JSON round-trip alongside page-level ones."""
+    doc = ParsedPdfDocument(pages={1: _page(attachments=[_attachment()])})
+    doc.attachments.append(_attachment(name="archive.zip", data=b"\x00\x01\x02"))
+
+    restored = ParsedPdfDocument.model_validate_json(doc.model_dump_json())
+
+    assert restored.attachments == doc.attachments
+    assert restored.attachments[0].name == "archive.zip"
+    assert restored.attachments[0].data == b"\x00\x01\x02"
+    assert restored.pages[1].attachments[0].name == "notes.txt"

--- a/test/test_page_attachments.py
+++ b/test/test_page_attachments.py
@@ -1,0 +1,84 @@
+"""Tests for page-level PDF attachment models."""
+
+from docling_core.types.doc import CoordOrigin
+from docling_core.types.doc.base import BoundingBox
+from docling_core.types.doc.page import (
+    BoundingRectangle,
+    FileAttachmentAnnotation,
+    PdfAttachment,
+    PdfPageBoundaryType,
+    PdfPageGeometry,
+)
+
+
+def _box(l: float = 0, b: float = 0, r: float = 612, t: float = 792) -> BoundingBox:
+    return BoundingBox(l=l, b=b, r=r, t=t, coord_origin=CoordOrigin.BOTTOMLEFT)
+
+
+def _geometry() -> PdfPageGeometry:
+    rect = BoundingRectangle(
+        r_x0=0,
+        r_y0=0,
+        r_x1=612,
+        r_y1=0,
+        r_x2=612,
+        r_y2=792,
+        r_x3=0,
+        r_y3=792,
+        coord_origin=CoordOrigin.BOTTOMLEFT,
+    )
+    return PdfPageGeometry(
+        angle=0.0,
+        rect=rect,
+        boundary_type=PdfPageBoundaryType.MEDIA_BOX,
+        art_bbox=_box(),
+        bleed_bbox=_box(),
+        crop_bbox=_box(),
+        media_bbox=_box(),
+        trim_bbox=_box(),
+    )
+
+
+def _annotation() -> FileAttachmentAnnotation:
+    return FileAttachmentAnnotation(
+        page_no=1,
+        bbox=BoundingRectangle(
+            r_x0=10,
+            r_y0=10,
+            r_x1=110,
+            r_y1=10,
+            r_x2=110,
+            r_y2=30,
+            r_x3=10,
+            r_y3=30,
+            coord_origin=CoordOrigin.BOTTOMLEFT,
+        ),
+    )
+
+
+def _attachment(name: str = "notes.txt", data: bytes | None = b"hello world") -> PdfAttachment:
+    return PdfAttachment(
+        name=name,
+        mime_type="text/plain",
+        size=len(data) if data else 0,
+        annotations=[_annotation()],
+        data=data,
+    )
+
+
+def test_pdf_attachment_json_round_trip():
+    """A PdfAttachment carrying binary data survives a JSON round-trip."""
+    att = _attachment()
+    restored = PdfAttachment.model_validate_json(att.model_dump_json())
+    assert restored == att
+    assert restored.name == "notes.txt"
+    assert restored.data == b"hello world"
+
+
+def test_pdf_attachment_defaults():
+    """Unset optional fields get sane defaults."""
+    att = PdfAttachment(name="empty.bin")
+    assert att.mime_type is None
+    assert att.size == 0
+    assert att.annotations == []
+    assert att.data is None


### PR DESCRIPTION
## Summary

Adds the parse-layer PDF attachment types to the page model so that `docling-parse` can report embedded-file attachments — including their binary payloads — on `SegmentedPdfPage` and `ParsedPdfDocument`.

- `FileAttachmentAnnotation` — position of a `/FileAttachment` annotation on a page (1-based `page_no` + `bbox`).
- `PdfAttachment` — `name`, `mime_type`, `size`, `annotations`, and raw `data: bytes` payload.
- `SegmentedPdfPage.attachments: list[PdfAttachment]` — attachments anchored to the page.
- `ParsedPdfDocument.attachments: list[PdfAttachment]` — document-level attachments.

## Backward compatibility

Fully additive: all new fields are optional with empty defaults, and the new models are standalone. No serializers are touched.

## Notes

- This supersedes the closed #713, which was split per maintainer feedback into focused PRs. The `AttachmentItem` + `DoclingDocument` storage follows in a separate PR (serializers deferred).
- Tests: `test/test_page_attachments.py` (model behavior + JSON round-trips, incl. binary payloads).