### PR TITLE
fix: updated the doclang serializer for groups

### DIFF
--- a/docling_core/transforms/deserializer/doclang.py
+++ b/docling_core/transforms/deserializer/doclang.py
@@ -362,9 +362,7 @@ class DocLangDocDeserializer(BaseDocDeserializer, BaseModel):
         else:
             self._walk_children(doc=doc, el=el, parent=parent)
 
-    def _parse_named_group(
-        self, *, doc: DoclingDocument, el: Element, parent: Optional[NodeItem], name: str
-    ) -> None:
+    def _parse_named_group(self, *, doc: DoclingDocument, el: Element, parent: Optional[NodeItem], name: str) -> None:
         r"""Rebuild a GroupItem from <group name="..."> and nest its children in it."""
         head_nodes = [node for node in el.childNodes if isinstance(node, Element) and self._is_element_head_tag(node)]
         label = GroupLabel.UNSPECIFIED

--- a/docling_core/transforms/deserializer/doclang.py
+++ b/docling_core/transforms/deserializer/doclang.py
@@ -343,8 +343,13 @@ class DocLangDocDeserializer(BaseDocDeserializer, BaseModel):
         elif name == DocLangToken.LIST.value:
             self._parse_list(doc=doc, el=el, parent=parent)
         elif name == DocLangToken.GROUP.value:
+            # A named group is an explicit GroupItem. The float + footnote wrapper
+            # never carries a name, so it must be checked first: an article group
+            # holding a picture or a table is not a float.
+            if group_name := el.getAttribute(DocLangAttributeKey.NAME.value):
+                self._parse_named_group(doc=doc, el=el, parent=parent, name=group_name)
             # Float + footnote siblings: parse as one unit (not a Docling GroupItem).
-            if self._first_child(el, DocLangToken.TABLE.value) or self._first_child(el, DocLangToken.INDEX.value):
+            elif self._first_child(el, DocLangToken.TABLE.value) or self._first_child(el, DocLangToken.INDEX.value):
                 self._parse_table(doc=doc, el=el, parent=parent)
             elif self._first_child(el, DocLangToken.PICTURE.value):
                 self._parse_picture(doc=doc, el=el, parent=parent)
@@ -356,6 +361,21 @@ class DocLangDocDeserializer(BaseDocDeserializer, BaseModel):
             self._parse_picture(doc=doc, el=el, parent=parent)
         else:
             self._walk_children(doc=doc, el=el, parent=parent)
+
+    def _parse_named_group(
+        self, *, doc: DoclingDocument, el: Element, parent: Optional[NodeItem], name: str
+    ) -> None:
+        r"""Rebuild a GroupItem from <group name="..."> and nest its children in it."""
+        head_nodes = [node for node in el.childNodes if isinstance(node, Element) and self._is_element_head_tag(node)]
+        label = GroupLabel.UNSPECIFIED
+        if label_value := self._label_value_from_nodes(head_nodes):
+            try:
+                label = GroupLabel(label_value)
+            except ValueError:
+                pass
+        group = doc.add_group(label=label, name=name, parent=parent)
+        self._source_recorder.bind_item(el, group)
+        self._walk_children(doc=doc, el=el, parent=group)
 
     def _walk_children(self, *, doc: DoclingDocument, el: Element, parent: Optional[NodeItem]) -> None:
         for node in el.childNodes:

--- a/docling_core/transforms/serializer/_doclang_utils.py
+++ b/docling_core/transforms/serializer/_doclang_utils.py
@@ -5,6 +5,7 @@ import warnings
 import xml.etree.ElementTree as ET
 from enum import Enum
 from typing import Any, ClassVar, Final, Optional
+from xml.sax.saxutils import escape
 
 from pydantic import BaseModel
 
@@ -366,6 +367,7 @@ class DocLangAttributeKey(str, Enum):
     CLASS = "class"
     THREAD_ID = "thread_id"
     URI = "uri"
