### PR TITLE
perf: stop building a throwaway serializer for every rich table cell

### DIFF
--- a/docling_core/types/doc/items/table/table_data.py
+++ b/docling_core/types/doc/items/table/table_data.py
@@ -70,7 +70,11 @@ class RichTableCell(TableCell):
         from docling_core.transforms.serializer.markdown import MarkdownDocSerializer
 
         if doc is not None:
-            doc_serializer = kwargs.pop("doc_serializer", MarkdownDocSerializer(doc=doc))
+            doc_serializer = kwargs.pop("doc_serializer", None)
+            if doc_serializer is None:
+                # Built only as a fallback: creating a serializer validates the whole
+                # document, which is far too costly to repeat for every rich cell.
+                doc_serializer = MarkdownDocSerializer(doc=doc)
             ser_res = doc_serializer.serialize(item=self.ref.resolve(doc=doc), **kwargs)
             return ser_res.text
         else:

--- a/tests/test_docling_doc.py
+++ b/tests/test_docling_doc.py
@@ -15,6 +15,7 @@ import yaml
 from PIL import Image as PILImage
 from pydantic import AnyUrl, BaseModel, ValidationError
 
+from docling_core.transforms.serializer.markdown import MarkdownDocSerializer
 from docling_core.types.doc import (
     BoundingBox,
     CodeItem,
@@ -2131,6 +2132,28 @@ def test_doc_manipulation_with_rich_tables(rich_table_doc):
 
     exp_doc = DoclingDocument.load_from_yaml(exp_file)
     assert rich_table_doc == exp_doc
+
+
+def test_rich_table_cell_text_reuses_given_serializer(rich_table_doc, monkeypatch):
+    """A rich cell must not build a fallback serializer when the caller passes one.
+
+    Building a serializer validates the whole document, so doing it for every rich
+    cell made serializing documents with many rich tables quadratic in the document
+    size (docling-project/docling#3222).
+    """
+    serializer = MarkdownDocSerializer(doc=rich_table_doc)
+    rich_cells = [
+        cell for table in rich_table_doc.tables for cell in table.data.table_cells if isinstance(cell, RichTableCell)
+    ]
+    expected = [serializer.serialize(item=cell.ref.resolve(doc=rich_table_doc)).text for cell in rich_cells]
+
+    def fail_on_fallback(self, *args, **kwargs):
+        raise AssertionError("RichTableCell built its own serializer although one was passed")
+
+    monkeypatch.setattr(MarkdownDocSerializer, "__init__", fail_on_fallback)
+
+    assert rich_cells
+    assert [cell._get_text(doc=rich_table_doc, doc_serializer=serializer) for cell in rich_cells] == expected
 
 
 def test_invalid_rich_table_doc():


### PR DESCRIPTION
Fixes docling-project/docling#3222.

### Problem

`RichTableCell._get_text()` takes the caller's serializer with

```python
doc_serializer = kwargs.pop("doc_serializer", MarkdownDocSerializer(doc=doc))
```

The default of `dict.pop` is evaluated before the call, so a new `MarkdownDocSerializer` is built for every rich cell, even though the library's callers all pass their own `doc_serializer` (the chunker's `TripletTableSerializer` via `_export_to_dataframe_with_options`, the Markdown/HTML table export, and the DocLang and Azure serializers). Building a serializer runs `DoclingDocument` validation over the whole document (`validate_document` → `validate_tree`, `validate_misplaced_list_items`), so every rich cell paid for a full-document validation whose result was thrown away. On documents with many rich tables, table serialization became quadratic in the document size.

### Change

Build the fallback `MarkdownDocSerializer` only when no `doc_serializer` is passed. The serializer used for each cell is the same as before, so output is unchanged.

### Measurements

The `large.html` reproducer from docling-project/docling#3222 (14 MB), converted with docling's HTML backend: 63,060 text items, 1,642 tables, **16,347 rich table cells**. `HybridChunker` with `ibm-granite/granite-embedding-30m-english` and `max_tokens=512`, same machine for both runs:

| | `main` | this PR |
|---|---|---|
| `HybridChunker.chunk()` | 12,360 s (3 h 26 min) | **102.6 s** |
| hierarchical pass only | — | 25.7 s (13,795 chunks) |

Both runs produce the same 6,284 chunks. The follow-up PR for the split stage brings the total down a little further, to about 95–98 s.

On this document a single `MarkdownDocSerializer(doc=doc)` takes about 0.9 s, and `main` built one per rich cell.

### Tests

- New `test_rich_table_cell_text_reuses_given_serializer` checks that a rich cell uses the serializer it is given and builds no fallback. It fails on `main` and passes with this change.
- `ruff check`, `ruff format --check`, `mypy docling_core tests` and `scripts/check_compat_projectors.py` pass.
- Full test suite: no new failures. I ran it locally on Windows, where 191 tests in the DocLang, DocTags and visualization suites also fail on `main`, identically with and without this change.

A separate PR will follow for the remaining time in `HybridChunker`'s split stage, which re-serializes the items of a chunk once per window step.
