### PR TITLE
fix(html): encode referenced image URIs like the Markdown serializer

### DIFF
--- a/docling_core/transforms/serializer/common.py
+++ b/docling_core/transforms/serializer/common.py
@@ -7,8 +7,9 @@ import warnings
 from abc import abstractmethod
 from collections.abc import Iterable
 from functools import cached_property
-from pathlib import Path
-from typing import Annotated, Any, Optional, Union
+from pathlib import Path, PurePath
+from typing import Annotated, Any, Final, Optional, Union
+from urllib.parse import quote, urlsplit, urlunsplit
 
 from pydantic import (
     AnyUrl,
@@ -64,6 +65,81 @@ _DEFAULT_LAYERS = set(ContentLayer)
 
 
 _logger = logging.getLogger(__name__)
+
+_URI_KEEP_CHARS: Final[str] = "/%:@+,;=~$!&'*"
+"""Characters that survive percent-encoding in a link destination.
+
+Includes the RFC 3986 reserved characters that carry meaning in a URI, plus
+`%` so that an already-encoded destination is not encoded a second time.
+Whitespace and parentheses are deliberately absent: they would end a Markdown
+inline link.
+"""
+
+_WINDOWS_DRIVE_RE: Final[re.Pattern[str]] = re.compile(r"[A-Za-z]:/")
+"""Matches the drive prefix of an absolute Windows path, e.g. `C:/`."""
+
+
+def _escape_uri_path(value: AnyUrl | PurePath) -> str:
+    """Encode a URL or filesystem path as a link destination.
+
+    Used for Markdown link destinations and HTML `src` values alike. Handles URLs of
+    any scheme (https/s3/ftp/...) as well as POSIX and Windows paths, keeps relative
+    paths relative, and never double-encodes. A Windows path is recognized by either
+    flavour, so a document authored on Windows still resolves when it is exported on
+    POSIX.
+
+    The only destination this gives a ``file://`` scheme to is an absolute Windows
+    path, where it is the sole spelling a renderer cannot misread as a URL scheme
+    (``C:``) or as an authority (``//server``). A URL that already carries the
+    scheme is passed through, since dropping it would turn an absolute filesystem
+    reference into a root-relative URL.
+
+    Known limitation: a backslash in a `PosixPath` string is ambiguous.
+    It may be a Windows separator surviving a JSON round-trip (correct to
+    convert) or a literal filename character (where converting it to `/`
+    would split one component into two). The two cases are indistinguishable
+    from `str()`. In practice this is not a concern because `ImageRef.uri`
+    is always populated from native filesystem operations, so a `PosixPath`
+    can only carry a literal backslash if the caller explicitly constructed one.
+
+    Args:
+        value: The URL or path to encode.
+
+    Returns:
+        A percent-encoded link destination.
+    """
+    keep = _URI_KEEP_CHARS
+    # A backslash is both the Windows separator and a Markdown escape character, and
+    # is read as a separator whatever flavour the path arrives in: a document authored
+    # on Windows keeps its backslashes once it is re-read on POSIX, where the flavour
+    # can no longer tell. A URL is unaffected, as pydantic normalizes backslashes away
+    # when parsing.
+    s = str(value).replace("\\", "/")
+
+    if s.startswith("//"):  # In case of a fileshare (//someserver/somefolder)
+        host, _, tail = s.lstrip("/").partition("/")  # get the end of the path
+        # file://<host>/<path>, with <host> being a possibly empty string.
+        return urlunsplit(("file", host, quote(f"/{tail}", safe=keep), "", ""))
+    if _WINDOWS_DRIVE_RE.match(s):  # In case of a Windows filename with drive letter
+        # file://<full_path_with_filename>
+        return urlunsplit(("file", "", quote(f"/{s}", safe=keep), "", ""))
+
+    # A URL keeps its scheme, authority and delimiters; only its components are
+    # encoded. A single-character scheme cannot be real, so it is read as a path.
+    parts = urlsplit(s)
+    if len(parts.scheme) > 1:
+        return urlunsplit(
+            (
+                parts.scheme,
+                parts.netloc,
+                quote(parts.path, safe=keep),
+                quote(parts.query, safe=keep + "="),
+                quote(parts.fragment, safe=keep),
+            )
+        )
+
+    # A relative or root-relative local path.
+    return quote(s, safe=keep)
 
 
 class _PageBreakNode(NodeItem):

--- a/docling_core/transforms/serializer/html.py
+++ b/docling_core/transforms/serializer/html.py
@@ -8,7 +8,6 @@ from html.parser import HTMLParser
 from io import BytesIO
 from pathlib import Path
 from typing import Any, Optional, Union
-from urllib.parse import quote
 from xml.etree.ElementTree import SubElement, tostring
 from xml.sax.saxutils import unescape
 
@@ -34,6 +33,7 @@ from docling_core.transforms.serializer.base import (
 from docling_core.transforms.serializer.common import (
     CommonParams,
     DocSerializer,
+    _escape_uri_path,
     _get_annotation_text,
     _should_use_legacy_annotations,
     create_ser_result,
@@ -607,7 +607,7 @@ class HTMLPictureSerializer(BasePictureSerializer):
                 if isinstance(item.image, ImageRef) and not (
                     isinstance(item.image.uri, AnyUrl) and item.image.uri.scheme == "data"
                 ):
-                    img_text = f'<img src="{quote(str(item.image.uri))}">'
+                    img_text = f'<img src="{html.escape(_escape_uri_path(item.image.uri))}">'
 
         if img_text:
             res_parts.append(create_ser_result(text=img_text, span_source=item))

--- a/docling_core/transforms/serializer/markdown.py
+++ b/docling_core/transforms/serializer/markdown.py
@@ -30,6 +30,7 @@ from docling_core.transforms.serializer.base import (
 from docling_core.transforms.serializer.common import (
     CommonParams,
     DocSerializer,
+    _escape_uri_path,
     _get_annotation_text,
     _PageBreakSerResult,
     _should_use_legacy_annotations,
@@ -781,18 +782,6 @@ class MarkdownTableSerializer(BaseTableSerializer):
 class MarkdownPictureSerializer(BasePictureSerializer):
     """Markdown-specific picture item serializer."""
 
-    _URI_KEEP_CHARS: Final[str] = "/%:@+,;=~$!&'*"
-    """Characters that survive percent-encoding in a Markdown link destination.
-
-    Includes the RFC 3986 reserved characters that carry meaning in a URI, plus
-    `%` so that an already-encoded destination is not encoded a second time.
-    Whitespace and parentheses are deliberately absent: they would end a Markdown
-    inline link.
-    """
-
-    _WINDOWS_DRIVE_RE: Final[re.Pattern[str]] = re.compile(r"[A-Za-z]:/")
-    """Matches the drive prefix of an absolute Windows path, e.g. `C:/`."""
-
     @override
     def serialize(
         self,
@@ -896,66 +885,8 @@ class MarkdownPictureSerializer(BasePictureSerializer):
 
     @staticmethod
     def _escape_uri_path(value: AnyUrl | PurePath) -> str:
-        """Encode a URL or filesystem path as a Markdown link destination.
-
-        Handles URLs of any scheme (https/s3/ftp/...) as well as POSIX and Windows
-        paths, keeps relative paths relative, and never double-encodes. A Windows path
-        is recognized by either flavour, so a document authored on Windows still
-        resolves when it is exported on POSIX.
-
-        The only destination this gives a ``file://`` scheme to is an absolute Windows
-        path, where it is the sole spelling a renderer cannot misread as a URL scheme
-        (``C:``) or as an authority (``//server``). A URL that already carries the
-        scheme is passed through, since dropping it would turn an absolute filesystem
-        reference into a root-relative URL.
-
-        Known limitation: a backslash in a `PosixPath` string is ambiguous.
-        It may be a Windows separator surviving a JSON round-trip (correct to
-        convert) or a literal filename character (where converting it to `/`
-        would split one component into two). The two cases are indistinguishable
-        from `str()`. In practice this is not a concern because `ImageRef.uri`
-        is always populated from native filesystem operations, so a `PosixPath`
-        can only carry a literal backslash if the caller explicitly constructed one.
-
-        Args:
-            value: The URL or path to encode.
-
-        Returns:
-            A percent-encoded Markdown link destination.
-        """
-
-        keep = MarkdownPictureSerializer._URI_KEEP_CHARS
-        # A backslash is both the Windows separator and a Markdown escape character, and
-        # is read as a separator whatever flavour the path arrives in: a document authored
-        # on Windows keeps its backslashes once it is re-read on POSIX, where the flavour
-        # can no longer tell. A URL is unaffected, as pydantic normalizes backslashes away
-        # when parsing.
-        s = str(value).replace("\\", "/")
-
-        if s.startswith("//"):  # In case of a fileshare (//someserver/somefolder)
-            host, _, tail = s.lstrip("/").partition("/")  # get the end of the path
-            # file://<host>/<path>, with <host> being a possibly empty string.
-            return urlunsplit(("file", host, quote(f"/{tail}", safe=keep), "", ""))
-        if MarkdownPictureSerializer._WINDOWS_DRIVE_RE.match(s):  # In case of a Windows filename with drive letter
-            # file://<full_path_with_filename>
-            return urlunsplit(("file", "", quote(f"/{s}", safe=keep), "", ""))
-
-        # A URL keeps its scheme, authority and delimiters; only its components are
-        # encoded. A single-character scheme cannot be real, so it is read as a path.
-        parts = urlsplit(s)
-        if len(parts.scheme) > 1:
-            return urlunsplit(
-                (
-                    parts.scheme,
-                    parts.netloc,
-                    quote(parts.path, safe=keep),
-                    quote(parts.query, safe=keep + "="),
-                    quote(parts.fragment, safe=keep),
-                )
-            )
-
-        # A relative or root-relative local path.
-        return quote(s, safe=keep)
+        """Encode a URL or filesystem path as a Markdown link destination."""
+        return _escape_uri_path(value)
 
 
 class MarkdownKeyValueSerializer(BaseKeyValueSerializer):

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -1640,3 +1640,28 @@ def test_referenced_image_data_uri_is_not_encoded():
     doc.add_picture(image=ImageRef(mimetype="image/png", dpi=72, size=Size(width=10, height=10), uri=uri))
 
     assert doc.export_to_markdown(image_mode=ImageRefMode.REFERENCED) == "<!-- image -->"
+
+
+@pytest.mark.parametrize(
+    ("uri", "expected"),
+    [
+        (Path("doc_artifacts/image_000001_ab12.png"), "doc_artifacts/image_000001_ab12.png"),
+        (Path("My Report (final)_artifacts/img.png"), "My%20Report%20%28final%29_artifacts/img.png"),
+        # A Windows-authored separator must reach the page as "/", not as "%5C"
+        # (docling-project/docling#3617).
+        (Path("My Report_artifacts\\img.png"), "My%20Report_artifacts/img.png"),
+        # An absolute Windows path becomes a file:// URL, as in the Markdown output.
+        (Path("C:/Users/me/My Docs/img.png"), "file:///C:/Users/me/My%20Docs/img.png"),
+        # URLs keep their scheme and delimiters, and pydantic's escapes are not encoded twice.
+        (AnyUrl("file:///home/a b/img.png"), "file:///home/a%20b/img.png"),
+        (AnyUrl("s3://bucket/My Report_artifacts/img.png"), "s3://bucket/My%20Report_artifacts/img.png"),
+        # In an HTML attribute, "&" is written as "&amp;".
+        (AnyUrl("https://example.com/img.png?w=1&h=2"), "https://example.com/img.png?w=1&amp;h=2"),
+    ],
+)
+def test_html_referenced_image_uri_is_encoded(uri, expected: str):
+    """Test that the HTML serializer encodes a referenced image URI the same way as Markdown."""
+    doc = DoclingDocument(name="x")
+    doc.add_picture(image=ImageRef(mimetype="image/png", dpi=72, size=Size(width=10, height=10), uri=uri))
+
+    assert f'<img src="{expected}">' in doc.export_to_html(image_mode=ImageRefMode.REFERENCED)


### PR DESCRIPTION
Fixes the HTML side of docling-project/docling#3617 (the Markdown side was fixed in #698), following the suggestion in the review of #641 to extend `_escape_uri_path` to the HTML serializer.

### Problem

In `ImageRefMode.REFERENCED`, the HTML serializer writes

```python
img_text = f'<img src="{quote(str(item.image.uri))}">'
```

- On Windows, `str()` of the path uses backslashes and `quote()` encodes them, so the page points at `picture_classification_artifacts%5Cimage_000000_….png` (the exact output reported in docling-project/docling#3617).
- `quote()` with its default safe set also breaks URLs: `https://example.com/img.png?w=1&h=2` becomes `https%3A//example.com/img.png%3Fw%3D1%26h%3D2`, and `file:///home/a%20b/img.png` has its escape encoded a second time as `%2520`.

### Change

- Move `_escape_uri_path` (and its two constants) from `MarkdownPictureSerializer` to `serializer/common.py`, unchanged apart from the docstring, so the Markdown and HTML serializers share it. `MarkdownPictureSerializer._escape_uri_path` still exists and delegates, so its tests and any callers keep working.
- Use it for HTML referenced images, passing the result through `html.escape` since it goes into an attribute (`&` in a query string becomes `&amp;`).

Markdown output is unchanged.

### Tests

- New `test_html_referenced_image_uri_is_encoded`, the HTML counterpart of `test_referenced_image_uri_is_encoded`: relative paths, parentheses, a Windows separator, an absolute Windows path, and `file://`, `s3://` and `https://` URLs. On `main` the Windows-separator, drive-letter and URL cases fail (on Windows, every path case fails); all pass with this change.
- The existing `_escape_uri_path` and Markdown tests pass unchanged.
- `ruff check`, `ruff format --check` and `mypy docling_core tests` pass. The full test suite shows no new failures (run locally on Windows, where some DocLang, DocTags and visualization tests fail on `main` as well).