+    NAME = "name"
 
 
 class DocLangAttributeValue(str, Enum):
@@ -416,6 +418,7 @@ class DocLangVocabulary(BaseModel):
         DocLangToken.LIST: {DocLangAttributeKey.CLASS},
         DocLangToken.THREAD: {DocLangAttributeKey.THREAD_ID},
         DocLangToken.XREF: {DocLangAttributeKey.THREAD_ID},
+        DocLangToken.GROUP: {DocLangAttributeKey.NAME},
     }
 
     # Allowed values for specific attributes (enumerations)
@@ -666,16 +669,21 @@ class DocLangVocabulary(BaseModel):
         return f'<{token.value} {DocLangAttributeKey.THREAD_ID.value}="{thread_id}"/>'
 
     @classmethod
-    def _create_group_token(cls, *, closing: bool = False) -> str:
+    def _create_group_token(cls, *, name: Optional[str] = None, closing: bool = False) -> str:
         """Create a group tag.
 
         - When `closing` is True, returns the closing tag.
-        - Otherwise returns an opening tag without attributes.
+        - When `name` is given, returns an opening tag carrying it, otherwise an
+          opening tag without attributes.
         """
+        token = DocLangToken.GROUP
         if closing:
-            return f"</{DocLangToken.GROUP.value}>"
-        else:
-            return f"<{DocLangToken.GROUP.value}>"
+            return f"</{token.value}>"
+        if name is None:
+            return f"<{token.value}>"
+        assert DocLangAttributeKey.NAME in cls.ALLOWED_ATTRIBUTES.get(token, set())
+        safe = escape(name, {'"': "&quot;"})
+        return f'<{token.value} {DocLangAttributeKey.NAME.value}="{safe}">'
 
     @classmethod
     def _create_list_token(cls, *, ordered: bool, closing: bool = False) -> str:

--- a/docling_core/transforms/serializer/doclang.py
+++ b/docling_core/transforms/serializer/doclang.py
@@ -263,6 +263,16 @@ class DocLangParams(CommonParams):
         _advanced_field(detail="When True, the <text> wrapper is omitted whenever allowed."),
     ] = True
     label_mode: Annotated[LabelMode, _advanced_field()] = LabelMode.AUTO
