### PR TITLE
fix: strip cue timestamp tags when parsing WebVTT cue text

### DIFF
--- a/docling_core/types/doc/webvtt.py
+++ b/docling_core/types/doc/webvtt.py
@@ -13,6 +13,7 @@ from typing_extensions import Self, override
 
 _VALID_ENTITIES: set = {"amp", "lt", "gt", "lrm", "rlm", "nbsp"}
 _ENTITY_PATTERN: re.Pattern = re.compile(r"&([a-zA-Z0-9]+);")
+_TIMESTAMP_PATTERN_STR: str = r"(?:(\d{2,}):)?([0-5]\d):([0-5]\d)\.(\d{3})"
 START_TAG_NAMES = Literal["c", "b", "i", "u", "v", "lang"]
 
 
@@ -51,7 +52,7 @@ class WebVTTTimestamp(BaseModel):
         Field(description="A representation of the WebVTT Timestamp as a single string"),
     ]
 
-    _pattern: ClassVar[re.Pattern] = re.compile(r"^(?:(\d{2,}):)?([0-5]\d):([0-5]\d)\.(\d{3})$")
+    _pattern: ClassVar[re.Pattern] = re.compile(r"^" + _TIMESTAMP_PATTERN_STR + r"$")
     _hours: int
     _minutes: int
     _seconds: int
@@ -419,6 +420,9 @@ class WebVTTCueBlock(BaseModel):
         r"(?:[ \t](?P<annotation>[^\n\r&>]*))?>"
     )
 
+    # pattern of a WebVTT cue timestamp tag (e.g. <00:00:01.500> or <00:01.500>)
+    _pattern_cue_timestamp: ClassVar[re.Pattern] = re.compile(r"<" + _TIMESTAMP_PATTERN_STR + r">")
+
     @field_validator("payload", mode="after")
     @classmethod
     def validate_payload(cls, payload):
@@ -475,6 +479,9 @@ class WebVTTCueBlock(BaseModel):
             if cue_text.startswith(f"<{omm}") and f"</{omm}>" not in cue_text:
                 cue_text += f"</{omm}>"
                 break
+
+        # Strip cue timestamp tags (e.g. <00:00:01.500>) — they carry no text content.
+        cue_text = cls._pattern_cue_timestamp.sub("", cue_text)
 
         stack: list[list[WebVTTCueComponentWithTerminator]] = [[]]
         tag_stack: list[dict] = []

--- a/test/data/webvtt/webvtt_example_04.vtt
+++ b/test/data/webvtt/webvtt_example_04.vtt
@@ -31,3 +31,6 @@ NOTE I’m not sure the timing is right on the following cue.
 — It will perforate your stomach.
 — You could <b.loud>die</b>.
 <v John>This is true.</v>
+
+00:10.000 --> 00:14.000
+the<00:10.389> quick<00:10.750> brown<00:11.110> fox

--- a/test/test_webvtt.py
+++ b/test/test_webvtt.py
@@ -198,6 +198,13 @@ def test_webvttcueblock_parse() -> None:
     assert block.payload[2].component.text == ", ici à Montpellier"
     assert raw == str(block)
 
+    # Cue timestamps must be stripped so that the surrounding text is preserved.
+    raw = "00:00:00.030 --> 00:00:02.669\nthe<00:00:00.389> quick<00:00:00.750> brown\n"
+    block = WebVTTCueBlock.parse(raw)
+    assert len(block.payload) == 1
+    assert isinstance(block.payload[0].component, WebVTTCueTextSpan)
+    assert block.payload[0].component.text == "the quick brown"
+
 
 def test_webvtt_file() -> None:
     """Test WebVTT files."""
@@ -252,7 +259,7 @@ def test_webvtt_file() -> None:
         with warnings.catch_warnings():
             warnings.simplefilter("error")
             vtt = WebVTTFile.parse(content)
-    assert len(vtt) == 2
+    assert len(vtt) == 3
     block = vtt.cue_blocks[1]
     assert len(block.payload) == 5
     assert str(block) == (
@@ -261,6 +268,10 @@ def test_webvtt_file() -> None:
         "— You could <b.loud>die</b>.\n"
         "<v John>This is true.</v>\n"
     )
+    block = vtt.cue_blocks[2]
+    assert len(block.payload) == 1
+    assert isinstance(block.payload[0].component, WebVTTCueTextSpan)
+    assert block.payload[0].component.text == "the quick brown fox"
     assert vtt.title == "Danger of Nitrogen"
 
 


### PR DESCRIPTION
Resolves docling-project/docling#4152

## Problem

WebVTT cue text may contain inline cue timestamp tags such as `<00:00:00.389>`
(defined in the [WebVTT spec §cue-timestamp](https://www.w3.org/TR/webvtt1/#webvtt-cue-timestamp)).
This is the format written by yt-dlp for YouTube auto-generated captions.

The parser did not recognise these tags, so the `<` character they contain
caused `WebVTTCueTextSpan` validation to fail with
`"Cue text contains invalid characters"`. The entire cue block was silently
dropped with a `RuntimeWarning`, resulting in an empty document despite a
`ConversionStatus.SUCCESS` status.

## Solution

- Extract the timestamp regex into a module-level string constant
  `_TIMESTAMP_PATTERN_STR`, shared by both `WebVTTTimestamp._pattern` and the
  new `WebVTTCueBlock._pattern_cue_timestamp`.
- Before the tag-parsing loop in `WebVTTCueBlock.parse`, strip all cue
  timestamp tags from the cue text using `_pattern_cue_timestamp`. The
  surrounding words are preserved and parsed normally.

## Changes

- `docling_core/types/doc/webvtt.py` — introduce `_TIMESTAMP_PATTERN_STR`,
  refactor `WebVTTTimestamp._pattern` to use it, add
  `WebVTTCueBlock._pattern_cue_timestamp` and the stripping step in `parse`.
- `test/data/webvtt/webvtt_example_04.vtt` — add a cue block with inline
  timestamp tags to exercise the fix through `WebVTTFile.parse`.
- `test/test_webvtt.py` — add assertions for the new cue block in
  `test_webvtt_file`, and a dedicated case in `test_webvttcueblock_parse`.
