### PR TITLE
fix(doclang): nest InlineGroup runs inside a TextItem that has its own text

### DIFF
--- a/docling_core/transforms/serializer/doclang.py
+++ b/docling_core/transforms/serializer/doclang.py
@@ -965,24 +965,32 @@ class DocLangTextSerializer(BaseModel, BaseTextSerializer):
             or (isinstance(item, FormulaItem) and ContentType.TEXT_FORMULA in params.content_types)
             or (not isinstance(item, CodeItem | FormulaItem) and ContentType.TEXT_OTHER in params.content_types)
         ):
-            if item.children and not item.text:
-                # Check if first child is InlineGroup - if so, only serialize that as text content
-                first_child_ref = item.children[0]
-                first_child_item = first_child_ref.resolve(doc)
-
-                if isinstance(first_child_item, InlineGroup):
-                    # Only serialize the first child (InlineGroup) as the text content
-                    # Other children are hierarchical subordinates and will be serialized separately
-                    text_part = doc_serializer.serialize(item=first_child_item, visited=my_visited, **kwargs).text
+            first_child_item = item.children[0].resolve(doc) if item.children else None
+            if isinstance(first_child_item, InlineGroup):
+                # Only serialize the first child (InlineGroup) as the text content
+                # Other children are hierarchical subordinates and will be serialized separately.
+                # The item's own text, when present, precedes the runs within the same element:
+                # emitting the runs as siblings instead yields invalid DocLang and loses content.
+                inline_part = doc_serializer.serialize(item=first_child_item, visited=my_visited, **kwargs).text
+                if item.text:
+                    own_part = _escape_text(item.text, params)
+                    own_part = doc_serializer.post_process(
+                        text=own_part,
+                        formatting=item.formatting,
+                        hyperlink=None,
+                    )
+                    text_part = _get_delim(params=params).join([p for p in (own_part, inline_part) if p])
                 else:
-                    # Serialize all children as text content
-                    sub_parts: list[str] = []
-                    for child_ref in item.children:
-                        child_item = child_ref.resolve(doc)
-                        if isinstance(item, ListItem) and _list_item_segment_sibling(child_item):
-                            continue
-                        sub_parts.append(doc_serializer.serialize(item=child_item, visited=my_visited, **kwargs).text)
-                    text_part = _get_delim(params=params).join(sub_parts)
+                    text_part = inline_part
+            elif item.children and not item.text:
+                # Serialize all children as text content
+                sub_parts: list[str] = []
+                for child_ref in item.children:
+                    child_item = child_ref.resolve(doc)
+                    if isinstance(item, ListItem) and _list_item_segment_sibling(child_item):
+                        continue
+                    sub_parts.append(doc_serializer.serialize(item=child_item, visited=my_visited, **kwargs).text)
+                text_part = _get_delim(params=params).join(sub_parts)
             else:
                 text_part = _escape_text(item.text, params)
                 text_part = doc_serializer.post_process(

--- a/tests/test_serialization_doclang.py
+++ b/tests/test_serialization_doclang.py
@@ -2561,3 +2561,44 @@ def test_create_threading_token_emits_thread_id():
     assert DocLangVocabulary._create_threading_token(thread_id="42") == '<thread thread_id="42"/>'
     with pytest.raises(ValueError, match="thread_id length"):
         DocLangVocabulary._create_threading_token(thread_id="")
+
+
+def test_inline_group_nested_when_parent_text_item_has_text():
+    """Runs of an InlineGroup stay inside the parent element even if it has text.
+
+    Regression test for #750: when the parent ``TextItem`` carries text of its
+    own, the inline runs used to be emitted bare at the parent's sibling level,
+    which is invalid against the DocLang XSD (``group`` is not mixed) and drops
+    the plain-text run on deserialization.
+    """
+    doc = DoclingDocument(name="t")
+    heading = doc.add_heading(text="Heading text", level=2)
+    inline = doc.add_inline_group(parent=heading)
+    doc.add_text(
+        label=DocItemLabel.TEXT,
+        text="bold",
+        parent=inline,
+        formatting=Formatting(bold=True),
+    )
+    doc.add_text(label=DocItemLabel.TEXT, text=" plain ", parent=inline)
+    doc.add_text(
+        label=DocItemLabel.TEXT,
+        text="italic",
+        parent=inline,
+        formatting=Formatting(italic=True),
+    )
+
+    txt = serialize_doclang(doc)
+
+    root = ET.fromstring(txt)
+    assert [child.tag for child in root] == ["heading"]
+    heading_el = root[0]
+    assert [child.tag for child in heading_el] == ["bold", "content", "italic"]
+    assert "".join(heading_el.itertext()).replace("\n", " ").split() == [
+        "Heading",
+        "text",
+        "bold",
+        "plain",
+        "italic",
+    ]
+    assert " plain " in txt


### PR DESCRIPTION
### Problem

`DocLangTextSerializer.serialize` renders a `TextItem`'s `InlineGroup` child as the item's element content only under `if item.children and not item.text:`. Meanwhile `DocLangInlineSerializer.serialize` sets `should_wrap = False` for *every* `InlineGroup` whose parent is a `TextItem`, assuming the parent will render the runs itself.

When the parent `TextItem` carries text of its own, neither side emits a container and the runs land bare at the parent's sibling level:

```xml
<doclang version="0.7">
  <heading level="2">Heading text</heading>
  <bold>bold</bold>
  <content> plain </content>
  <italic>italic</italic>
</doclang>
```

Two consequences:

1. **Invalid output** — the DocLang 0.7 `group` content model is `element_head` + `top_level_cat*` and is not `mixed`, so validation reports `Element 'bold': This element is not expected.`
2. **Silent content loss** — the XML stays well-formed, so serialization itself does not raise. But the deserializer's `_walk_children` dispatches only on `isinstance(node, Element)`, so the DOM text node between two runs is never visited and ` plain ` disappears on round-trip.

This is the shape docling's DOCX backend produces for a paragraph of inline-formatted runs.

### Fix

Render the `InlineGroup` child as element content whenever it is the first child, prefixing the item's own text when it has any — so the runs stay inside the parent element:

```xml
<doclang version="0.7">
  <heading level="2">
    Heading text
    <bold>bold</bold>
    <content> plain </content>
    <italic>italic</italic>
  </heading>
</doclang>
```

This puts the text-bearing case on exactly the same footing as the already-correct empty-text case: with `heading.text == ""`, the same document already serializes correctly nested today, so this is a gap in one path rather than a second kind of shape.

I deliberately did **not** narrow `should_wrap` in `DocLangInlineSerializer`, which is the other obvious way to make the schema error go away. That would emit `<heading>Heading text</heading><text><bold>…</bold>…</text>` — valid, and it does not lose the plain run, but it demotes the `InlineGroup` to a sibling when it *is* a child of the `TextItem` in the `DoclingDocument`. Round-tripping that output yields a heading and a parallel `InlineGroup`, so the parent/child relationship is lost permanently. Fixing the container rather than the nesting keeps the serialized tree faithful to the document tree.

### Tests

New regression test `test_inline_group_nested_when_parent_text_item_has_text` asserts the runs are nested inside `<heading>` and that the plain run survives. It fails on `main` with the XSD error above; I also re-ran it with the production change stashed to confirm it goes red for the right reason rather than passing vacuously.

`tests/test_serialization_doclang.py`: 91 passed. Full suite green (note: `uv sync --frozen --all-extras` is needed, otherwise seven chunker modules fail to collect on missing `tree_sitter`/`tiktoken`/`transformers`). `ruff check` and `ruff format --check` clean.

**No golden fixture changes** — no existing fixture has a `TextItem` carrying both text and an `InlineGroup` child, which is why this went unnoticed.

### Noted but out of scope

`serializer/html.py:157-161` guards `has_inline_repr` on the same `item.text == ""` premise, so the HTML serializer likely has the same gap. I have not touched it here to keep this change reviewable against one schema; happy to open a separate issue for it.

Fixes #750