+    add_named_groups: Annotated[
+        bool,
+        _advanced_field(
+            detail=(
+                "When True, a plain GroupItem is emitted as a <group> element carrying its "
+                "name and label, so the grouping survives a round trip. When False, the "
+                "group is transparent and only its children are emitted."
+            ),
+        ),
+    ] = False
     interpret_code_unknown_as_other: Annotated[
         bool,
         _advanced_field(
@@ -1668,6 +1678,17 @@ class DocLangFallbackSerializer(BaseFallbackSerializer):
         if isinstance(item, GroupItem):
             parts = doc_serializer.get_parts(item=item, **kwargs)
             text_res = delim.join([p.text for p in parts if p.text])
+            # ListGroup and InlineGroup have their own serializers and never reach
+            # the fallback; guard anyway so they can never be double-wrapped.
+            if params.add_named_groups and not isinstance(item, (ListGroup, InlineGroup)):
+                head = ""
+                if item.label and item.label != GroupLabel.UNSPECIFIED:
+                    head = _create_label_token(value=item.label.value)
+                text_res = (
+                    f"{DocLangVocabulary._create_group_token(name=item.name)}"
+                    f"{head}{text_res}"
+                    f"{DocLangVocabulary._create_group_token(closing=True)}"
+                )
             return create_ser_result(text=text_res, span_source=parts)
         elif isinstance(item, FieldRegionItem | FieldItem):
             parts = []

--- a/docling_core/types/doc/document.py
+++ b/docling_core/types/doc/document.py
@@ -4841,24 +4841,34 @@ class DoclingDocument(BaseModel):
 
     def export_to_doclang(
         self,
+        *,
+        add_named_groups: bool = False,
     ) -> str:
-        """Export to DocLang."""
+        """Export to DocLang.
+
+        Args:
+            add_named_groups: When True, a plain ``GroupItem`` is emitted as a
+                ``<group name="...">`` element instead of being transparent, so
+                the grouping survives a round trip.
+        """
         from docling_core.transforms.serializer.doclang import DocLangDocSerializer, DocLangParams
 
         serializer = DocLangDocSerializer(
             doc=self,
-            params=DocLangParams(),
+            params=DocLangParams(add_named_groups=add_named_groups),
         )
         return serializer.serialize().text
 
     def save_as_doclang(
         self,
         filename: Union[str, Path],
+        *,
+        add_named_groups: bool = False,
     ) -> None:
         """Save the document as DocLang."""
         if isinstance(filename, str):
             filename = Path(filename)
-        out = self.export_to_doclang()
+        out = self.export_to_doclang(add_named_groups=add_named_groups)
         filename.write_text(f"{out}\n", encoding="utf-8")
 
     def save_as_doclang_archive(
@@ -4867,11 +4877,15 @@ class DoclingDocument(BaseModel):
         *,
         artifacts_dir: Optional[Path] = None,
         validate: bool = False,
+        add_named_groups: bool = False,
     ) -> None:
         """Save the document as a DocLang OPC archive (``.dclx``).
 
         Picture and page images are always stored outside the markup, under
         ``assets/`` and ``pages/`` in the archive respectively.
+
+        ``add_named_groups`` emits plain ``GroupItem``s as ``<group name="...">``
+        elements so the grouping survives a round trip.
         """
         from doclang import pack
 
@@ -4893,7 +4907,10 @@ class DoclingDocument(BaseModel):
 
             serializer = DocLangDocSerializer(
                 doc=doc,
-                params=DocLangParams(image_mode=ImageRefMode.REFERENCED),
+                params=DocLangParams(
+                    image_mode=ImageRefMode.REFERENCED,
+                    add_named_groups=add_named_groups,
+                ),
             )
             document_path = staging_root / "document.dclg.xml"
             document_path.write_text(f"{serializer.serialize().text}\n", encoding="utf-8")

--- a/test/test_deserializer_doclang.py
+++ b/test/test_deserializer_doclang.py
@@ -2286,3 +2286,132 @@ def test_deserialize_accepts_document_within_budgets() -> None:
     )
     assert len(doc.texts) == 1
     assert doc.texts[0].text == "hello"
+
+
+def _doc_with_named_groups() -> DoclingDocument:
+    doc = DoclingDocument(name="t")
+    _add_default_page(doc)
+    doc.add_text(label=DocItemLabel.TITLE, text="Masthead")
+    for index in (1, 2):
+        group = doc.add_group(label=GroupLabel.SECTION, name="article")
+        doc.add_heading(text=f"Headline {index}", level=2, parent=group)
+        doc.add_text(label=DocItemLabel.TEXT, text=f"Body {index}", parent=group)
+    return doc
+
+
+def _serialize_named_groups(doc: DoclingDocument, *, add_named_groups: bool) -> str:
+    ser = DocLangDocSerializer(
+        doc=doc,
+        params=DocLangParams(include_version=False, add_named_groups=add_named_groups),
+    )
+    return ser.serialize().text
+
+
+def test_named_groups_are_off_by_default() -> None:
+    """A plain group stays transparent unless ``add_named_groups`` is set."""
+    text = _serialize_named_groups(_doc_with_named_groups(), add_named_groups=False)
+    assert "<group" not in text
+    assert_valid_dclg_xml(text)
+
+    doc = _deserialize(text)
+    assert doc.groups == []
+    assert [item.text for item in doc.texts] == [
+        "Masthead",
+        "Headline 1",
+        "Body 1",
+        "Headline 2",
+        "Body 2",
+    ]
+
+
+def test_named_group_roundtrip() -> None:
+    """``add_named_groups`` keeps the group, its name and its label across a roundtrip."""
+    text = _serialize_named_groups(_doc_with_named_groups(), add_named_groups=True)
+    assert text.count('<group name="article">') == 2
+    assert text.count('<label value="section"/>') == 2
+
+    # Not validated against the DocLang XSD: the schema has no `name` attribute
+    # on <group> yet.
+    doc = _deserialize(text, validate=False)
+    assert [(group.label, group.name) for group in doc.groups] == [
+        (GroupLabel.SECTION, "article"),
+        (GroupLabel.SECTION, "article"),
+    ]
+    assert [child.cref for child in doc.body.children] == [
+        "#/texts/0",
+        "#/groups/0",
+        "#/groups/1",
+    ]
+    for group in doc.groups:
+        children = [child.resolve(doc) for child in group.children]
+        assert [item.label for item in children] == [
+            DocItemLabel.SECTION_HEADER,
+            DocItemLabel.TEXT,
+        ]
+    assert _serialize_named_groups(doc, add_named_groups=True) == text
+
+
+def test_named_group_escapes_its_name() -> None:
+    doc = DoclingDocument(name="t")
+    group = doc.add_group(label=GroupLabel.UNSPECIFIED, name='a & "b"')
+    doc.add_text(label=DocItemLabel.TEXT, text="child", parent=group)
+
+    text = _serialize_named_groups(doc, add_named_groups=True)
+    assert '<group name="a &amp; &quot;b&quot;">' in text
+    assert "<label" not in text
+
+    parsed = _deserialize(text, validate=False)
+    assert [(g.label, g.name) for g in parsed.groups] == [
+        (GroupLabel.UNSPECIFIED, 'a & "b"')
+    ]
+
+
+def test_named_group_keeps_a_picture_and_a_table_inside() -> None:
+    """A named group holding a float is a group, not the float+footnote wrapper."""
+    doc = DoclingDocument(name="t")
+    _add_default_page(doc)
+    group = doc.add_group(label=GroupLabel.SECTION, name="article")
+    doc.add_heading(text="Headline", level=2, parent=group)
+    doc.add_picture(parent=group)
+    doc.add_table(
+        data=TableData(
+            num_rows=1,
+            num_cols=1,
+            table_cells=[
+                TableCell(
+                    text="cell",
+                    start_row_offset_idx=0,
+                    end_row_offset_idx=1,
+                    start_col_offset_idx=0,
+                    end_col_offset_idx=1,
+                )
+            ],
+        ),
+        parent=group,
+    )
+    doc.add_text(label=DocItemLabel.TEXT, text="Body", parent=group)
+
+    text = _serialize_named_groups(doc, add_named_groups=True)
+    parsed = _deserialize(text, validate=False)
+
+    assert len(parsed.groups) == 1
+    assert len(parsed.pictures) == 1
+    assert len(parsed.tables) == 1
+    children = [child.resolve(parsed) for child in parsed.groups[0].children]
+    assert [item.label for item in children] == [
+        DocItemLabel.SECTION_HEADER,
+        DocItemLabel.PICTURE,
+        DocItemLabel.TABLE,
+        DocItemLabel.TEXT,
+    ]
+
+
+def test_unnamed_group_markup_still_wraps_floats() -> None:
+    """The float+footnote ``<group>`` wrapper keeps parsing as one unit."""
+    xml = (
+        "<doclang><group><picture><caption>cap</caption></picture>"
+        "<footnote>note</footnote></group></doclang>"
+    )
+    doc = _deserialize(xml, validate=False)
+    assert doc.groups == []
+    assert len(doc.pictures) == 1

--- a/test/test_deserializer_doclang.py
+++ b/test/test_deserializer_doclang.py
@@ -2361,9 +2361,7 @@ def test_named_group_escapes_its_name() -> None:
     assert "<label" not in text
 
     parsed = _deserialize(text, validate=False)
-    assert [(g.label, g.name) for g in parsed.groups] == [
-        (GroupLabel.UNSPECIFIED, 'a & "b"')
-    ]
+    assert [(g.label, g.name) for g in parsed.groups] == [(GroupLabel.UNSPECIFIED, 'a & "b"')]
 
 
 def test_named_group_keeps_a_picture_and_a_table_inside() -> None:
@@ -2408,10 +2406,7 @@ def test_named_group_keeps_a_picture_and_a_table_inside() -> None:
 
 def test_unnamed_group_markup_still_wraps_floats() -> None:
     """The float+footnote ``<group>`` wrapper keeps parsing as one unit."""
-    xml = (
-        "<doclang><group><picture><caption>cap</caption></picture>"
-        "<footnote>note</footnote></group></doclang>"
-    )
+    xml = "<doclang><group><picture><caption>cap</caption></picture><footnote>note</footnote></group></doclang>"
     doc = _deserialize(xml, validate=False)
     assert doc.groups == []
     assert len(doc.pictures) == 1


### PR DESCRIPTION
  ## Summary

  A plain `GroupItem` is transparent in DocLang: the fallback serializer emits its
  children and drops the grouping, so any structural grouping in a
  `DoclingDocument` is lost on a round trip.

  This adds `add_named_groups` to `DocLangParams` (default `False`, so nothing
  changes unless you ask for it). When enabled, a plain `GroupItem` is emitted as
  a `<group>` element carrying its name and label, and the deserializer rebuilds
  it.

  ```xml
  <group name="article">
    <label value="section"/>
    <heading level="3">Headline</heading>
    <text>Body</text>
  </group>
```

  The motivating case is synthetic newspaper ground truth, where each article is a
  GroupItem holding everything from its section label to its last paragraph.

  Changes

  - serializer/_doclang_utils.py: DocLangAttributeKey.NAME, allowed on
    DocLangToken.GROUP; _create_group_token takes an optional name.
  - serializer/doclang.py: DocLangParams.add_named_groups; DocLangFallbackSerializer
    wraps plain groups when it is set. ListGroup and InlineGroup are excluded —
    they have their own serializers. The <label> element is emitted only when the
    label is not UNSPECIFIED, keeping XSD element-head order and satisfying the
    schematron head-placement rule.
  - deserializer/doclang.py: _parse_named_group restores the group's name,
    label and nesting. The name attribute is checked before the float +
    footnote <group> heuristic — that wrapper never carries a name, so without
    this an article group holding a picture or a table would be parsed as a float
    and swallow its siblings.
  - types/doc/document.py: add_named_groups threaded through
    export_to_doclang, save_as_doclang and save_as_doclang_archive.

  Testing

  Five tests in test/test_deserializer_doclang.py: default-off behaviour,
  name/label/nesting round trip, attribute escaping, a named group containing a
  picture and a table, and the unnamed float wrapper still parsing as one unit.

  With the flag off, export_to_doclang() is byte-identical to the previous
  behaviour across every loadable document in test/data/doc/, and
  serialize → deserialize results are unchanged.

  Follow-up: schema

  doclang.xsd gives <group> no attributes, so with the flag enabled validation
  reports attribute 'name' is not allowed. Default output validates clean, and
  the new tests skip XSD validation with a comment pointing here. The schema needs
  one line in the doclang repo:

```
  <xs:element name="group">
    <xs:complexType>
      <xs:sequence>
        <xs:group ref="dl:element_head"/>
        <xs:group ref="dl:top_level_cat" minOccurs="0" maxOccurs="unbounded"/>
      </xs:sequence>
      <xs:attribute name="name" type="xs:string"/>
    </xs:complexType>
  </xs:element>
```
  Verified against a patched copy of the schema. Once it lands, the
  validate=False in the new tests can be dropped.