### PR TITLE
fix(serializer): resolve page-break sentinel in single-node serialize

### DIFF
--- a/docling_core/transforms/serializer/common.py
+++ b/docling_core/transforms/serializer/common.py
@@ -357,6 +357,7 @@ class DocSerializer(BaseModel, BaseDocSerializer):
         **kwargs: Any,
     ) -> SerializationResult:
         """Serialize a given node."""
+        _internal = kwargs.pop("_internal", False)
         my_visited: set[str] = visited if visited is not None else set()
         parts: list[SerializationResult] = []
         delim: str = kwargs.get("delim", "\n")
@@ -497,7 +498,10 @@ class DocSerializer(BaseModel, BaseDocSerializer):
         if meta_part is not None and meta_position == "after":
             parts.append(meta_part)
 
-        return create_ser_result(text=delim.join([p.text for p in parts if p.text]), span_source=parts)
+        text_res = delim.join([p.text for p in parts if p.text])
+        if not _internal:
+            text_res = self._resolve_page_breaks(text_res, **kwargs)
+        return create_ser_result(text=text_res, span_source=parts)
 
     # making some assumptions about the kwargs it can pass
     @override
@@ -537,7 +541,7 @@ class DocSerializer(BaseModel, BaseDocSerializer):
                 list_level=list_level,
                 is_inline_scope=is_inline_scope,
                 visited=my_visited,
-                **(dict(level=lvl) | kwargs),
+                **(kwargs | dict(level=lvl, _internal=True)),
             )
             if part.text or not add_content:
                 parts.append(part)
@@ -713,6 +717,16 @@ class DocSerializer(BaseModel, BaseDocSerializer):
 
     def _create_page_break(self, node: _PageBreakNode) -> str:
         return f"#_#_DOCLING_DOC_PAGE_BREAK_{node.prev_page}_{node.next_page}_#_#"
+
+    def _resolve_page_breaks(self, text: str, **kwargs: Any) -> str:
+        """Resolve internal page-break sentinels in a serialized fragment.
+
+        Full-document rendering resolves sentinels in `serialize_doc`.
+        Single-node `serialize(item=...)` calls (and chunking, which builds
+        on them) never reach `serialize_doc`, so they resolve here instead.
+        Subclasses override to apply their own page-break replacement.
+        """
+        return text
 
     def _get_page_breaks(self, text: str) -> Iterable[tuple[str, int, int]]:
         pattern = r"#_#_DOCLING_DOC_PAGE_BREAK_(\d+)_(\d+)_#_#"

--- a/docling_core/transforms/serializer/doclang.py
+++ b/docling_core/transforms/serializer/doclang.py
@@ -1948,11 +1948,7 @@ class DocLangDocSerializer(DocSerializer):
 
         text_res = delim.join([p.text for p in parts if p.text])
 
-        if self.params.add_page_break:
-            # Always emit well-formed page breaks using the vocabulary
-            page_sep = DocLangVocabulary._create_selfclosing_token(token=DocLangToken.PAGE_BREAK)
-            for full_match, _, _ in self._get_page_breaks(text=text_res):
-                text_res = text_res.replace(full_match, page_sep)
+        text_res = self._resolve_page_breaks(text_res, **kwargs)
 
         text_res = f"{open_token}{head}{text_res}{close_token}"
 
@@ -2012,6 +2008,15 @@ class DocLangDocSerializer(DocSerializer):
     def requires_page_break(self):
         """Return whether page breaks should be emitted for the document."""
         return self.params.add_page_break
+
+    @override
+    def _resolve_page_breaks(self, text: str, **kwargs: Any) -> str:
+        if self.params.add_page_break:
+            # Always emit well-formed page breaks using the vocabulary
+            page_sep = DocLangVocabulary._create_selfclosing_token(token=DocLangToken.PAGE_BREAK)
+            for full_match, _, _ in self._get_page_breaks(text=text):
+                text = text.replace(full_match, page_sep)
+        return text
 
     @override
     def serialize_bold(self, text: str, **kwargs: Any) -> str:

