### PR TITLE
fix(serializer): keep row-header rows out of the markdown table header block

### DIFF
--- a/docling_core/transforms/serializer/markdown.py
+++ b/docling_core/transforms/serializer/markdown.py
@@ -531,6 +531,11 @@ def _count_header_rows(item: TableItem) -> int:
     pull the data rows beneath a vertically spanning header into the header
     block.
 
+    A row is only promoted when it carries no non-flagged text outside the
+    leading column. Text in the leading column is exempt, because that column
+    holds the row labels, which stay unmarked even on rows that belong to the
+    header.
+
     Args:
         item: The table whose header rows are to be counted.
 
@@ -546,8 +551,14 @@ def _count_header_rows(item: TableItem) -> int:
           "no promotable header block", and every row stays in the body.
     """
     num_headers = 0
+    first_col = min((cell.start_col_offset_idx for cell in item.data.table_cells), default=0)
     for row_idx, row in enumerate(item.data.grid):
-        if any(cell.column_header and cell.start_row_offset_idx == row_idx for cell in row):
+        starting_cells = [cell for cell in row if cell.start_row_offset_idx == row_idx]
+        carries_body_text = any(
+            not cell.column_header and cell.text.strip() and cell.start_col_offset_idx != first_col
+            for cell in starting_cells
+        )
+        if any(cell.column_header for cell in starting_cells) and not carries_body_text:
             num_headers += 1
         else:
             if row_idx == 0 and not any(cell.column_header for later_row in item.data.grid[1:] for cell in later_row):

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -584,6 +584,68 @@ def test_md_table_keeps_rows_under_a_vertically_spanning_header():
     assert actual == ("| Category   |   Price |\n|------------|---------|\n| Category   |   10.00 |")
 
 
+def test_md_table_row_header_above_the_body_is_not_promoted():
+    """A row header that starts on the first body row must stay in the body.
+
+    The ``"2025"`` cell below is intentionally mis-flagged with
+    ``column_header=True`` rather than ``row_header=True``. That reproduces the
+    erroneous output of the HTML backend prior to
+    ``docling-project/docling#4216``, and models documents already serialized
+    with those old flags. It is not a canonical model of a pivot table; this
+    test only verifies the defensive guard in the markdown serializer.
+    """
+    doc = DoclingDocument(name="")
+    table = doc.add_table(data=TableData(num_rows=3, num_cols=2))
+    for cell in (
+        TableCell(
+            text="Year",
+            start_row_offset_idx=0,
+            end_row_offset_idx=1,
+            start_col_offset_idx=0,
+            end_col_offset_idx=1,
+            column_header=True,
+        ),
+        TableCell(
+            text="Month",
+            start_row_offset_idx=0,
+            end_row_offset_idx=1,
+            start_col_offset_idx=1,
+            end_col_offset_idx=2,
+            column_header=True,
+        ),
+        TableCell(
+            text="2025",
+            start_row_offset_idx=1,
+            end_row_offset_idx=3,
+            start_col_offset_idx=0,
+            end_col_offset_idx=1,
+            row_span=2,
+            column_header=True,
+        ),
+        TableCell(
+            text="January",
+            start_row_offset_idx=1,
+            end_row_offset_idx=2,
+            start_col_offset_idx=1,
+            end_col_offset_idx=2,
+        ),
+        TableCell(
+            text="February",
+            start_row_offset_idx=2,
+            end_row_offset_idx=3,
+            start_col_offset_idx=1,
+            end_col_offset_idx=2,
+        ),
+    ):
+        doc.add_table_cell(table_item=table, cell=cell)
+
+    actual = MarkdownDocSerializer(doc=doc).serialize().text
+    lines = actual.splitlines()
+    assert lines[0].replace(" ", "") == "|Year|Month|"
+    assert lines[2].replace(" ", "") == "|2025|January|"
+    assert lines[3].replace(" ", "") == "|2025|February|"
+
+
 def test_md_table_with_header_flags_below_row_zero_keeps_every_row_as_data():
     """No leading header block, so nothing is promoted and no row is dropped."""
     doc = DoclingDocument(name="")


### PR DESCRIPTION
## What

`_count_header_rows()` now only promotes a row into the markdown column-header block when that row carries no body text outside the leading column.

## Why

The HTML backend marks a `<th rowspan="N">` that occupies its own `<tr>` as a *column* header — it only clears `col_header` when the row holds a `<td>`. Such a cell is semantically a *row* header, and the row it starts on is the first body row.

Since #723, `_count_header_rows()` trusts the `column_header` flag, so that first body row is folded into the header block and disappears from the body:

```
| Year - 2025 | Month - January | Revenue - $134 | Cost - $162 |
|-------------|-----------------|----------------|-------------|
|        2025 | February        | $150           | $155        |   <- January row lost
```

After this change:

```
| Year | Month    | Revenue | Cost |
|------|----------|---------|------|
| 2025 | January  | $134    | $162 |
| 2025 | February | $150    | $155 |
```

Text in the leading column is exempt, because that column carries the row labels (`CPU`, `Class-count`, `Split`), which the backend leaves unmarked even on rows that do belong to the header. The rule is derived from the multi-row header cases #723 introduced: their only unmarked cells sit in the leading column, whereas the pivot table's unmarked cells (`January`, `$134`) sit in column 1 onward.

## How checked

- New regression test: `tests/test_serialization.py::test_md_table_row_header_above_the_body_is_not_promoted`.
- `tests/test_serialization.py`: 102 passed.
- Wider run (serialization / docling_doc / doclang / compat): failure set identical to the pre-change baseline, no new failures.
- `ruff check` and `ruff format --check` pass.

## Root cause (credit @wittjeff)

The backend lays a `<tr>` that holds only `<th rowspan>` cells out as a row-header row: it does not consume a grid row. The row header and the first data row therefore share a single grid row, and that row necessarily carries unmarked body cells outside the leading column — which is exactly why the guard above is sufficient and does not need to special-case row 0.

The flag is wrong at the source: those cells are emitted as `column_header=True, row_header=False` because `col_header` is only cleared when a row holds a `<td>`. docling-project/docling#4216 flips that, after which the markdown export is correct on its own; this PR then remains a safety net for documents already serialized with the old flags, and the `example_08` skip can be removed.

(`TableItem.export_to_dataframe()` carries its own copy of the header-row loop and is handled separately in #767.)

Fixes #765.

Related to docling-project/docling#4214 — same root cause, reported against the docling repo.


