### PR TITLE
fix: keep row headers flagged as column_header out of dataframe column names

### DIFF
--- a/docling_core/types/doc/items/table/table.py
+++ b/docling_core/types/doc/items/table/table.py
@@ -98,15 +98,28 @@ class TableItem(FloatingItem):
 
         grid = self.data.grid
 
-        # Count how many rows are column headers
+        # Count how many rows are column headers. A row joins the header block
+        # when a column header cell starts on it and no body text starts on it
+        # beyond the leading column. The second condition keeps a *row* header
+        # that arrives flagged as ``column_header`` (the HTML backend flags a
+        # ``<th rowspan="N">`` occupying its own ``<tr>`` that way) from pulling
+        # the first body row into the column names, e.g. ``Year.2025``.
+        # Text in the leading column is exempt because that column holds the
+        # row labels, which backends leave unmarked even on genuine header rows.
+        first_col = min((cell.start_col_offset_idx for cell in self.data.table_cells), default=0)
         num_headers = 0
         for row_idx, row in enumerate(grid):
             if len(row) == 0:
                 raise RuntimeError(f"Invalid table. {len(row)=} but {self.data.num_cols=}.")
 
-            any_header = any(cell.column_header and cell.start_row_offset_idx == row_idx for cell in row)
+            starting_cells = [cell for cell in row if cell.start_row_offset_idx == row_idx]
+            any_header = any(cell.column_header for cell in starting_cells)
+            carries_body_text = any(
+                not cell.column_header and cell.text.strip() and cell.start_col_offset_idx != first_col
+                for cell in starting_cells
+            )
 
-            if any_header:
+            if any_header and not carries_body_text:
                 num_headers += 1
             else:
                 break

--- a/tests/test_docling_doc.py
+++ b/tests/test_docling_doc.py
@@ -1982,6 +1982,96 @@ def test_export_dataframe_with_row_spanning_column_header():
     assert dataframe.values.tolist() == [["Alpha", ""]]
 
 
+def test_export_dataframe_with_row_header_flagged_as_column_header():
+    """A row header that starts on the first body row must not become a column name.
+
+    The HTML backend flags a ``<th rowspan="N">`` occupying its own ``<tr>`` as
+    ``column_header``, so counting that row as a header would fold the first body
+    row into the column names (``Year.2025``) and drop it from the data.
+    """
+
+    def cell(
+        text: str,
+        row: int,
+        column: int,
+        row_span: int = 1,
+        column_header: bool = False,
+    ) -> TableCell:
+        return TableCell(
+            text=text,
+            start_row_offset_idx=row,
+            end_row_offset_idx=row + row_span,
+            start_col_offset_idx=column,
+            end_col_offset_idx=column + 1,
+            row_span=row_span,
+            column_header=column_header,
+        )
+
+    doc = DoclingDocument(name="test")
+    table = doc.add_table(
+        data=TableData(
+            num_rows=3,
+            num_cols=3,
+            table_cells=[
+                cell("Year", 0, 0, column_header=True),
+                cell("Month", 0, 1, column_header=True),
+                cell("Revenue", 0, 2, column_header=True),
+                cell("2025", 1, 0, row_span=2, column_header=True),
+                cell("January", 1, 1),
+                cell("$134", 1, 2),
+                cell("February", 2, 1),
+                cell("$150", 2, 2),
+            ],
+        )
+    )
+
+    dataframe = table.export_to_dataframe(doc)
+
+    assert list(dataframe.columns) == ["Year", "Month", "Revenue"]
+    assert dataframe.values.tolist() == [
+        ["2025", "January", "$134"],
+        ["2025", "February", "$150"],
+    ]
+
+
+def test_export_dataframe_keeps_stacked_header_with_unmarked_row_label():
+    """A stacked header whose lower row only has unmarked text in the leading column stays a header."""
+
+    def cell(text: str, row: int, column: int, column_header: bool = False) -> TableCell:
+        return TableCell(
+            text=text,
+            start_row_offset_idx=row,
+            end_row_offset_idx=row + 1,
+            start_col_offset_idx=column,
+            end_col_offset_idx=column + 1,
+            column_header=column_header,
+        )
+
+    doc = DoclingDocument(name="test")
+    table = doc.add_table(
+        data=TableData(
+            num_rows=3,
+            num_cols=3,
+            table_cells=[
+                cell("", 0, 0, column_header=True),
+                cell("% of Total", 0, 1, column_header=True),
+                cell("% of Total", 0, 2, column_header=True),
+                cell("class label", 1, 0),
+                cell("Train", 1, 1, column_header=True),
+                cell("Test", 1, 2, column_header=True),
+                cell("Caption", 2, 0),
+                cell("2.5", 2, 1),
+                cell("2.4", 2, 2),
+            ],
+        )
+    )
+
+    dataframe = table.export_to_dataframe(doc)
+
+    assert list(dataframe.columns) == ["class label", "% of Total.Train", "% of Total.Test"]
+    assert dataframe.values.tolist() == [["Caption", "2.5", "2.4"]]
+
+
 def test_export_traverse_pictures_ocr_scanned_pdf():
     """Test that OCR text nested under a PictureItem is included when traverse_pictures=True."""
     doc = DoclingDocument(name="Scanned Doc")


