### PR TITLE
feat: add AttachmentItem and DoclingDocument storage

### DIFF
--- a/docling_core/types/doc/__init__.py
+++ b/docling_core/types/doc/__init__.py
@@ -57,6 +57,7 @@ from docling_core.types.doc.doctags import (
     DocTagsPage,
 )
 from docling_core.types.doc.document import DoclingDocument
+from docling_core.types.doc.items.attachment import AttachmentItem
 from docling_core.types.doc.items.code import CodeItem
 from docling_core.types.doc.items.content import ContentItem
 from docling_core.types.doc.items.form import (

--- a/docling_core/types/doc/document.py
+++ b/docling_core/types/doc/document.py
@@ -99,6 +99,7 @@ from docling_core.types.doc.common.reference import (
 from docling_core.types.doc.common.scalars import CharSpan, LevelNumber, Uint64
 from docling_core.types.doc.common.source import BaseSource, SourceType, TrackSource
 from docling_core.types.doc.doctags import DocTagsDocument, DocTagsPage
+from docling_core.types.doc.items.attachment import AttachmentItem
 from docling_core.types.doc.items.code import CodeItem
 from docling_core.types.doc.items.content import ContentItem
 from docling_core.types.doc.items.form import FieldHeadingItem, FieldItem, FieldRegionItem, FieldValueItem
@@ -209,6 +210,7 @@ class DoclingDocument(BaseModel):
     form_items: list[FormItem] = []
     field_regions: list[FieldRegionItem] = []
     field_items: list[FieldItem] = []
+    attachments: list[AttachmentItem] = []
 
     pages: dict[int, PageItem] = {}  # empty as default
 
@@ -217,7 +219,7 @@ class DoclingDocument(BaseModel):
         dumped = handler(self)
 
         # suppress serializing certain fields when empty:
-        for field in {"field_regions", "field_items"}:
+        for field in {"field_regions", "field_items", "attachments"}:
             if dumped.get(field) == []:
                 del dumped[field]
 
@@ -346,6 +348,7 @@ class DoclingDocument(BaseModel):
             self.form_items,
             self.field_regions,
             self.field_items,
+            self.attachments,
         )
         for item_list in item_lists:
             for item in item_list:
@@ -932,6 +935,17 @@ class DoclingDocument(BaseModel):
             item.parent = parent_ref
 
             self.field_items.append(item)
+
+        elif isinstance(item, AttachmentItem):
+            item_label = "attachments"
+            item_index = len(self.attachments)
+
+            cref = f"#/{item_label}/{item_index}"
+
+            item.self_ref = cref
+            item.parent = parent_ref
+
+            self.attachments.append(item)
 
         elif isinstance(item, ListGroup | InlineGroup):
             item_label = "groups"
@@ -1760,6 +1774,61 @@ class DoclingDocument(BaseModel):
         parent.children.append(RefItem(cref=cref))
 
         return fig_item
+
+    def add_attachment(
+        self,
+        name: str,
+        mime_type: Optional[str] = None,
+        size: Optional[int] = None,
+        target: Optional[Union[str, AnyUrl]] = None,
+        data: Optional[bytes] = None,
+        doc_data: Optional[bytes] = None,
+        prov: Optional[ProvenanceItem] = None,
+        parent: Optional[NodeItem] = None,
+        content_layer: Optional[ContentLayer] = None,
+        *,
+        source: Optional[SourceType] = None,
+    ) -> AttachmentItem:
+        """Add an attachment reference to the document.
+
+        :param name: Original attachment filename.
+        :param mime_type: Optional MIME type.
+        :param size: Optional payload size in bytes.
+        :param target: Optional relative path/URL to converted output.
+        :param data: Optional raw binary payload.
+        :param doc_data: Optional serialized DoclingDocument bytes for the recursively parsed attachment.
+        :param prov: Optional provenance (page + bbox) for inline placement.
+        :param parent: Parent node; defaults to body.
+        :param content_layer: Optional content layer override.
+        :param source: Optional source reference.
+        """
+        if not parent:
+            parent = self.body
+
+        attachment_index = len(self.attachments)
+        cref = f"#/attachments/{attachment_index}"
+
+        item = AttachmentItem(
+            name=name,
+            mime_type=mime_type,
+            size=size,
+            target=target,
+            data=data,
+            doc_data=doc_data,
+            self_ref=cref,
+            parent=parent.get_ref(),
+        )
+        if prov:
+            item.prov.append(prov)
+        if source is not None:
+            item.source.append(source)
+        if content_layer:
+            item.content_layer = content_layer
+
+        self.attachments.append(item)
+        parent.children.append(RefItem(cref=cref))
+
+        return item
 
     def add_title(
         self,
@@ -5226,6 +5295,7 @@ class DoclingDocument(BaseModel):
             self.form_items,
             self.field_regions,
             self.field_items,
+            self.attachments,
         ]
         for item_list in item_lists:
             for item in item_list:
@@ -5323,6 +5393,7 @@ class DoclingDocument(BaseModel):
         form_items: list[FormItem] = []
         field_regions: list[FieldRegionItem] = []
         field_items: list[FieldItem] = []
+        attachments: list[AttachmentItem] = []
 
         pages: dict[int, PageItem] = {}
 
@@ -5355,6 +5426,7 @@ class DoclingDocument(BaseModel):
                 "form_items",
                 "field_regions",
                 "field_items",
+                "attachments",
             ]
             start_indices = {k: len(self.get_item_list(k)) for k in post_processing_keys}
 
