### PR TITLE
fix(webvtt): accept CR line terminator in verify_signature

### DIFF
--- a/docling_core/types/doc/webvtt.py
+++ b/docling_core/types/doc/webvtt.py
@@ -594,13 +594,18 @@ class WebVTTFile(BaseModel):
 
     @staticmethod
     def verify_signature(content: str) -> bool:
-        """Verify the WebVTT file signature."""
+        """Verify the WebVTT file signature.
+
+        Conforms to the W3C WebVTT specification (https://www.w3.org/TR/webvtt1/),
+        which allows a line terminator (CR, LF, or CRLF) immediately after "WEBVTT"
+        in addition to a space or tab character.
+        """
         if not content:
             return False
         elif len(content) == 6:
             return content == "WEBVTT"
         elif len(content) > 6 and content.startswith("WEBVTT"):
-            return content[6] in (" ", "\t", "\n")
+            return content[6] in (" ", "\t", "\r", "\n")
         else:
             return False
 

--- a/tests/test_webvtt.py
+++ b/tests/test_webvtt.py
@@ -206,6 +206,51 @@ def test_webvttcueblock_parse() -> None:
     assert block.payload[0].component.text == "the quick brown"
 
 
+def test_webvtt_verify_signature() -> None:
+    """Test WebVTTFile.verify_signature conforms to the W3C WebVTT specification.
+
+    Per https://www.w3.org/TR/webvtt1/ the magic string is "WEBVTT" optionally
+    followed by a space (U+0020), a tab (U+0009), or any line terminator
+    (CR U+000D, LF U+000A, or CRLF).
+    """
+    # Exact 6-character "WEBVTT" with nothing after it
+    assert WebVTTFile.verify_signature("WEBVTT") is True
+
+    # Valid: space or tab after "WEBVTT"
+    assert WebVTTFile.verify_signature("WEBVTT some title") is True
+    assert WebVTTFile.verify_signature("WEBVTT\t") is True
+
+    # Valid: LF line terminator (already worked before this fix)
+    assert WebVTTFile.verify_signature("WEBVTT\ncue block") is True
+
+    # Valid: CR line terminator (CR-only files — fixed by this patch)
+    assert WebVTTFile.verify_signature("WEBVTT\rcue block") is True
+
+    # Valid: CRLF — the \r at position 6 is now accepted; the \n at 7 is fine too
+    assert WebVTTFile.verify_signature("WEBVTT\r\ncue block") is True
+
+    # Invalid: empty string
+    assert WebVTTFile.verify_signature("") is False
+
+    # Invalid: wrong magic bytes
+    assert WebVTTFile.verify_signature("WEBVT") is False
+    assert WebVTTFile.verify_signature("webvtt") is False
+
+    # Invalid: character other than space/tab/CR/LF after "WEBVTT"
+    assert WebVTTFile.verify_signature("WEBVTT!") is False
+
+
+def test_webvtt_parse_cr_separator() -> None:
+    """WebVTTFile.parse must handle files that use bare CR as line separator."""
+    # Bare CR (U+000D) as line terminator — per the W3C WebVTT spec this is valid.
+    cr_vtt = "WEBVTT\r\r00:00:00.000 --> 00:00:01.000\rHello world\r"
+    vtt = WebVTTFile.parse(cr_vtt)
+    assert len(vtt) == 1
+    component = vtt[0].payload[0].component
+    assert isinstance(component, WebVTTCueTextSpan)
+    assert component.text == "Hello world"
+
+
 def test_webvtt_file() -> None:
     """Test WebVTT files."""
     with open("./tests/data/webvtt/webvtt_example_01.vtt", encoding="utf-8") as f:


### PR DESCRIPTION
## Problem

The [W3C WebVTT specification §8.1](https://www.w3.org/TR/webvtt1/#file-structure) defines a valid file signature as the string `WEBVTT` optionally followed by a space (U+0020), a tab (U+0009), or **any line terminator** — where a line terminator is U+000D CR, U+000A LF, or CRLF.

`WebVTTFile.verify_signature` only checked for space, tab, and LF at position 6, omitting bare CR (U+000D). This meant that files using CR-only or CRLF line endings were incorrectly rejected when `verify_signature` was called on raw, un-normalised content — for example, by callers who consume `docling-core` directly without pre-processing newlines.

Related upstream report: [docling-project/docling#4157](https://github.com/docling-project/docling/pull/4157).

## Change

`WebVTTFile.verify_signature` now accepts `\r` at position 6 in addition to the already-accepted `\t`, ` `, and `\n`:

```python
# before
return content[6] in (" ", "\t", "\n")

# after
return content[6] in (" ", "\t", "\r", "\n")
```

`WebVTTFile.parse` is unaffected: it normalises all line endings to LF before calling `verify_signature`, so the full-file parsing path was already correct. The fix benefits callers who invoke `verify_signature` directly on raw content.

## Tests

Two new test functions cover the fix:

- `test_webvtt_verify_signature` — exhaustive parametric checks against all characters the spec allows or disallows immediately after `WEBVTT` (space, tab, CR, LF, CRLF, and invalid values).
- `test_webvtt_parse_cr_separator` — end-to-end round-trip: parses a synthetic CR-only WebVTT file and asserts that cue text is extracted correctly.