### PR DESCRIPTION
Companion to #766 for `TableItem.export_to_dataframe()`.

`_export_to_dataframe_with_options` keeps its own copy of the header-row count. A row header that arrives flagged as `column_header` — the docling HTML backend flags a `<th rowspan="N">` occupying its own `<tr>` that way — starts on the first body row, so that row was folded into the column names and dropped from the data:

```
docling-core 2.96.0:  columns ['Year.2025', 'Month.January', 'Revenue.$134', 'Cost.$162'], 4 rows
docling-core 2.95.0:  columns ['Year.2025.2025.2025.2025.2025', 'Month.January.February.March.April.May', ...], 0 rows
```

(#756 narrowed it from "every row" to "the first row"; the symptom is older than the markdown regression in #765.)

### Change

A row joins the header block only when a column header cell starts on it **and** no unflagged, non-empty cell starts on it beyond the leading column. Text in the leading column is exempt because that column holds row labels, which backends leave unmarked even on genuine stacked header rows (`class label` under a `% of Total` span). This is the same rule #766 applies in `_count_header_rows`; once both are in, the two loops could share one helper, and I am happy to rebase onto #766 to do that.

After the change, on `tests/data/html/groundtruth/example_08.html.json` from docling (all three pivot tables):

```
columns ['Year', 'Month', 'Revenue', 'Cost'], 5 rows
columns ['Year', 'Quarter', 'Month', 'Revenue', 'Cost'], 5 rows
```

### Root cause

The flag is wrong at the source. docling-project/docling#4216 fixes the HTML backend to emit `row_header=True, column_header=False` for those cells, which makes both exports right without any serializer heuristic. This PR and #766 still matter for documents that were serialized with the old flags.

### Tests

- `test_export_dataframe_with_row_header_flagged_as_column_header`: the pivot case above.
- `test_export_dataframe_keeps_stacked_header_with_unmarked_row_label`: a stacked header whose lower row has unmarked text only in the leading column still counts as a header.
- `tests/test_docling_doc.py`, `tests/test_serialization.py`, `tests/test_otsl_table_export.py`: 181 passed; the 3 failures in `test_docling_doc.py` (`test_save_to_disk`, `test_document_manipulation`, `test_concatenate`) are identical on unmodified `main` in my environment (Pillow PNG re-encoding and a missing fixture), same set #723 reported.
- `ruff check` and `ruff format --check` clean.

Fixes #765 (dataframe side).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X7AdKLZDGfNTS2LJGmhehR