@@ -5484,6 +5556,7 @@ class DoclingDocument(BaseModel):
         self.form_items = doc_index.form_items
         self.field_regions = doc_index.field_regions
         self.field_items = doc_index.field_items
+        self.attachments = doc_index.attachments
         self.pages = doc_index.pages
         self.name = doc_index.get_name()
 

--- a/docling_core/types/doc/items/attachment.py
+++ b/docling_core/types/doc/items/attachment.py
@@ -1,0 +1,34 @@
+"""Attachment document item."""
+
+import typing
+from typing import Optional, Union
+
+from pydantic import AnyUrl, Field
+
+from docling_core.types.doc.items.node import DocItem
+from docling_core.types.doc.labels import DocItemLabel
+
+
+class AttachmentItem(DocItem):
+    """An embedded file attachment referenced by a document."""
+
+    label: typing.Literal[DocItemLabel.ATTACHMENT] = DocItemLabel.ATTACHMENT  # type: ignore[assignment]
+
+    name: str = Field(description="Original attachment filename.")
+    mime_type: Optional[str] = Field(default=None, description="MIME type of the attachment payload.")
+    size: Optional[int] = Field(default=None, description="Attachment payload size in bytes.")
+    target: Optional[Union[str, AnyUrl]] = Field(
+        default=None,
+        description="Relative path/URL to the converted attachment output, or None if not converted.",
+    )
+    data: Optional[bytes] = Field(
+        default=None,
+        description="Raw binary payload of the attachment. Stored as base64 in JSON.",
+    )
+    doc_data: Optional[bytes] = Field(
+        default=None,
+        description=(
+            "Serialized DoclingDocument (e.g. JSON/DCLG/DCLX) of the recursively parsed attachment. "
+            "When present, the attachment is implicitly considered converted."
+        ),
+    )

--- a/docling_core/types/doc/labels.py
+++ b/docling_core/types/doc/labels.py
@@ -29,6 +29,7 @@ class DocItemLabel(str, Enum):
     # e.g. ★★☆☆☆
     HANDWRITTEN_TEXT = "handwritten_text"
     EMPTY_VALUE = "empty_value"  # used for empty value fields in fillable forms
