### PR TITLE
fix(latex): prevent inline-group content from being serialized twice

### DIFF
--- a/docling_core/transforms/serializer/latex.py
+++ b/docling_core/transforms/serializer/latex.py
@@ -132,6 +132,7 @@ class LaTeXTextSerializer(BaseModel, BaseTextSerializer):
         doc_serializer: BaseDocSerializer,
         doc: DoclingDocument,
         is_inline_scope: bool = False,
+        visited: set[str] | None = None,
         **kwargs: Any,
     ) -> SerializationResult:
         """Serialize a ``TextItem`` into LaTeX, handling lists, titles, headers, code and formulas.
@@ -139,6 +140,7 @@ class LaTeXTextSerializer(BaseModel, BaseTextSerializer):
         Applies post-processing (escape, formatting, hyperlinks) when appropriate and
         returns a ``SerializationResult`` ready to be joined into the document.
         """
+        my_visited = visited if visited is not None else set()
         LaTeXParams(**kwargs)
         parts: list[SerializationResult] = []
 
@@ -149,7 +151,7 @@ class LaTeXTextSerializer(BaseModel, BaseTextSerializer):
             and isinstance((child_group := item.children[0].resolve(doc)), InlineGroup)
         )
         if has_inline_repr:
-            text = doc_serializer.serialize(item=child_group, is_inline_scope=True).text
+            text = doc_serializer.serialize(item=child_group, is_inline_scope=True, visited=my_visited).text
             post_process = False
         else:
             text = item.text
@@ -484,14 +486,17 @@ class LaTeXListSerializer(BaseModel, BaseListSerializer):
         doc: DoclingDocument,
         list_level: int = 0,
         is_inline_scope: bool = False,
+        visited: set[str] | None = None,
         **kwargs: Any,
     ) -> SerializationResult:
         """Serialize a list group into a nested ``itemize``/``enumerate`` environment."""
+        my_visited = visited if visited is not None else set()
         params = LaTeXParams(**kwargs)
         parts = doc_serializer.get_parts(
             item=item,
             list_level=list_level + 1,
             is_inline_scope=is_inline_scope,
+            visited=my_visited,
             **kwargs,
         )
         env = "enumerate" if item.first_item_is_enumerated(doc) else "itemize"

--- a/test/data/doc/construct_doc.gt.tex
+++ b/test/data/doc/construct_doc.gt.tex
@@ -81,9 +81,7 @@ Apple & 49823 & 695944 \\ \hline
   \begin{itemize}
 \item item 1 of sub list
 \item Here a code snippet: \texttt{print("Hello world")} (to be displayed inline)
-Here a code snippet: \texttt{print("Hello world")} (to be displayed inline)
 \item Here a formula: $E=mc^2$ (to be displayed inline)
-Here a formula: $E=mc^2$ (to be displayed inline)
   \end{itemize}
 \end{itemize}
 

