### PR TITLE
fix(chunker): resolve an InlineGroup-held heading for meta.headings

### DIFF
--- a/docling_core/transforms/chunker/hierarchical_chunker.py
+++ b/docling_core/transforms/chunker/hierarchical_chunker.py
@@ -26,6 +26,7 @@ from docling_core.transforms.serializer.markdown import (
     MarkdownDocSerializer,
     MarkdownParams,
 )
+from docling_core.transforms.serializer.plain_text import PlainTextDocSerializer
 from docling_core.types import DoclingDocument as DLDocument
 from docling_core.types.doc.base import ImageRefMode
 from docling_core.types.doc.document import (
@@ -41,6 +42,33 @@ from docling_core.types.doc.document import (
 )
 
 _logger = logging.getLogger(__name__)
+
+
+def _heading_text(
+    item: TitleItem | SectionHeaderItem,
+    doc: DoclingDocument,
+    visited: set[str],
+) -> str:
+    """Plain text of a heading, including one held in an ``InlineGroup`` child.
+
+    The Markdown backend gives a heading with more than one inline run a
+    ``text=""`` item plus a single ``InlineGroup`` child holding the runs, so
+    reading ``item.text`` alone yields ``""``. The shape is detected exactly as
+    the LaTeX and DocLang serializers detect it.
+
+    Serialized as plain text on purpose: ``meta.headings`` is metadata, so it
+    carries what the heading says, not how a given format renders its links and
+    emphasis.
+
+    Serializing the group also records it and its runs in ``visited``, which is
+    what keeps them from arriving later as a content item of their own.
+    """
+    if item.text or len(item.children) != 1:
+        return item.text
+    child = item.children[0].resolve(doc)
+    if not isinstance(child, InlineGroup):
+        return item.text
+    return PlainTextDocSerializer(doc=doc).serialize(item=child, is_inline_scope=True, visited=visited).text
 
 
 class TripletTableSerializer(BaseTableSerializer):
@@ -204,6 +232,7 @@ class HierarchicalChunker(BaseChunker):
         """
         my_doc_ser = self.serializer_provider.get_serializer(doc=dl_doc)
         heading_by_level: dict[LevelNumber, TitleItem | SectionHeaderItem] = {}
+        heading_text_by_level: dict[LevelNumber, str] = {}
         heading_emitted: set[str] = set()
         visited: set[str] = set()
         ser_res = create_ser_result()
@@ -235,7 +264,7 @@ class HierarchicalChunker(BaseChunker):
                         text="",
                         meta=DocMeta(
                             doc_items=[heading_by_level[k] for k in sorted_keys],
-                            headings=[heading_by_level[k].text for k in sorted_keys],
+                            headings=[heading_text_by_level[k] for k in sorted_keys],
                         ),
                     )
                     heading_emitted.add(leaf_ref)
@@ -243,9 +272,14 @@ class HierarchicalChunker(BaseChunker):
                 # actually remove shadowed headings
                 for k in keys_to_del:
                     heading_by_level.pop(k, None)
+                    heading_text_by_level.pop(k, None)
 
                 # capture current heading
                 heading_by_level[level] = item
+                # Resolving here also marks an InlineGroup-held heading's runs
+                # visited, so they do not arrive later as a content item and
+                # surface the heading again as a chunk of its own.
+                heading_text_by_level[level] = _heading_text(item, dl_doc, visited)
 
                 continue
             elif isinstance(item, ListGroup | InlineGroup | DocItem) and item.self_ref not in visited:
@@ -267,7 +301,7 @@ class HierarchicalChunker(BaseChunker):
                 continue
             if doc_items := [u.item for u in ser_res.spans]:
                 sorted_keys = sorted(heading_by_level)
-                headings = [heading_by_level[k].text for k in sorted_keys] or None
+                headings = [heading_text_by_level[k] for k in sorted_keys] or None
                 c = DocChunk(
                     text=ser_res.text,
                     meta=DocMeta(
@@ -291,7 +325,7 @@ class HierarchicalChunker(BaseChunker):
                 text="",
                 meta=DocMeta(
                     doc_items=[heading_by_level[k] for k in sorted_keys],
-                    headings=[heading_by_level[k].text for k in sorted_keys],
+                    headings=[heading_text_by_level[k] for k in sorted_keys],
                 ),
             )
             heading_emitted.add(leaf_ref)

--- a/tests/test_hierarchical_chunker.py
+++ b/tests/test_hierarchical_chunker.py
@@ -326,3 +326,34 @@ def test_contextualize_excludes_fields_when_alias_differs_from_attribute_name():
     assert "drop me" not in result
     assert "keep me" in result
     assert "body" in result
+
+
+def test_chunk_heading_with_inline_group():
+    """A heading whose text lives in an InlineGroup still contributes its plain text.
+
+    The Markdown backend gives a multi-run heading a ``SectionHeaderItem`` with
+    ``text=""`` and one ``InlineGroup`` child. ``meta.headings`` must carry the
+    heading's plain text -- how the runs render is the serializer's concern --
+    and the runs must not surface again as a body chunk of their own.
+    """
+    doc = DoclingDocument(name="t")
+    doc.add_title(text="Sample")
+    heading = doc.add_heading(text="", level=1)
+    group = doc.add_inline_group(parent=heading)
+    doc.add_text(
+        label=DocItemLabel.TEXT,
+        text="Release",
+        parent=group,
+        hyperlink="https://example.com/releases",
+    )
+    doc.add_text(label=DocItemLabel.TEXT, text="notes", parent=group)
+    para = doc.add_inline_group()
+    doc.add_text(label=DocItemLabel.TEXT, text="Install with", parent=para)
+    doc.add_code(text="pip install x", parent=para)
+    doc.add_text(label=DocItemLabel.TEXT, text="first.", parent=para)
+
+    chunks = list(HierarchicalChunker().chunk(dl_doc=doc))
+
+    assert [(chunk.meta.headings, chunk.text) for chunk in chunks] == [
+        (["Sample", "Release notes"], "Install with `pip install x` first."),
+    ]


### PR DESCRIPTION
Fixes #769

## Problem

The Markdown backend represents a heading with more than one inline run as a heading item with `text=""` plus a single `InlineGroup` child holding the runs. `HierarchicalChunker` did not handle that shape, in two ways:

- `meta.headings` was built from `item.text`, so such a heading contributed `''`.
- The loop `continue`d on a heading without marking its children visited, so the `InlineGroup` arrived later as an item of its own and was serialized into a body chunk whose text was the heading.

On the reproduction from the issue, `main` gives:

```
['Sample', ''] '[Release](https://example.com/releases) notes'
['Sample', ''] 'Install with `pip install x` first.'
```

## Change

Resolve the heading's text where the heading is captured. The shape is detected the way `LatexDocSerializer` and the DocLang serializer already detect it (`text == ""`, one child, child is an `InlineGroup`), so this adds no new notion of what such a heading is.

`meta.headings` is metadata, so the runs are serialized with `PlainTextDocSerializer`: it carries what the heading says, not how one format renders its links and emphasis. That is why the expected value is `Release notes` rather than `[Release](https://example.com/releases) notes`.

Serializing the group also records it and its runs in `visited`, which is what stops them resurfacing as a content item — so one call addresses both halves of the issue rather than adding a separate suppression rule.

The same document shape was fixed for the LaTeX serializer in #743 and for the DocLang serializer in #750.

After the change:

```
['Sample', 'Release notes'] 'Install with `pip install x` first.'
```

which matches the issue's expected output. `export_to_markdown()` is unchanged.

## Verification

- New test `test_chunk_heading_with_inline_group` covers both halves (headings metadata and the absence of a heading-text body chunk). Written before the fix, it fails on `main` with exactly the output quoted above.
- Reverse check: reverting `hierarchical_chunker.py` alone, with the test kept, fails it again.
- Full suite: `718 passed, 6 skipped` — including the chunker ground-truth JSON comparisons, which are unchanged.
- `ruff check`, `ruff format --check` and `mypy` are clean.

Not addressed here: #770 (`HybridChunker` re-serializing `InlineGroup` runs) is a separate defect in a different layer, and the `# TODO: merging should ideally be done by the serializer` above that code suggests it wants its own discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K5hLnmSWco1QjCAgMcWdcA