--- a/docling_core/transforms/serializer/doctags.py
+++ b/docling_core/transforms/serializer/doctags.py
@@ -595,14 +595,19 @@ class DocTagsDocSerializer(DocSerializer):
         delim = _get_delim(params=self.params)
         text_res = delim.join([p.text for p in parts if p.text])
 
-        if self.params.add_page_break:
-            page_sep = f"<{DocumentToken.PAGE_BREAK.value}>"
-            for full_match, _, _ in self._get_page_breaks(text=text_res):
-                text_res = text_res.replace(full_match, page_sep)
+        text_res = self._resolve_page_breaks(text_res, **kwargs)
 
         wrap_tag = DocumentToken.DOCUMENT.value
         text_res = f"<{wrap_tag}>{text_res}{delim}</{wrap_tag}>"
         return create_ser_result(text=text_res, span_source=parts)
+
+    @override
+    def _resolve_page_breaks(self, text: str, **kwargs: Any) -> str:
+        if self.params.add_page_break:
+            page_sep = f"<{DocumentToken.PAGE_BREAK.value}>"
+            for full_match, _, _ in self._get_page_breaks(text=text):
+                text = text.replace(full_match, page_sep)
+        return text
 
     @override
     def serialize_captions(

--- a/docling_core/transforms/serializer/html.py
+++ b/docling_core/transforms/serializer/html.py
@@ -1322,3 +1322,13 @@ class HTMLDocSerializer(DocSerializer):
     def requires_page_break(self):
         """Whether to add page breaks."""
         return self.params.output_style == HTMLOutputStyle.SPLIT_PAGE
+
+    @override
+    def _resolve_page_breaks(self, text: str, **kwargs: Any) -> str:
+        # Full-document SPLIT_PAGE rendering splits on the sentinel in
+        # serialize_doc to build per-page tables. A single-node fragment
+        # cannot do that, so strip the sentinel to avoid leaking it.
+        if self.requires_page_break():
+            for full_match, _, _ in self._get_page_breaks(text=text):
+                text = text.replace(full_match, "")
+        return text

--- a/docling_core/transforms/serializer/latex.py
+++ b/docling_core/transforms/serializer/latex.py
@@ -630,9 +630,7 @@ class LaTeXDocSerializer(DocSerializer):
 
         # Join body content and handle page break replacement within the body
         body_text = "\n\n".join([p.text for p in parts if p.text])
-        if params.page_break_command is not None:
-            for full_match, _, _ in self._get_page_breaks(text=body_text):
-                body_text = body_text.replace(full_match, params.page_break_command)
+        body_text = self._resolve_page_breaks(body_text, **kwargs)
 
         # Post-process title: move any \title{...} into the preamble
         # and add \maketitle after \begin{document}
@@ -679,6 +677,14 @@ class LaTeXDocSerializer(DocSerializer):
     def requires_page_break(self) -> bool:
         """Return True if page break replacement is enabled."""
         return self.params.page_break_command is not None
+
+    @override
+    def _resolve_page_breaks(self, text: str, **kwargs: Any) -> str:
+        params = self.params.merge_with_patch(patch=kwargs)
+        if params.page_break_command is not None:
+            for full_match, _, _ in self._get_page_breaks(text=text):
+                text = text.replace(full_match, params.page_break_command)
+        return text
 
     def _post_process_title(self, body_text: str) -> tuple[str | None, str, bool]:
         r"""Detect and relocate LaTeX \title{...} commands.

--- a/docling_core/transforms/serializer/markdown.py
+++ b/docling_core/transforms/serializer/markdown.py
@@ -1124,12 +1124,17 @@ class MarkdownDocSerializer(DocSerializer):
     ) -> SerializationResult:
         """Serialize a document out of its parts."""
         text_res = "\n\n".join([p.text for p in parts if p.text])
-        if self.requires_page_break():
-            page_sep = self.params.page_break_placeholder or ""
-            for full_match, _, _ in self._get_page_breaks(text=text_res):
-                text_res = text_res.replace(full_match, page_sep)
+        text_res = self._resolve_page_breaks(text_res, **kwargs)
 
         return create_ser_result(text=text_res, span_source=parts)
+
+    @override
+    def _resolve_page_breaks(self, text: str, **kwargs: Any) -> str:
+        if self.requires_page_break():
+            page_sep = self.params.page_break_placeholder or ""
+            for full_match, _, _ in self._get_page_breaks(text=text):
+                text = text.replace(full_match, page_sep)
+        return text
 
     @override
     def requires_page_break(self) -> bool:

--- a/tests/test_page_break_single_node.py
+++ b/tests/test_page_break_single_node.py
@@ -1,0 +1,44 @@
+"""Regression test for https://github.com/docling-project/docling-core/issues/714.
+
+Single-node serialize() calls never reach serialize_doc(), where the
+internal page-break sentinel was previously resolved. This leaked
+`#_#_DOCLING_DOC_PAGE_BREAK_*` into single-node output and chunk text.
+"""
+
+from docling_core.transforms.serializer.markdown import (
+    MarkdownDocSerializer,
+    MarkdownParams,
+)
+from docling_core.types.doc.base import BoundingBox, CoordOrigin, Size
+from docling_core.types.doc.document import (
+    DoclingDocument,
+    PageItem,
+    ProvenanceItem,
+)
+
+_BBOX = BoundingBox(l=50, t=700, r=500, b=680, coord_origin=CoordOrigin.BOTTOMLEFT)
+
+
+def _prov(pn: int, text: str) -> ProvenanceItem:
+    return ProvenanceItem(page_no=pn, bbox=_BBOX, charspan=(0, len(text)))
+
+
+def _make_doc() -> tuple[DoclingDocument, object]:
+    doc = DoclingDocument(name="d")
+    for pn in (1, 2):
+        doc.pages[pn] = PageItem(page_no=pn, size=Size(width=595, height=842))
+    lst = doc.add_list_group(name="l")
+    for text, pn in (("item one", 1), ("item two", 2)):
+        doc.add_list_item(text=text, parent=lst, prov=_prov(pn, text))
+    return doc, lst
+
+
+def test_single_node_page_break_resolved():
+    doc, lst = _make_doc()
+    ser = MarkdownDocSerializer(doc=doc, params=MarkdownParams(page_break_placeholder="<!-- page break -->"))
+    whole = ser.serialize().text
+    single = ser.serialize(item=lst).text
+    assert "#_#_DOCLING_DOC_PAGE_BREAK" not in whole
+    assert "#_#_DOCLING_DOC_PAGE_BREAK" not in single
+    assert "<!-- page break -->" in single
+    assert single == whole


### PR DESCRIPTION
Fixes #714.

Single-node serialize(item=...) never reached serialize_doc, where the internal page-break sentinel was resolved. This leaked #_#_DOCLING_DOC_PAGE_BREAK_* into single-node output and into HierarchicalChunker chunk text.

Changes:
- Add DocSerializer._resolve_page_breaks hook (base no-op), overridden per format: markdown, doctags, doclang, latex, html.
- Public serialize paths resolve sentinels; internal traversal passes _internal=True so full-document rendering still resolves in serialize_doc (preserves HTML SPLIT_PAGE splitting).
- Add tests/test_page_break_single_node.py regression test.

Verification:
- Repro from #714 now returns placeholder in both whole-doc and single-group serialize, no sentinel.
- tests/test_serialization.py: 95 passed.
- tests/test_page_break_single_node.py: 1 passed.
- ruff check and format clean.
- tests/test_serialization_doclang.py has 6 pre-existing failures on clean main (PNG byte diffs), unrelated.