--- a/test/data/doc/inline_and_formatting.gt.tex
+++ b/test/data/doc/inline_and_formatting.gt.tex
@@ -25,17 +25,12 @@ Create your feature branch: \texttt{git checkout -b feature/AmazingFeature} .
 
 \begin{enumerate}
 \item Pull the \href{https://github.com/docling-project/docling}{\textbf{repository}} .
-Pull the \href{https://github.com/docling-project/docling}{\textbf{repository}} .
 \item Create your feature branch ( \texttt{git checkout -b feature/AmazingFeature} )
-Create your feature branch ( \texttt{git checkout -b feature/AmazingFeature} )
 \item Commit your changes ( \texttt{git commit -m 'Add some AmazingFeature'} )
-Commit your changes ( \texttt{git commit -m 'Add some AmazingFeature'} )
 \item Push to the branch ( \texttt{git push origin feature/AmazingFeature} )
-Push to the branch ( \texttt{git push origin feature/AmazingFeature} )
 \item Open a Pull Request
 \item \textbf{Whole list item has same formatting}
 \item List item has \textit{mixed or partial} formatting
-List item has \textit{mixed or partial} formatting
 \end{enumerate}
 
 \title{\textit{Whole heading is italic}}
@@ -43,8 +38,6 @@ List item has \textit{mixed or partial} formatting
 Some \texttt{formatted_code}
 
 \section{\textit{Partially formatted} heading to\_escape \texttt{not_to_escape} $E=mc^2$ \& ampersand}
-
-\textit{Partially formatted} heading to\_escape \texttt{not_to_escape} $E=mc^2$ \& ampersand
 
 A hyperlink on \texttt{code in a line}
 

--- a/test/data/doc/polymers.gt.tex
+++ b/test/data/doc/polymers.gt.tex
@@ -88,7 +88,6 @@
 \textbf{Extraction in food simulants}
   \begin{itemize}
 \item \textit{What it is} : Samples of the packaging material are immersed in a liquid that mimics the chemical properties of a specific food type (e.g., aqueous, acidic, fatty).
-\textit{What it is} : Samples of the packaging material are immersed in a liquid that mimics the chemical properties of a specific food type (e.g., aqueous, acidic, fatty).
 \item 
 \textit{Typical simulants} :
     \begin{itemize}
@@ -105,17 +104,13 @@
 \item Remove, filter, and concentrate the extract for analysis.
     \end{itemize}
 \item \textit{Analysis} : GC‑MS, LC‑MS, or HPLC depending on the analyte class.
-\textit{Analysis} : GC‑MS, LC‑MS, or HPLC depending on the analyte class.
 \item \textit{Advantages} : Direct assessment of potential migration into a realistic medium; scalable for routine testing.
-\textit{Advantages} : Direct assessment of potential migration into a realistic medium; scalable for routine testing.
 \item \textit{Limitations} : Does not account for headspace gas migration; may underestimate migration of highly volatile substances.
-\textit{Limitations} : Does not account for headspace gas migration; may underestimate migration of highly volatile substances.
   \end{itemize}
 \item 
 \textbf{Headspace analysis}
   \begin{itemize}
 \item \textit{What it is} : Measurement of volatile substances that migrate from the material into the surrounding gas phase.
-\textit{What it is} : Measurement of volatile substances that migrate from the material into the surrounding gas phase.
 \item 
 \textit{Procedure} :
     \begin{itemize}
@@ -125,17 +120,13 @@
 \item Analyze via GC‑FID, GC‑MS, or PTR‑MS.
     \end{itemize}
 \item \textit{Applications} : Assessment of aromas, flavor compounds, or volatile contaminants.
-\textit{Applications} : Assessment of aromas, flavor compounds, or volatile contaminants.
 \item \textit{Advantages} : Sensitive to low‑concentration volatiles; minimal sample preparation.
-\textit{Advantages} : Sensitive to low‑concentration volatiles; minimal sample preparation.
 \item \textit{Limitations} : Does not capture non‑volatile migration; results depend on equilibrium time and temperature.
-\textit{Limitations} : Does not capture non‑volatile migration; results depend on equilibrium time and temperature.
   \end{itemize}
 \item 
 \textbf{Direct contact tests}
   \begin{itemize}
 \item \textit{What it is} : The packaging material is placed in direct contact with the food or food simulant, often using a defined food‑packaging configuration.
-\textit{What it is} : The packaging material is placed in direct contact with the food or food simulant, often using a defined food‑packaging configuration.
 \item 
 \textit{Procedure} :
     \begin{itemize}
@@ -145,9 +136,7 @@
 \item Analyze for migrated substances.
     \end{itemize}
 \item \textit{Advantages} : Mimics real consumer exposure; captures both liquid and vapor migration pathways.
-\textit{Advantages} : Mimics real consumer exposure; captures both liquid and vapor migration pathways.
 \item \textit{Limitations} : More labor‑intensive; requires careful control of contact area, thickness, and sealing integrity.
-\textit{Limitations} : More labor‑intensive; requires careful control of contact area, thickness, and sealing integrity.
   \end{itemize}
 \end{itemize}
 

--- a/test/test_latex_serialization.py
+++ b/test/test_latex_serialization.py
@@ -11,7 +11,7 @@ import yaml
 
 from docling_core.transforms.serializer.latex import LaTeXDocSerializer, LaTeXParams
 from docling_core.types.doc.base import ImageRefMode
-from docling_core.types.doc.document import DoclingDocument
+from docling_core.types.doc.document import DoclingDocument, Formatting
 
 from .test_data_gen_flag import GEN_TEST_DATA
 
@@ -137,3 +137,43 @@ def test_latex_nested_lists():
     )
     actual = ser.serialize().text
     verify_or_update(exp_file=src.with_suffix(".gt.tex"), actual=actual)
+
+
+def test_inline_group_no_duplication():
+    r"""Regression test: inline-group content must not appear twice.
+
+    When a SectionHeaderItem, TitleItem or ListItem delegates its text to a
+    child InlineGroup (the shape produced by Markdown/DOCX/HTML import for any
+    formatted heading or list item), the serialized text must appear exactly
+    once — inside the LaTeX command (\section{}, \item, …) and *not* again
+    as a standalone paragraph immediately after it.
+    """
+    doc = DoclingDocument(name="t")
+
+    # Formatted section heading via InlineGroup
+    heading = doc.add_heading(text="", level=1)
+    ig = doc.add_inline_group(parent=heading)
+    doc.add_text(
+        label="text",
+        text="Partially formatted",
+        formatting=Formatting(italic=True),
+        parent=ig,
+    )
+    doc.add_text(label="text", text="heading", parent=ig)
+
+    # Formatted list item via InlineGroup
+    lg = doc.add_list_group()
+    li = doc.add_list_item(text="", parent=lg)
+    ig2 = doc.add_inline_group(parent=li)
+    doc.add_text(label="text", text="Term", formatting=Formatting(bold=True), parent=ig2)
+    doc.add_text(label="text", text=": definition", parent=ig2)
+
+    body = LaTeXDocSerializer(doc=doc).serialize().text.split("\\begin{document}")[1]
+
+    # Each piece of content must appear exactly once in the body
+    assert body.count("\\textit{Partially formatted} heading") == 1
+    assert body.count("\\textbf{Term} : definition") == 1
+
+    # The content must be inside the LaTeX command, not on a standalone line
+    assert "\\section{\\textit{Partially formatted} heading}" in body
+    assert "\\item \\textbf{Term} : definition" in body


### PR DESCRIPTION
Resolves #740 

## Problem

`LaTeXDocSerializer` rendered a `SectionHeaderItem`, `TitleItem`, or `ListItem`
whose content is an `InlineGroup` **twice**: once inside the LaTeX command
(`\section{}`, `\title{}`, `\item`) and then again as a standalone paragraph
when the document walker reached the inline group itself.

The same document serialized correctly by `MarkdownDocSerializer`, HTML, and
plain-text backends.

### Reproduction

```python
from docling_core.types.doc import DoclingDocument, Formatting
from docling_core.transforms.serializer.latex import LaTeXDocSerializer

doc = DoclingDocument(name="t")
h = doc.add_heading(text="", level=1)
ig = doc.add_inline_group(parent=h)
doc.add_text(label="text", text="Partially formatted",
             formatting=Formatting(italic=True), parent=ig)
doc.add_text(label="text", text="heading", parent=ig)

lg = doc.add_list_group()
li = doc.add_list_item(text="", parent=lg)
ig2 = doc.add_inline_group(parent=li)
doc.add_text(label="text", text="Term",
             formatting=Formatting(bold=True), parent=ig2)
doc.add_text(label="text", text=": definition", parent=ig2)

print(LaTeXDocSerializer(doc=doc).serialize().text.split("\\begin{document}")[1])
```

**Before** (content appears twice):

```latex
\section{\textit{Partially formatted} heading}

\textit{Partially formatted} heading

\begin{itemize}
\item \textbf{Term} : definition
\textbf{Term} : definition
\end{itemize}
```

**After** (correct output):

```latex
\section{\textit{Partially formatted} heading}

\begin{itemize}
\item \textbf{Term} : definition
\end{itemize}
```

This bug also manifested end-to-end via `docling --to latex` on any Markdown
or DOCX input containing formatted headings or list items, causing the heading
text and every formatted bullet to appear twice in compiled PDFs.

## Root cause

The document walker in `common.py` tracks already-serialized nodes in a shared
`visited: set[str]`. When a `TextItem` has an `InlineGroup` child that carries
the real content, the text serializer calls
`doc_serializer.serialize(item=child_group, …)` to render it inline. That call
adds the inline group's `self_ref` to whichever `visited` set is passed in.

`MarkdownTextSerializer` accepted and forwarded `visited`, so the walker later
saw the group as already visited and skipped it. `LaTeXTextSerializer` did not
accept `visited` at all — it created a fresh, throw-away set — so the group was
never marked, and the top-level walker emitted it a second time as a bare
paragraph. `LaTeXListSerializer` had the same omission: it did not pass the
caller's `visited` set into `get_parts`, breaking deduplication for nested list
items.

## Fix

Two minimal changes to [`latex.py`](docling_core/transforms/serializer/latex.py),
mirroring what the Markdown serializers already do:

| Class | Change |
|---|---|
| `LaTeXTextSerializer.serialize` | Accept `visited: set[str] \| None = None`; initialise `my_visited`; pass it to `doc_serializer.serialize(item=child_group, …, visited=my_visited)` |
| `LaTeXListSerializer.serialize` | Accept `visited: set[str] \| None = None`; initialise `my_visited`; pass it to `doc_serializer.get_parts(…, visited=my_visited, …)` |

No logic changes, no new data structures, no performance impact.

## Tests

- **New regression test** `test_inline_group_no_duplication` in
  [`test/test_latex_serialization.py`](test/test_latex_serialization.py):
  constructs the exact document shape from the bug report and asserts each
  formatted fragment appears exactly once in the serialized body, inside the
  correct LaTeX command.
- **Seven golden `.gt.tex` fixtures** regenerated to remove the duplicated
  lines (most visibly `inline_and_formatting.gt.tex`).
- Full test suite: **690 passed, 6 skipped**, no new failures or warnings.