+    ATTACHMENT = "attachment"
 
     # Additional labels for markup-based formats (e.g. HTML, Word)
     PARAGRAPH = "paragraph"
@@ -80,6 +81,7 @@ class DocItemLabel(str, Enum):
             DocItemLabel.FIELD_VALUE: (135, 80, 20),
             DocItemLabel.FIELD_HINT: (190, 120, 90),
             DocItemLabel.MARKER: (205, 85, 120),
+            DocItemLabel.ATTACHMENT: (204, 204, 255),
         }
         return color_map.get(label, (0, 0, 0))
 

--- a/docs/DoclingDocument.json
+++ b/docs/DoclingDocument.json
@@ -1,5 +1,174 @@
 {
   "$defs": {
+    "AttachmentItem": {
+      "additionalProperties": false,
+      "description": "An embedded file attachment referenced by a document.",
+      "properties": {
+        "self_ref": {
+          "pattern": "^#(?:/([\\w-]+)(?:/(\\d+))?)?$",
+          "title": "Self Ref",
+          "type": "string"
+        },
+        "parent": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RefItem"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "children": {
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/RefItem"
+          },
+          "title": "Children",
+          "type": "array"
+        },
+        "content_layer": {
+          "$ref": "#/$defs/ContentLayer",
+          "default": "body"
+        },
+        "meta": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/BaseMeta"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "label": {
+          "const": "attachment",
+          "default": "attachment",
+          "title": "Label",
+          "type": "string"
+        },
+        "prov": {
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/ProvenanceItem"
+          },
+          "title": "Prov",
+          "type": "array"
+        },
+        "source": {
+          "default": [],
+          "description": "The provenance of this document item. Currently, it is only used for media track provenance.",
+          "items": {
+            "discriminator": {
+              "mapping": {
+                "track": "#/$defs/TrackSource"
+              },
+              "propertyName": "kind"
+            },
+            "oneOf": [
+              {
+                "$ref": "#/$defs/TrackSource"
+              }
+            ]
+          },
+          "title": "Source",
+          "type": "array"
+        },
+        "comments": {
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/FineRef"
+          },
+          "title": "Comments",
+          "type": "array"
+        },
+        "name": {
+          "description": "Original attachment filename.",
+          "title": "Name",
+          "type": "string"
+        },
+        "mime_type": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "MIME type of the attachment payload.",
+          "title": "Mime Type"
+        },
+        "size": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Attachment payload size in bytes.",
+          "title": "Size"
+        },
+        "target": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "format": "uri",
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Relative path/URL to the converted attachment output, or None if not converted.",
+          "title": "Target"
+        },
+        "data": {
+          "anyOf": [
+            {
+              "format": "binary",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Raw binary payload of the attachment. Stored as base64 in JSON.",
+          "title": "Data"
+        },
+        "doc_data": {
+          "anyOf": [
+            {
+              "format": "binary",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Serialized DoclingDocument (e.g. JSON/DCLG/DCLX) of the recursively parsed attachment. When present, the attachment is implicitly considered converted.",
+          "title": "Doc Data"
+        }
+      },
+      "required": [
+        "self_ref",
+        "name"
+      ],
+      "title": "AttachmentItem",
+      "type": "object"
+    },
     "BaseMeta": {
       "additionalProperties": true,
       "description": "Base class for metadata.",
@@ -4636,6 +4805,14 @@
         "$ref": "#/$defs/FieldItem"
       },
       "title": "Field Items",
+      "type": "array"
+    },
+    "attachments": {
+      "default": [],
+      "items": {
+        "$ref": "#/$defs/AttachmentItem"
+      },
+      "title": "Attachments",
       "type": "array"
     },
     "pages": {

--- a/test/test_docling_doc.py
+++ b/test/test_docling_doc.py
@@ -16,6 +16,7 @@ from PIL import Image as PILImage
 from pydantic import AnyUrl, BaseModel, ValidationError
 
 from docling_core.types.doc import (
+    AttachmentItem,
     BoundingBox,
     CodeItem,
     ContentLayer,
@@ -582,10 +583,54 @@ def test_docitems():
                 level=2,
             )
             verify(dc, obj)
+        elif dc is AttachmentItem:
+            # No gold fixture here: serializer changes are deferred to a follow-up PR.
+            # Storage + JSON round-trip are covered by test_add_attachment_round_trip.
+            continue
         elif dc is GraphData:  # we skip this on purpose
             continue
         else:
             raise RuntimeError(f"New derived class detected {dc.__name__}")
+
+
+def test_add_attachment_round_trip():
+    doc = DoclingDocument(name="attachments")
+    attachment = doc.add_attachment(
+        name="report.pdf",
+        mime_type="application/pdf",
+        size=1234,
+        target="attachments/report.dclg",
+        data=b"%PDF-1.4 binary payload",
+        doc_data=b'{"document_type": "DCLG", "name": "report"}',
+    )
+
+    assert attachment is doc.attachments[0]
+    assert attachment.label == DocItemLabel.ATTACHMENT
+    assert attachment.self_ref == "#/attachments/0"
+    assert attachment.parent == doc.body.get_ref()
+
+    # Binary payloads survive a JSON round-trip (pydantic base64-encodes bytes).
+    doc_reloaded = DoclingDocument.model_validate_json(doc.model_dump_json())
+
+    assert len(doc_reloaded.attachments) == 1
+    reloaded = doc_reloaded.attachments[0]
+    assert reloaded.name == "report.pdf"
+    assert reloaded.mime_type == "application/pdf"
+    assert reloaded.size == 1234
+    assert reloaded.target == "attachments/report.dclg"
+    assert reloaded.data == b"%PDF-1.4 binary payload"
+    assert reloaded.doc_data == b'{"document_type": "DCLG", "name": "report"}'
+    assert reloaded.parent == doc_reloaded.body.get_ref()
+
+    # Storage wiring: attachments are reachable via iteration and survive
+    # _normalize_references / filter / concatenate.
+    assert any(item.self_ref.startswith("#/attachments/") for item, _ in doc.iterate_items())
+    assert reloaded.data == doc.filter().attachments[0].data
+    merged = DoclingDocument.concatenate([doc, DoclingDocument(name="other")])
+    assert [a.name for a in merged.attachments] == ["report.pdf"]
+
+    # Empty attachments are suppressed in dumps.
+    assert "attachments" not in DoclingDocument(name="empty").model_dump()
 
 
 def test_reference_doc():


### PR DESCRIPTION
## Summary

Adds the `AttachmentItem` data model and its storage in `DoclingDocument`, so the final document model can hold embedded-file attachment entries (the recipient's log that applications consume). This is PR #3 of the PDF-attachment split — it follows the page-level types in #734.

- `AttachmentItem` — `name`, `mime_type`, `size`, `target`, raw `data: bytes` payload, and `doc_data: bytes` for a future serialized (DCLG/DCLX) recursive conversion. No `status` field (dropped per maintainer direction; presence of `doc_data` implies converted).
- `DoclingDocument.attachments: list[AttachmentItem]` + `doc.add_attachment()` with full index wiring (`_DocIndex`, iteration, `_append_item`, empty-list suppression in dumps).
- `DocItemLabel.ATTACHMENT` + package export.
- Regenerated `docs/DoclingDocument.json` (schema doc only).

## Backward compatibility

Fully additive: `attachments` is a new optional field with an empty default and is suppressed from dumps when empty. No serializers are touched.

## Notes

- Serializer support (markdown/HTML/doctags/tokens) is deliberately deferred to a follow-up PR.
- Tests: `test/test_docling_doc.py` — `test_add_attachment_round_trip` (add_attachment + JSON round-trip incl. binary payloads + `filter`/`concatenate`/iteration wiring) and `AttachmentItem` handling in `test_docitems`.
