### PR TITLE
fix: preserve rows under spanning column headers

### DIFF
--- a/docling_core/types/doc/items/table/table.py
+++ b/docling_core/types/doc/items/table/table.py
@@ -98,15 +98,11 @@ class TableItem(FloatingItem):
 
         # Count how many rows are column headers
         num_headers = 0
-        for i, row in enumerate(self.data.grid):
+        for row_idx, row in enumerate(self.data.grid):
             if len(row) == 0:
                 raise RuntimeError(f"Invalid table. {len(row)=} but {self.data.num_cols=}.")
 
-            any_header = False
-            for cell in row:
-                if cell.column_header:
-                    any_header = True
-                    break
+            any_header = any(cell.column_header and cell.start_row_offset_idx == row_idx for cell in row)
 
             if any_header:
                 num_headers += 1

--- a/tests/test_docling_doc.py
+++ b/tests/test_docling_doc.py
@@ -1926,6 +1926,43 @@ def test_export_markdown_compact_tables():
     assert len(md_compact) < len(md_padded)
 
 
+def test_export_dataframe_with_row_spanning_column_header():
+    def cell(
+        text: str,
+        row: int,
+        column: int,
+        row_span: int = 1,
+        column_header: bool = False,
+    ) -> TableCell:
+        return TableCell(
+            text=text,
+            start_row_offset_idx=row,
+            end_row_offset_idx=row + row_span,
+            start_col_offset_idx=column,
+            end_col_offset_idx=column + 1,
+            row_span=row_span,
+            column_header=column_header,
+        )
+
+    doc = DoclingDocument(name="test")
+    table = doc.add_table(
+        data=TableData(
+            num_rows=2,
+            num_cols=2,
+            table_cells=[
+                cell("Name", 0, 0, column_header=True),
+                cell("", 0, 1, row_span=2, column_header=True),
+                cell("Alpha", 1, 0),
+            ],
+        )
+    )
+
+    dataframe = table.export_to_dataframe(doc)
+
+    assert list(dataframe.columns) == ["Name", ""]
+    assert dataframe.values.tolist() == [["Alpha", ""]]
+
+
 def test_export_traverse_pictures_ocr_scanned_pdf():
     """Test that OCR text nested under a PictureItem is included when traverse_pictures=True."""
     doc = DoclingDocument(name="Scanned Doc")


### PR DESCRIPTION
## What this changes

Count a column header only in the grid row where the cell starts.

## Why

`TableData.grid` repeats a row-spanning cell in every row that it covers. The dataframe exporter treated each covered row as a header row and removed it from the output.

Fixes #755.

## Testing

- Added a regression test for a row-spanning column header.
- `uv run pre-commit run --all-files`
