### PR TITLE
fix: register AFP MIME types

### DIFF
--- a/docling_core/types/doc/common/origin.py
+++ b/docling_core/types/doc/common/origin.py
@@ -28,6 +28,7 @@ class DocumentOrigin(BaseModel):
         "application/epub+zip",
         "application/vnd.box.boxnote",
         "application/vnd.docling.ebcdic",  # accepted alias, see application/x-ebcdic
+        "application/vnd.ibm.modcap",
         "application/vnd.oasis.opendocument.presentation",
         "application/vnd.oasis.opendocument.spreadsheet",
         "application/vnd.oasis.opendocument.text",
@@ -40,6 +41,7 @@ class DocumentOrigin(BaseModel):
         # EBCDIC data files have no IANA-registered media type, so they will never
         # appear in mimetypes.types_map. "application/x-ebcdic" is the standard
         # spelling docling emits; the vendor-tree alias above is accepted as well.
+        "application/x-afp",
         "application/x-ebcdic",
         "audio/mp3",
         "audio/wav",


### PR DESCRIPTION
## Summary

- register `application/vnd.ibm.modcap` for AFP MO:DCA documents
- register the accepted `application/x-afp` alias
- allow `DocumentOrigin` to validate AFP origins without mutating the global `mimetypes` registry

## Context

This is the `docling-core` prerequisite requested during review of [docling-project/docling#4177](https://github.com/docling-project/docling/pull/4177).

## Testing

The Docling AFP end-to-end fixture and focused backend tests pass with these MIME entries enabled.